### PR TITLE
Add missing opcodes to k_rgnStackPushes

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -100,6 +100,8 @@ static int k_rgnStackPushes[] = {
 #undef PushRef
 #undef VarPush
 #undef OPDEF
+    0,  // CEE_COUNT
+    0   // CEE_SWITCH_ARG
 };
 
 ILRewriter::ILRewriter(


### PR DESCRIPTION
Original fix: https://github.com/DataDog/dd-trace-dotnet/pull/875