### PR TITLE
Add ActivityStub skeleton

### DIFF
--- a/src/OpenTelemetry.DynamicActivityBinding/OpenTelemetry.DynamicActivityBinding.csproj
+++ b/src/OpenTelemetry.DynamicActivityBinding/OpenTelemetry.DynamicActivityBinding.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <CLSCompliant>false</CLSCompliant>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net45;net46;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/src/OpenTelemetry.DynamicActivityBinding/OpenTelemetry.DynamicActivityBinding.sln
+++ b/src/OpenTelemetry.DynamicActivityBinding/OpenTelemetry.DynamicActivityBinding.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.DynamicActivityBinding", "OpenTelemetry.DynamicActivityBinding.csproj", "{85212C50-B085-4EF4-87D0-60A8B0FEF406}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{85212C50-B085-4EF4-87D0-60A8B0FEF406}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85212C50-B085-4EF4-87D0-60A8B0FEF406}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85212C50-B085-4EF4-87D0-60A8B0FEF406}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85212C50-B085-4EF4-87D0-60A8B0FEF406}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4B7F676E-43E8-4277-9A9D-24906AAB5F1D}
+	EndGlobalSection
+EndGlobal

--- a/src/OpenTelemetry.DynamicActivityBinding/internal/DynamicLoader.cs
+++ b/src/OpenTelemetry.DynamicActivityBinding/internal/DynamicLoader.cs
@@ -1,0 +1,34 @@
+namespace OpenTelemetry.DynamicActivityBinding
+{
+    /// <summary>
+    /// The <see cref="DynamicLoader"/> is used to load the <c>System.Diagnostics.DiagnosticSource</c> assembly
+    /// while handling the many possible scenarios, eg.: already loaded by the process, available on default
+    /// load context, etc.
+    /// </summary>
+    internal static class DynamicLoader
+    {
+        // Assembly System.Diagnostics.DiagnosticSource version 4.0.2.0 is the first official version of that assembly
+        // that contains Activity previous versions contained DiagnosticSource only.
+        // That version was shipped in the System.Diagnostics.DiagnosticSource NuGet version 4.4.0 on 2017-06-28.
+        // See https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/4.4.0
+        // It is highly unlikey that an application references an older version of DiagnosticSource.
+        // However, if it does, we will not instrument it.
+
+        /// <summary>
+        /// Returns the result of the attempt to load the <c>System.Diagnostics.DiagnosticSource</c> assembly.
+        /// </summary>
+        /// <remarks>
+        /// It can be called concurrently the implementation will ensure that only a single attempt is performed
+        /// and all concurrent and subsequent calls return the result of that attempt.
+        /// </remarks>
+        /// <returns>
+        /// True if the <c>System.Diagnostics.DiagnosticSource</c> assembly was successfully
+        /// loaded or false otherwise.
+        /// </returns>
+        public static bool EnsureInitialized()
+        {
+            // TODO: Always false until actual assembly load is in implemented.
+            return false;
+        }
+    }
+}

--- a/src/OpenTelemetry.DynamicActivityBinding/public/ActivityIdFormatStub.cs
+++ b/src/OpenTelemetry.DynamicActivityBinding/public/ActivityIdFormatStub.cs
@@ -1,0 +1,27 @@
+namespace OpenTelemetry.DynamicActivityBinding
+{
+    /// <summary>
+    /// Specifies the format of the Id property.
+    /// The values need to map exactly to
+    /// https://github.com/dotnet/runtime/blob/db6c3205edb3ad2fd7bc2b4a77bbaadbf3c95945/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs#L1513
+    /// </summary>
+    public enum ActivityIdFormatStub
+    {
+        /// <summary>
+        /// An unknown format.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// The hierarchical format.
+        /// See https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format.
+        /// </summary>
+        Hierarchical = 1,
+
+        /// <summary>
+        /// The W3C format.
+        /// See https://w3c.github.io/trace-context/.
+        /// </summary>
+        W3C = 2,
+    }
+}

--- a/src/OpenTelemetry.DynamicActivityBinding/public/ActivityKindStub.cs
+++ b/src/OpenTelemetry.DynamicActivityBinding/public/ActivityKindStub.cs
@@ -1,0 +1,36 @@
+namespace OpenTelemetry.DynamicActivityBinding
+{
+    /// <summary>
+    /// Describes the relationship between the activity, its parents and its children in a trace.
+    /// This MUST have a 1-to-1 value mapping to
+    /// https://github.com/dotnet/runtime/blob/master/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityKind.cs
+    /// </summary>
+    public enum ActivityKindStub
+    {
+        /// <summary>
+        /// Internal operation within an application, as opposed to operations with remote parents or children.
+        /// This is the default value.
+        /// </summary>
+        Internal = 0,
+
+        /// <summary>
+        /// Requests incoming from external component.
+        /// </summary>
+        Server = 1,
+
+        /// <summary>
+        /// Outgoing request to the external component.
+        /// </summary>
+        Client = 2,
+
+        /// <summary>
+        /// Output provided to external components.
+        /// </summary>
+        Producer = 3,
+
+        /// <summary>
+        /// Output received from an external component.
+        /// </summary>
+        Consumer = 4,
+    }
+}

--- a/src/OpenTelemetry.DynamicActivityBinding/public/ActivityStub.cs
+++ b/src/OpenTelemetry.DynamicActivityBinding/public/ActivityStub.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.DynamicActivityBinding
                 {
                     // TODO: is the no-op stub enough to represent "no current activity"? no need to differentiate
                     // "no current activity" from "no-op activity"?
-                    return NoOpSingeltons.ActivityStub;
+                    return NoOpSingletons.ActivityStub;
                 }
 
                 throw new NotImplementedException(MissingCapability);
@@ -92,7 +92,7 @@ namespace OpenTelemetry.DynamicActivityBinding
             {
                 if (ActivityInstance == null)
                 {
-                    return NoOpSingeltons.KvpEnumerable;
+                    return NoOpSingletons.KvpEnumerable;
                 }
 
                 throw new NotImplementedException(MissingCapability);
@@ -112,7 +112,7 @@ namespace OpenTelemetry.DynamicActivityBinding
             {
                 if (ActivityInstance == null)
                 {
-                    return NoOpSingeltons.TimeSpan;
+                    return NoOpSingletons.TimeSpan;
                 }
 
                 throw new NotImplementedException(MissingCapability);
@@ -174,7 +174,7 @@ namespace OpenTelemetry.DynamicActivityBinding
             {
                 if (ActivityInstance == null)
                 {
-                    return NoOpSingeltons.ActivityIdFormat;
+                    return NoOpSingletons.ActivityIdFormat;
                 }
 
                 throw new NotImplementedException(MissingCapability);
@@ -202,7 +202,7 @@ namespace OpenTelemetry.DynamicActivityBinding
             {
                 if (ActivityInstance == null)
                 {
-                    return NoOpSingeltons.ActivityKind;
+                    return NoOpSingletons.ActivityKind;
                 }
 
                 throw new NotImplementedException(MissingCapability);
@@ -295,7 +295,7 @@ namespace OpenTelemetry.DynamicActivityBinding
             {
                 if (ActivityInstance == null)
                 {
-                    return NoOpSingeltons.KvpEnumerable;
+                    return NoOpSingletons.KvpEnumerable;
                 }
 
                 throw new NotImplementedException(MissingCapability);
@@ -331,7 +331,7 @@ namespace OpenTelemetry.DynamicActivityBinding
         {
             if (activity == null)
             {
-                return NoOpSingeltons.ActivityStub;
+                return NoOpSingletons.ActivityStub;
             }
             else
             {
@@ -476,7 +476,7 @@ namespace OpenTelemetry.DynamicActivityBinding
             if (ActivityInstance == null)
             {
                 hasParent = false;
-                return NoOpSingeltons.ActivityStub;
+                return NoOpSingletons.ActivityStub;
             }
 
             throw new NotImplementedException(MissingCapability);
@@ -567,7 +567,7 @@ namespace OpenTelemetry.DynamicActivityBinding
             throw new NotImplementedException(MissingCapability);
         }
 
-        private static class NoOpSingeltons
+        private static class NoOpSingletons
         {
             internal static readonly ActivityStub ActivityStub = new ActivityStub(null);
             internal static readonly IEnumerable<KeyValuePair<string, string?>> KvpEnumerable = new KeyValuePair<string, string?>[0];

--- a/src/OpenTelemetry.DynamicActivityBinding/public/ActivityStub.cs
+++ b/src/OpenTelemetry.DynamicActivityBinding/public/ActivityStub.cs
@@ -1,0 +1,580 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenTelemetry.DynamicActivityBinding
+{
+    /// <summary>
+    /// This is the type used by auto-instrumentation code to generate trace data. It is based
+    /// on the <c>System.Diagnostics.Activity</c> type. The latter can't be used directly by the
+    /// instrumentation code since it isn't feasible to determine prior runtime if it is going
+    /// to be possible to load it and if possible the exact version that is going to be loaded.
+    /// </summary>
+    public struct ActivityStub : IDisposable
+    {
+        // Temporary constant to be used with NotImplementedException.
+        // TODO: remove it when functionatily is implemented.
+        private const string MissingCapability = "Currently ActivityStub only supports no-op";
+
+        private ActivityStub(object? activityInstance)
+        {
+            TraceId = null;
+            SpanId = null;
+            ParentSpanId = null;
+            ForceDefaultIdFormat = false;
+
+            ActivityInstance = activityInstance;
+        }
+
+        /// <summary>
+        /// Gets the current ActivityStub for the current thread. This flows across async calls.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <c>System.Diagnostics.Activity</c> ActivityStub is a struct so <c>null</c> can't be
+        /// used to indicate "no current activity".
+        /// <para/>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Current</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public static ActivityStub Current
+        {
+            get
+            {
+                if (!DynamicLoader.EnsureInitialized())
+                {
+                    // TODO: is the no-op stub enough to represent "no current activity"? no need to differentiate
+                    // "no current activity" from "no-op activity"?
+                    return NoOpSingeltons.ActivityStub;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets the default ID format for the Activity.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.DefaultIdFormat</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.4.0
+        /// </remarks>
+        public static ActivityIdFormatStub DefaultIdFormat
+        {
+            get
+            {
+                if (!DynamicLoader.EnsureInitialized())
+                {
+                    return ActivityIdFormatStub.Unknown;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets the actual object instance backing the ActivityStub.
+        /// </summary>
+        /// <remarks>
+        /// This property is exclusive of <see cref="ActivityStub"/> as a way to provide
+        /// access to the underlying providing the actual functionality.
+        /// </remarks>
+        public object? ActivityInstance { get; private set; }
+
+        /// <summary>
+        /// Gets a collection of key/value pairs that represents information that is passed to children of this Activity.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Baggage</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public IEnumerable<KeyValuePair<string, string?>> Baggage
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return NoOpSingeltons.KvpEnumerable;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets the duration of the operation.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Duration</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public TimeSpan Duration
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return NoOpSingeltons.TimeSpan;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="DefaultIdFormat"/> is always used to define the default ID format.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.ForceDefaultIdFormat</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.4.0
+        /// </remarks>
+        public bool ForceDefaultIdFormat
+        {
+            // TODO: actual implementation
+            get; set;
+        }
+
+        /// <summary>
+        /// Gets an identifier that is specific to a particular request.
+        /// </summary>
+        /// <remarks>
+        /// This is an ID that is specific to a particular request.   Filtering
+        /// to a particular ID insures that you get only one request that matches.
+        /// Id has a hierarchical structure: '|root-id.id1_id2.id3_' Id is generated when
+        /// <see cref="Start"/> is called by appending suffix to Parent.Id
+        /// or ParentId; Activity has no Id until it started
+        /// <para/>
+        /// See <see href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/>
+        /// for more details.
+        /// <para/>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Id</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public string? Id
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return string.Empty;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets the format for the <see cref="Id"/>.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.IdFormat</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.4.0
+        /// </remarks>
+        public ActivityIdFormatStub IdFormat
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return NoOpSingeltons.ActivityIdFormat;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the ActivityStub is a no-op or not.
+        /// </summary>
+        public bool IsNoOpStub
+        {
+            get { return ActivityInstance == null; }
+        }
+
+        /// <summary>
+        /// Gets the relationship between the activity, its parents, and its children in a trace.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Kind</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=5.0.0.0
+        /// </remarks>
+        public ActivityKindStub Kind
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return NoOpSingeltons.ActivityKind;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets the operation name.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.OperationName</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public string? OperationName
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return string.Empty;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the parent's <see cref="SpanId"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the Activity.ParentId is in the W3C format, this property
+        /// returns the <see cref="SpanId"/> part of the ParentId. Otherwise
+        /// it returns the zero-value for the property type.
+        /// <para/>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.ParentSpanId</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.4.0
+        /// </remarks>
+        public string? ParentSpanId
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Gets the root ID of this activity.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.RootId</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public string? RootId
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return null;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the SPAN part of the <see cref="Id"/>.
+        /// </summary>
+        /// <remarks>
+        /// The ID for the SPAN part of <see cref="Id"/>,
+        /// if the ID has the W3C format; otherwise, the zero-value for the property type.
+        /// <para/>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.SpanId</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.4.0
+        /// </remarks>
+        public string? SpanId
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Gets a collection of key/value pairs that represent information that will be logged
+        /// along with the activity to the tracing system.
+        /// </summary>
+        /// <seealso cref="Baggage"/>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Tags</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public IEnumerable<KeyValuePair<string, string?>> Tags
+        {
+            get
+            {
+                if (ActivityInstance == null)
+                {
+                    return NoOpSingeltons.KvpEnumerable;
+                }
+
+                throw new NotImplementedException(MissingCapability);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the TraceId part of the <see cref="Id"/>.
+        /// </summary>
+        /// <remarks>
+        /// The ID for the TraceId part of the <see cref="Id"/>,
+        /// if the ID has the W3C format; otherwise, the zero-value for the property type.
+        /// <para/>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.TraceId</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.4.0
+        /// </remarks>
+        public string? TraceId
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Creates an ActivityStub wrapping the given object.
+        /// </summary>
+        /// <param name="activity">
+        /// Instance object that will be wrapped by the ActivityStub to
+        /// provide its actual functionality.
+        /// </param>
+        /// <returns>
+        /// An ActivityStub wrapping the given object.
+        /// </returns>
+        public static ActivityStub Wrap(object? activity)
+        {
+            if (activity == null)
+            {
+                return NoOpSingeltons.ActivityStub;
+            }
+            else
+            {
+                return new ActivityStub(activity);
+            }
+        }
+
+        /// <summary>
+        /// Updates the <see cref="ActivityStub"/> to have a new baggage item with the specified key and value.
+        /// </summary>
+        /// <param name="key">
+        /// The baggage key.
+        /// </param>
+        /// <param name="value">
+        /// The baggage value.
+        /// </param>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.AddBaggage</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public void AddBaggage(string key, string? value)
+        {
+            if (ActivityInstance == null)
+            {
+                return;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <summary>
+        /// Updates the <see cref="ActivityStub"/> to have a new tag with the provided key and value.
+        /// </summary>
+        /// <param name="key">
+        /// The tag key.
+        /// </param>
+        /// <param name="value">
+        /// The tag value.
+        /// </param>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.OperationName</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public void AddTag(string key, string? value)
+        {
+            if (ActivityInstance == null)
+            {
+                return;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Dispose</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=5.0.0.0
+        /// </remarks>
+        public void Dispose()
+        {
+            IDisposable? disposableActivity = ActivityInstance as IDisposable;
+            if (disposableActivity != null)
+            {
+                disposableActivity.Dispose();
+            }
+            else
+            {
+                Stop();
+            }
+        }
+
+        /// <summary>
+        /// Returns the value of the key-value pair added to the activity with <see cref="AddBaggage(string, string)"/>.
+        /// Returns null if that key does not exist.
+        /// </summary>
+        /// <param name="key">
+        /// The baggage key.
+        /// </param>
+        /// <returns>
+        /// The value of the key-value pair added to the activity with <see cref="AddBaggage(string, string)"/>.
+        /// Returns null if that key does not exist.
+        /// </returns>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.OperationName</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public string? GetBaggageItem(string key)
+        {
+            if (ActivityInstance == null)
+            {
+                return null;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <summary>
+        /// GetCustomProperty retrieve previously attached object mapped to the property name.
+        /// </summary>
+        /// <param name="propertyName">
+        /// The name to get the associated object with.
+        /// </param>
+        /// <returns>
+        /// The object mapped to the property name. Or null if there is no mapping previously
+        /// done with this property name.
+        /// </returns>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.GetCustomProperty</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=5.0.0.0
+        /// </remarks>
+        public object? GetCustomProperty(string propertyName)
+        {
+            if (ActivityInstance == null)
+            {
+                return null;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <summary>
+        /// Gets the parent activity that created <c>this</c> activity.
+        /// </summary>
+        /// <param name="hasParent">
+        /// Out parameter used to indicate if the activity actually has a parent.
+        /// </param>
+        /// <returns>
+        /// The parent activity or a no-op stub, check <paramref name="hasParent"/> to
+        /// determine the actual meaning.
+        /// </returns>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Parent</c>
+        /// plus the <paramref name="hasParent"/> to compensate for the fact that <see cref="ActivityStub"/>
+        /// is a value type unlike <c>System.Diagnostics.DiagnosticSource.Activity</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public ActivityStub Parent(out bool hasParent)
+        {
+            // A more appropriate shape for this API would be
+            //   bool TryGetParentStub(out ActivityStub parentStub);
+            // However, we want Intellisense to place this next to Parent.
+            if (ActivityInstance == null)
+            {
+                hasParent = false;
+                return NoOpSingeltons.ActivityStub;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <summary>
+        /// SetCustomProperty allow attaching any custom object to this Activity object.
+        /// If the property name was previously associated with other object, SetCustomProperty will update
+        /// to use the new propert value instead.
+        /// </summary>
+        /// <param name="propertyName"> The name to associate the value with.<see cref="OperationName"/></param>
+        /// <param name="propertyValue">The object to attach and map to the property name.</param>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.GetCustomProperty</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=5.0.0.0
+        /// </remarks>
+        public void SetCustomProperty(string propertyName, object? propertyValue)
+        {
+            if (ActivityInstance == null)
+            {
+                return;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <summary>
+        /// Updates the Activity To indicate that the activity with ID <paramref name="parentId"/>
+        /// caused this activity.   This is intended to be used only at 'boundary'
+        /// scenarios where an activity from another process logically started
+        /// this activity. The Parent ID shows up the Tags (as well as the ParentID
+        /// property), and can be used to reconstruct the causal tree.
+        /// </summary>
+        /// <param name="parentId">
+        /// The id of the parent operation.
+        /// </param>
+        /// <returns>
+        /// <c>this</c> for convenient chaining.
+        /// </returns>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.SetParentId</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public ActivityStub SetParentId(string parentId)
+        {
+            if (ActivityInstance == null)
+            {
+                return this;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <summary>
+        /// Starts the activity.
+        /// </summary>
+        /// <returns>
+        /// <c>this</c> for convenient chaining.
+        /// </returns>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Start</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public ActivityStub Start()
+        {
+            if (ActivityInstance == null)
+            {
+                return this;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        /// <summary>
+        /// Stops the activity.
+        /// </summary>
+        /// <remarks>
+        /// Provides functionality of <c>System.Diagnostics.DiagnosticSource.Activity.Start</c>.
+        /// Introduction: System.Diagnostics.DiagnosticSource, Version=4.0.2.1
+        /// </remarks>
+        public void Stop()
+        {
+            if (ActivityInstance == null)
+            {
+                return;
+            }
+
+            throw new NotImplementedException(MissingCapability);
+        }
+
+        private static class NoOpSingeltons
+        {
+            internal static readonly ActivityStub ActivityStub = new ActivityStub(null);
+            internal static readonly IEnumerable<KeyValuePair<string, string?>> KvpEnumerable = new KeyValuePair<string, string?>[0];
+            internal static readonly TimeSpan TimeSpan = TimeSpan.Zero;
+            internal static readonly DateTime DateTimeUtc = default(DateTime).ToUniversalTime();
+            internal static readonly ActivityIdFormatStub ActivityIdFormat = ActivityIdFormatStub.Unknown;
+            internal static readonly ActivityKindStub ActivityKind = ActivityKindStub.Internal;
+        }
+    }
+}


### PR DESCRIPTION
Bringing the skeleton for the `ActivityStub` described on issue #13, see also https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/18#issuecomment-705157637.

This first PR is just the skeleton for the stub and as such doesn't bring yet dynamic loader and related tests. The API surface is not 100% match with S.D.DS.Activity but gets us ready to start implementing the actual assembly loading. Extending the API to the desired surface is relatively mechanical after the dynamic loading of S.D.DS or the fallback to its "vendored" sources is done.

Some notes:

1. I went through the trouble of making it compatible with the current StyleCop settings for the whole repo, this may not be desirable when we bring the "vendored" sources from dotnet/runtime but for now it keeps the sources consistent.
2. For not the types for `TraceId` and `SpanId` are replaced with `string`: we likely need a wrapper for these types.
3. I didn't bring the methods that match methods from `ActivitySource` my initial thought is that we should also have a separate stub for `ActivitySource` instead of having all of those under `ActivityStub`.
4. For now supplemental data handling was not included either.

Missing `Activity` equivalent API surface:

| Property | S.D.DS.Activity version introduction |
| --------- | ---------------------------------------- |
| ActivityContext | 5.0.0.0 |
| DisplayName | 5.0.0.0 |
| Events | 5.0.0.0 |
| IsAllDataRequested | 5.0.0.0 |
| Links | 5.0.0.0 |
| ParentId | 4.0.2.1 |
| Recorced | 4.0.4.0 |
| Source | 5.0.0.0 |
| StartTimeUtc | 4.0.2.1 |
| TraceStateString | 4.0.4.0 |

| Method | S.D.DS.Activity version introduction |
| --------- | ---------------------------------------- |
| AddEvent | 5.0.0.0 |
| SetEndTime | 4.0.2.1 |
| SetIdFormat | 4.0.4.0 |
| SetParentId (overload w/ 3 parameters) | 4.0.4.0 |
| SetStartTime | 4.0.2.1 |

