### PR TITLE
Adds more info for newcomers to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project provides a .NET tracer that leverages the .NET profiling APIs to su
 
 ## Status
 
-This project is in the early stages of development starting with an initial seeding of code from the [.NET Tracer for DataDog APM](https://github.com/DataDog/dd-trace-dotnet). Our current goal is to take the seeded tracer and update it to both listen to and generate OpenTelemetry tracing data. To accomplish this our current priorities are to:
+This project is in the early stages of development starting with an initial seeding of code from the [.NET Tracer for Datadog APM](https://github.com/DataDog/dd-trace-dotnet). Our current goal is to take the seeded tracer and update it to both listen to and generate OpenTelemetry tracing data. To accomplish this our current priorities are to:
 1. Define System.Diagnostics.DiagnosticSource wrappers to generate and consume [.NET Activities](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0)
 2. Validate that the performance of this wrapping approach will be acceptable.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,32 @@
 # opentelemetry-dotnet-instrumentation
-.NET instrumentation and auto-instrumentation
+[![Gitter
+chat](https://badges.gitter.im/open-telemetry/opentelemetry-dotnet.svg)](https://gitter.im/open-telemetry/opentelemetry-dotnet-auto-instr)
 
-### Community Roles
+This project provides a .NET tracer that leverages the .NET profiling APIs to support .NET instrumentation and auto-instrumentation without requiring code changes to an application.
+
+## Status
+
+This project is in the early stages of development starting with an initial seeding of code from the [.NET Tracer for DataDog APM](https://github.com/DataDog/dd-trace-dotnet). Our current goal is to take the seeded tracer and update it to both listen to and generate OpenTelemetry tracing data. To accomplish this our current priorities are to:
+1. Define System.Diagnostics.DiagnosticSource wrappers to generate and consume [.NET Activities](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0)
+2. Validate that the performance of this wrapping approach will be acceptable.
+
+For more details about the preliminary roadmap refer to the [Preliminary Roadmap Google doc](https://docs.google.com/document/d/10BiAfYDURrk8PQxjT65bEc0ydVngWLoWk8IGo4xDKko/edit?usp=sharing).
+
+## Contributing
+
+We meet weekly on Wednesdays at 1PM PT. The meeting is subject to change depending on contributors'
+availability. Check the [OpenTelemetry community
+calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)
+for specific dates.
+
+Meetings take place via [Zoom video conference](https://zoom.us/j/8287234601).
+
+Meeting notes are available as a public [Google
+doc](https://docs.google.com/document/d/1XedN2D8_PH4YLej-maT8sp4RKogfuhFpccRi3QpUcoI/edit?usp=sharing).
+For edit access, get in touch on
+[Gitter](https://gitter.im/open-telemetry/opentelemetry-dotnet-auto-instr).
+
+## Community Roles
 
 Maintainers ([@open-telemetry/dotnet-instrumentation-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-instrumentation-maintainers)):
 


### PR DESCRIPTION
Adds information to the README to make it easier for newcomers to understand the current status of the project.

The maintainer list in the README is currently out of date, but I'd rather address that with a separate PR, and allow the discussion of this PR to focus on other useful information for newcomers.
