### PR TITLE
Add Zipkin as an option for exporting traces

### DIFF
--- a/src/Datadog.Trace/Agent/ZipkinApi.cs
+++ b/src/Datadog.Trace/Agent/ZipkinApi.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Agent
+{
+    internal class ZipkinApi : IApi
+    {
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<ZipkinApi>();
+
+        private readonly TracerSettings _settings;
+        private Uri _tracesEndpoint;
+
+        public ZipkinApi(TracerSettings settings)
+        {
+            Log.Debug("Creating new Zipkin Api");
+
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            _tracesEndpoint = _settings.AgentUri; // User needs to include the proper path.
+        }
+
+        public void SetBaseEndpoint(Uri baseEndpoint)
+        {
+            // TODO: This doesn't make sense for this exporter.
+            _tracesEndpoint = new Uri(baseEndpoint, _tracesEndpoint.PathAndQuery);
+        }
+
+        public async Task<bool> SendTracesAsync(Span[][] traces)
+        {
+            if (traces == null || traces.Length == 0)
+            {
+                // Nothing to send, no ping for Zipkin.
+                return true;
+            }
+
+            // retry up to 5 times with exponential back-off
+            var retryLimit = 5;
+            var retryCount = 1;
+            var sleepDuration = 100; // in milliseconds
+
+            while (true)
+            {
+                // TODO: Initially same code for Fx and Core.
+                var request = WebRequest.CreateHttp(_tracesEndpoint);
+                request.Method = "POST";
+                request.ContentType = "application/json";
+
+                foreach (var header in _settings.HeaderTags)
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
+
+                using (var requestStream = await request.GetRequestStreamAsync().ConfigureAwait(false))
+                {
+                    var serializer = new ZipkinSerializer();
+                    serializer.Serialize(requestStream, traces, _settings);
+                }
+
+                Exception requestException = null;
+                HttpStatusCode requestStatusCode = 0;
+                try
+                {
+                    using var httpWebResponse = (HttpWebResponse)await request.GetResponseAsync().ConfigureAwait(false);
+
+                    // Zipkin specifies only "Accepted" as valid response, the code is more tolerant here.
+                    if (httpWebResponse.StatusCode >= HttpStatusCode.OK && httpWebResponse.StatusCode <= HttpStatusCode.Accepted)
+                    {
+                        return true;
+                    }
+
+                    requestStatusCode = httpWebResponse.StatusCode;
+                    Log.Debug("HTTP error sending traces to {0}: {1}", _tracesEndpoint, httpWebResponse.StatusCode);
+                }
+                catch (Exception ex)
+                {
+                    requestException = ex;
+                    Log.Debug("Exception sending traces to {0}: {1}", _tracesEndpoint, ex.Message);
+                }
+
+                if (retryCount >= retryLimit)
+                {
+                    if (requestException != null)
+                    {
+                        Log.Error("No more retries, dropping spans. Last exception sending traces to {0}: {1}", _tracesEndpoint, requestException.Message);
+                    }
+                    else
+                    {
+                        Log.Error("No more retries, dropping spans. Last HTTP error sending traces to {0}: {1}", _tracesEndpoint, requestStatusCode);
+                    }
+
+                    return false;
+                }
+
+                // retry
+                await Task.Delay(sleepDuration).ConfigureAwait(false);
+                retryCount++;
+                sleepDuration *= 2;
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
+
+namespace Datadog.Trace.Agent
+{
+    internal class ZipkinSerializer
+    {
+        private readonly JsonSerializer serializer = new JsonSerializer();
+
+        // Don't serialize with BOM
+        private readonly Encoding utf8 = new UTF8Encoding(false);
+
+        public void Serialize(Stream stream, Span[][] traces, TracerSettings settings)
+        {
+            var zipkinTraces = new List<ZipkinSpan>();
+
+            foreach (var trace in traces)
+            {
+                foreach (var span in trace)
+                {
+                    var zspan = new ZipkinSpan(span, settings);
+                    zipkinTraces.Add(zspan);
+                }
+            }
+
+            using (var sw = new StreamWriter(stream, utf8, 4096, true))
+            {
+                serializer.Serialize(sw, zipkinTraces);
+            }
+        }
+
+        private static IDictionary<string, string> BuildTags(Span span, TracerSettings settings)
+        {
+            var tags = new Dictionary<string, string>();
+
+            foreach (var entry in span.Tags.Tags)
+            {
+                if (!entry.Key.Equals(Trace.Tags.SpanKind))
+                {
+                    tags[entry.Key] = entry.Value;
+                }
+            }
+
+            return tags;
+        }
+
+        [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+        internal class ZipkinSpan
+        {
+            private static IDictionary<string, string> emptyTags = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+
+            private readonly Span _span;
+            private readonly TracerSettings _settings;
+            private readonly IDictionary<string, string> _tags;
+
+            public ZipkinSpan(Span span, TracerSettings settings)
+            {
+                _span = span;
+                _settings = settings;
+                _tags = span.Tags != null ? BuildTags(span, settings) : emptyTags;
+            }
+
+            public string Id
+            {
+                get => _span.Context.SpanId.ToString("x16");
+            }
+
+            public string TraceId
+            {
+                get => _span.Context.TraceId.ToString("x16");
+            }
+
+            public string ParentId
+            {
+                get => _span.Context.ParentId?.ToString("x16");
+            }
+
+            public string Name
+            {
+                get => _span.OperationName;
+            }
+
+            public long Timestamp
+            {
+                get => _span.StartTime.ToUnixTimeMicroseconds();
+            }
+
+            public long Duration
+            {
+                get => _span.Duration.ToMicroseconds();
+            }
+
+            public string Kind
+            {
+                get => _span.GetTag(Trace.Tags.SpanKind)?.ToUpper();
+            }
+
+            public Dictionary<string, string> LocalEndpoint
+            {
+                get
+                {
+                    var actualServiceName = !string.IsNullOrWhiteSpace(_span.ServiceName)
+                        ? _span.ServiceName
+                        : Tracer.Instance.DefaultServiceName;
+
+                    // TODO: Save this allocation
+                    return new Dictionary<string, string>() { { "serviceName", actualServiceName } };
+                }
+            }
+
+            public IDictionary<string, string> Tags
+            {
+                get => _tags;
+            }
+
+            // Methods below are used by Newtonsoft JSON serializer to decide if should serialize
+            // some properties when they are null.
+
+            public bool ShouldSerializeTags()
+            {
+                return _tags != null;
+            }
+
+            public bool ShouldSerializeParentId()
+            {
+                return _span.Context.ParentId != null;
+            }
+
+            public bool ShouldSerializeKind()
+            {
+                return _span.Tags?.GetTag(Trace.Tags.SpanKind) != null;
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Agent
             {
                 _span = span;
                 _settings = settings;
-                _tags = BuildTags(span, settings);
+                _tags = BuildTags(span);
             }
 
             public string Id
@@ -105,7 +105,7 @@ namespace Datadog.Trace.Agent
                 get => _tags;
             }
 
-            private static IDictionary<string, string> BuildTags(Span span, TracerSettings settings)
+            private static IDictionary<string, string> BuildTags(Span span)
             {
                 var spanTags = span?.Tags?.Tags;
                 if (spanTags == null || spanTags.Count == 0)

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -212,7 +212,7 @@ namespace Datadog.Trace.Configuration
         public const string DiagnosticSourceEnabled = "DD_DIAGNOSTIC_SOURCE_ENABLED";
 
         /// <summary>
-        /// Configuration key for the exporter to be used the Tracer uses it to encode and
+        /// Configuration key for the exporter to be used. The Tracer uses it to encode and
         /// dispatch traces.
         /// Default is <c>"DatadogAgent"</c>.
         /// </summary>

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -212,6 +212,14 @@ namespace Datadog.Trace.Configuration
         public const string DiagnosticSourceEnabled = "DD_DIAGNOSTIC_SOURCE_ENABLED";
 
         /// <summary>
+        /// Configuration key for the exporter to be used the Tracer uses it to encode and
+        /// dispatch traces.
+        /// Default is <c>"DatadogAgent"</c>.
+        /// </summary>
+        /// <seealso cref="TracerSettings.Exporter"/>
+        public const string Exporter = "OTEL_EXPORTER";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/ExporterType.cs
+++ b/src/Datadog.Trace/Configuration/ExporterType.cs
@@ -1,0 +1,23 @@
+namespace Datadog.Trace.Configuration
+{
+    /// <summary>
+    /// Enumeration for the available exporter types.
+    /// </summary>
+    public enum ExporterType
+    {
+        /// <summary>
+        /// The default exporter.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// The Datadog Agent exporter.
+        /// </summary>
+        DatadogAgent = Default,
+
+        /// <summary>
+        /// The Zipkin exporter.
+        /// </summary>
+        Zipkin
+    }
+}

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -248,7 +248,7 @@ namespace Datadog.Trace.Configuration
         public bool TracerMetricsEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the exporter to be used the Tracer uses it to encode and
+        /// Gets or sets the name of the exporter to be used. The Tracer uses it to encode and
         /// dispatch traces.
         /// Default is <c>"DatadogAgent"</c>.
         /// <seealso cref="ConfigurationKeys.Exporter"/>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -130,6 +130,9 @@ namespace Datadog.Trace.Configuration
             StartupDiagnosticLogEnabled = source?.GetBool(ConfigurationKeys.StartupDiagnosticLogEnabled) ??
                                           // default value
                                           true;
+
+            Enum.TryParse(source?.GetString(ConfigurationKeys.Exporter) ?? "default", ignoreCase: true, out ExporterType exporterType);
+            Exporter = exporterType;
         }
 
         /// <summary>
@@ -243,6 +246,14 @@ namespace Datadog.Trace.Configuration
         /// are enabled and sent to DogStatsd.
         /// </summary>
         public bool TracerMetricsEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the exporter to be used the Tracer uses it to encode and
+        /// dispatch traces.
+        /// Default is <c>"DatadogAgent"</c>.
+        /// <seealso cref="ConfigurationKeys.Exporter"/>
+        /// </summary>
+        public ExporterType Exporter { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the use

--- a/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/TimeExtensions.cs
@@ -1,9 +1,12 @@
-﻿using System;
+using System;
 
 namespace Datadog.Trace.ExtensionMethods
 {
     internal static class TimeExtensions
     {
+        private const long MicrosecondsPerMillisecond = 1000;
+        private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / MicrosecondsPerMillisecond;
+
         /// <summary>
         /// Returns the number of nanoseconds that have elapsed since 1970-01-01T00:00:00.000Z.
         /// </summary>
@@ -14,9 +17,24 @@ namespace Datadog.Trace.ExtensionMethods
             return (dateTimeOffset.Ticks - TimeConstants.UnixEpochInTicks) * TimeConstants.NanoSecondsPerTick;
         }
 
+        /// <summary>
+        /// Returns the number of microseconds that have elapsed since 1970-01-01T00:00:00.000Z.
+        /// </summary>
+        /// <param name="dateTimeOffset">The value to get the number of elapsed microseconds for.</param>
+        /// <returns>The number of microseconds that have elapsed since 1970-01-01T00:00:00.000Z.</returns>
+        public static long ToUnixTimeMicroseconds(this DateTimeOffset dateTimeOffset)
+        {
+            return (dateTimeOffset.Ticks - TimeConstants.UnixEpochInTicks) / TicksPerMicrosecond;
+        }
+
         public static long ToNanoseconds(this TimeSpan ts)
         {
             return ts.Ticks * TimeConstants.NanoSecondsPerTick;
+        }
+
+        public static long ToMicroseconds(this TimeSpan ts)
+        {
+            return ts.Ticks / TicksPerMicrosecond;
         }
     }
 }

--- a/src/Datadog.Trace/Tagging/ITags.cs
+++ b/src/Datadog.Trace/Tagging/ITags.cs
@@ -1,7 +1,13 @@
+using System.Collections.Generic;
+
 namespace Datadog.Trace.Tagging
 {
     internal interface ITags
     {
+        List<KeyValuePair<string, double>> Metrics { get; }
+
+        List<KeyValuePair<string, string>> Tags { get; }
+
         string GetTag(string key);
 
         void SetTag(string key, string value);

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -11,9 +11,9 @@ namespace Datadog.Trace.Tagging
         private List<KeyValuePair<string, double>> _metrics;
         private List<KeyValuePair<string, string>> _tags;
 
-        protected List<KeyValuePair<string, double>> Metrics => Volatile.Read(ref _metrics);
+        public List<KeyValuePair<string, double>> Metrics => Volatile.Read(ref _metrics);
 
-        protected List<KeyValuePair<string, string>> Tags => Volatile.Read(ref _tags);
+        public List<KeyValuePair<string, string>> Tags => Volatile.Read(ref _tags);
 
         public string GetTag(string key)
         {

--- a/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
+++ b/test/Datadog.Trace.TestHelpers/MockZipkinCollector.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.ExtensionMethods;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Datadog.Trace.TestHelpers
+{
+    // Modeled from MockTracerAgent
+    public class MockZipkinCollector : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly Thread _listenerThread;
+        private readonly CancellationTokenSource _listenerCts = new CancellationTokenSource();
+
+        public MockZipkinCollector(int port = 9080, int retries = 5)
+        {
+            // try up to 5 consecutive ports before giving up
+            while (true)
+            {
+                // seems like we can't reuse a listener if it fails to start,
+                // so create a new listener each time we retry
+                var listener = new HttpListener();
+                listener.Prefixes.Add($"http://localhost:{port}/");
+
+                try
+                {
+                    listener.Start();
+
+                    // successfully listening
+                    Port = port;
+                    _listener = listener;
+
+                    _listenerThread = new Thread(HandleHttpRequests);
+                    _listenerThread.Start();
+
+                    return;
+                }
+                catch (HttpListenerException) when (retries > 0)
+                {
+                    // only catch the exception if there are retries left
+                    port++;
+                    retries--;
+                }
+
+                // always close listener if exception is thrown,
+                // whether it was caught or not
+                listener.Close();
+            }
+        }
+
+        public event EventHandler<EventArgs<HttpListenerContext>> RequestReceived;
+
+        public event EventHandler<EventArgs<IList<Span>>> RequestDeserialized;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip serialization of traces.
+        /// </summary>
+        public bool ShouldDeserializeTraces { get; set; } = true;
+
+        /// <summary>
+        /// Gets the TCP port that this Agent is listening on.
+        /// Can be different from <see cref="MockZipkinCollector(int, int)"/>'s <c>initialPort</c>
+        /// parameter if listening on that port fails.
+        /// </summary>
+        public int Port { get; }
+
+        /// <summary>
+        /// Gets the filters used to filter out spans we don't want to look at for a test.
+        /// </summary>
+        public List<Func<Span, bool>> SpanFilters { get; private set; } = new List<Func<Span, bool>>();
+
+        public IImmutableList<Span> Spans { get; private set; } = ImmutableList<Span>.Empty;
+
+        public IImmutableList<NameValueCollection> RequestHeaders { get; private set; } = ImmutableList<NameValueCollection>.Empty;
+
+        /// <summary>
+        /// Wait for the given number of spans to appear.
+        /// </summary>
+        /// <param name="count">The expected number of spans.</param>
+        /// <param name="timeoutInMilliseconds">The timeout</param>
+        /// <param name="operationName">The integration we're testing</param>
+        /// <param name="minDateTime">Minimum time to check for spans from</param>
+        /// <param name="returnAllOperations">When true, returns every span regardless of operation name</param>
+        /// <param name="operationNameContainsAny">Only return spans for which the operation name matches any names in the array.</param>
+        /// <returns>The list of spans.</returns>
+        public IImmutableList<Span> WaitForSpans(
+            int count,
+            int timeoutInMilliseconds = 20000,
+            string operationName = null,
+            DateTimeOffset? minDateTime = null,
+            bool returnAllOperations = false,
+            string[] operationNameContainsAny = null)
+        {
+            var deadline = DateTime.Now.AddMilliseconds(timeoutInMilliseconds);
+            var minimumOffset = (minDateTime ?? DateTimeOffset.MinValue).ToUnixTimeMicroseconds();
+
+            IImmutableList<Span> relevantSpans = ImmutableList<Span>.Empty;
+
+            operationNameContainsAny ??= new string[0];
+            while (DateTime.Now < deadline)
+            {
+                relevantSpans =
+                    Spans
+                       .Where(s => SpanFilters.All(shouldReturn => shouldReturn(s)))
+                       .Where(s => s.Start > minimumOffset)
+                       .ToImmutableList();
+
+                if (relevantSpans.Count(s => operationNameContainsAny.Any(contains => s.Name.Contains(contains)) || operationName == null || s.Name == operationName) >= count)
+                {
+                    break;
+                }
+
+                Thread.Sleep(500);
+            }
+
+            if (!returnAllOperations)
+            {
+                relevantSpans =
+                    relevantSpans
+                       .Where(s => operationNameContainsAny.Any(contains => s.Name.Contains(contains)) || operationName == null || s.Name == operationName)
+                       .ToImmutableList();
+            }
+
+            return relevantSpans;
+        }
+
+        public void Dispose()
+        {
+            lock (_listener)
+            {
+                _listenerCts.Cancel();
+                _listener.Stop();
+            }
+        }
+
+        protected virtual void OnRequestReceived(HttpListenerContext context)
+        {
+            RequestReceived?.Invoke(this, new EventArgs<HttpListenerContext>(context));
+        }
+
+        protected virtual void OnRequestDeserialized(IList<Span> trace)
+        {
+            RequestDeserialized?.Invoke(this, new EventArgs<IList<Span>>(trace));
+        }
+
+        private void AssertHeader(
+            NameValueCollection headers,
+            string headerKey,
+            Func<string, bool> assertion)
+        {
+            var header = headers.Get(headerKey);
+
+            if (string.IsNullOrEmpty(header))
+            {
+                throw new Exception($"Every submission to the agent should have a {headerKey} header.");
+            }
+
+            if (!assertion(header))
+            {
+                throw new Exception($"Failed assertion for {headerKey} on {header}");
+            }
+        }
+
+        private void HandleHttpRequests()
+        {
+            while (true)
+            {
+                try
+                {
+                    var getCtxTask = Task.Run(() => _listener.GetContext());
+                    getCtxTask.Wait(_listenerCts.Token);
+
+                    var ctx = getCtxTask.Result;
+                    OnRequestReceived(ctx);
+
+                    if (ShouldDeserializeTraces)
+                    {
+                        using (var reader = new StreamReader(ctx.Request.InputStream))
+                        {
+                            var zspans = JsonConvert.DeserializeObject<List<Span>>(reader.ReadToEnd());
+                            OnRequestDeserialized(zspans);
+
+                            Spans = Spans.AddRange(zspans);
+                            RequestHeaders = RequestHeaders.Add(new NameValueCollection(ctx.Request.Headers));
+                        }
+                    }
+
+                    ctx.Response.ContentType = "application/json";
+                    var buffer = Encoding.UTF8.GetBytes("{}");
+                    ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                    ctx.Response.Close();
+                }
+                catch (Exception ex) when (ex is HttpListenerException || ex is OperationCanceledException || ex is AggregateException)
+                {
+                    lock (_listener)
+                    {
+                        if (!_listener.IsListening)
+                        {
+                            return;
+                        }
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        [DebuggerDisplay("TraceId={TraceId}, SpanId={SpanId}, Service={Service}, Name={Name}, Resource={Resource}")]
+        public class Span
+        {
+            [JsonExtensionData]
+            private IDictionary<string, JToken> _zipkinData;
+
+            public Span()
+            {
+                _zipkinData = new Dictionary<string, JToken>();
+            }
+
+            public ulong TraceId
+            {
+                get => Convert.ToUInt64(_zipkinData["traceId"].ToString(), 16);
+            }
+
+            public ulong SpanId
+            {
+                get => Convert.ToUInt64(_zipkinData["id"].ToString(), 16);
+            }
+
+            public string Name { get; set; }
+
+            public string Kind { get; set; }
+
+            public string Resource { get; set; }
+
+            public string Service
+            {
+                get => _zipkinData["localEndpoint"]["serviceName"].ToString();
+            }
+
+            public string Type { get; set; }
+
+            public long Start
+            {
+                get => Convert.ToInt64(_zipkinData["timestamp"].ToString());
+            }
+
+            public long Duration { get; set; }
+
+            public ulong? ParentId
+            {
+                get
+                {
+                    ((IDictionary)_zipkinData).TryGetValue<string>("parentId", out string parentId);
+                    return parentId == null ? null : (ulong?)Convert.ToUInt64(parentId.ToString(), 16);
+                }
+            }
+
+            public byte Error { get; set; }
+
+            public Dictionary<string, string> Tags { get; set; }
+
+            public Dictionary<DateTimeOffset, Dictionary<string, string>> Logs
+            {
+                get
+                {
+                    var annotations = _zipkinData["annotations"].ToObject<List<Dictionary<string, object>>>();
+                    var logs = new Dictionary<DateTimeOffset, Dictionary<string, string>>();
+                    foreach (var item in annotations)
+                    {
+                        DateTimeOffset timestamp = TimeHelpers.UnixMicrosecondsToDateTimeOffset((long)item["timestamp"]);
+                        Dictionary<string, string> fields = JsonConvert.DeserializeObject<Dictionary<string, string>>(item["value"].ToString());
+                        logs[timestamp] = fields;
+                    }
+
+                    return logs;
+                }
+            }
+
+            public Dictionary<string, double> Metrics { get; set; }
+
+            public override string ToString()
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine($"TraceId: {TraceId}");
+                sb.AppendLine($"ParentId: {ParentId}");
+                sb.AppendLine($"SpanId: {SpanId}");
+                sb.AppendLine($"Service: {Service}");
+                sb.AppendLine($"Name: {Name}");
+                sb.AppendLine($"Resource: {Resource}");
+                sb.AppendLine($"Type: {Type}");
+                sb.AppendLine($"Start: {Start}");
+                sb.AppendLine($"Duration: {Duration}");
+                sb.AppendLine($"Error: {Error}");
+                sb.AppendLine("Tags:");
+
+                if (Tags?.Count > 0)
+                {
+                    foreach (var kv in Tags)
+                    {
+                        sb.Append($"\t{kv.Key}:{kv.Value}\n");
+                    }
+                }
+
+                sb.AppendLine("Logs:");
+                foreach (var e in Logs)
+                {
+                    sb.Append($"\t{e.Key}:\n");
+                    foreach (var kv in e.Value)
+                    {
+                        sb.Append($"\t\t{kv.Key}:{kv.Value}\n");
+                    }
+                }
+
+                return sb.ToString();
+            }
+
+            [OnDeserialized]
+            private void OnDeserialized(StreamingContext context)
+            {
+                var resourceNameTag = DictionaryExtensions.GetValueOrDefault(Tags, "resource.name");
+                // If resource.name tag not set, it matches the operation name
+                Resource = string.IsNullOrEmpty(resourceNameTag) ? Name : resourceNameTag;
+                Type = DictionaryExtensions.GetValueOrDefault(Tags, "span.type");
+                var error = DictionaryExtensions.GetValueOrDefault(Tags, "error") ?? "false";
+                Error = (byte)(error.ToLowerInvariant().Equals("true") ? 1 : 0);
+                var spanKind = (string)DictionaryExtensions.GetValueOrDefault(_zipkinData, "kind");
+                if (spanKind != null)
+                {
+                    Tags["span.kind"] = spanKind.ToLowerInvariant();
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.TestHelpers/TestRunners.cs
+++ b/test/Datadog.Trace.TestHelpers/TestRunners.cs
@@ -8,6 +8,8 @@ namespace Datadog.Trace.TestHelpers
                                                                 {
                                                                     "testhost",
                                                                     "testhost.x86",
+                                                                    "testhost.net452.x86",
+                                                                    "testhost.net461.x86",
                                                                     "vstest.console",
                                                                     "xunit.console.x86",
                                                                     "xunit.console.x64",

--- a/test/Datadog.Trace.TestHelpers/TimeHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/TimeHelpers.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Datadog.Trace.TestHelpers
+{
+    internal static class TimeHelpers
+    {
+        /// <summary>
+        /// Reconverts a long timestamp from TimeExtensions.ToUnixTimeMicroseconds.
+        /// </summary>
+        /// <param name="ts">The unix time in microseconds.</param>
+        /// <returns>The corresponding DateTimeOffset.</returns>
+        public static DateTimeOffset UnixMicrosecondsToDateTimeOffset(long ts)
+        {
+            const long microsecondsPerMillisecond = 1000;
+            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / microsecondsPerMillisecond;
+            var ticks = (ts * ticksPerMicrosecond) + TimeConstants.UnixEpochInTicks;
+            return new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -86,6 +86,12 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,:tagonly,headeronly:,:,nocolon", CreateFunc(s => s.HeaderTags), HeaderTags };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:tag1", CreateFunc(s => s.HeaderTags), HeaderTagsSameTag };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header1:tag2", CreateFunc(s => s.HeaderTags.Count), 1 };
+
+            yield return new object[] { ConfigurationKeys.Exporter, null, CreateFunc(s => s.Exporter), ExporterType.Default };
+            yield return new object[] { ConfigurationKeys.Exporter, string.Empty, CreateFunc(s => s.Exporter), ExporterType.Default };
+            yield return new object[] { ConfigurationKeys.Exporter, "datadogagent", CreateFunc(s => s.Exporter), ExporterType.DatadogAgent };
+            yield return new object[] { ConfigurationKeys.Exporter, "Zipkin", CreateFunc(s => s.Exporter), ExporterType.Zipkin };
+            yield return new object[] { ConfigurationKeys.Exporter, "unknown", CreateFunc(s => s.Exporter), ExporterType.Default };
         }
 
         // JsonConfigurationSource needs to be tested with JSON data, which cannot be used with the other IConfigurationSource implementations.

--- a/test/Datadog.Trace.Tests/TimeUtilsTests.cs
+++ b/test/Datadog.Trace.Tests/TimeUtilsTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NET45 && !NET451 && !NET452
+#if !NET45 && !NET451 && !NET452
 using System;
 using Datadog.Trace.ExtensionMethods;
 using Xunit;
@@ -19,6 +19,34 @@ namespace Datadog.Trace.Tests
         {
             var date = DateTimeOffset.UtcNow;
             Assert.Equal(date.ToUnixTimeMilliseconds(), date.ToUnixTimeNanoseconds() / 1000000);
+        }
+
+        [Fact]
+        public void ToUnixTimeMicroseconds_UnixEpoch_Zero()
+        {
+            var date = DateTimeOffset.FromUnixTimeMilliseconds(0);
+            Assert.Equal(0, date.ToUnixTimeMicroseconds());
+        }
+
+        [Fact]
+        public void ToUnixTimeMicrooseconds_Now_CorrectMillisecondRoundedValue()
+        {
+            var date = DateTimeOffset.UtcNow;
+            Assert.Equal(date.ToUnixTimeMilliseconds(), date.ToUnixTimeMicroseconds() / 1000);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(0.5)]
+        [InlineData(0.001)]
+        [InlineData(1500)]
+        public void ToMicroseconds(double milliseconds)
+        {
+            var expectedTimeSpan = TimeSpan.FromMilliseconds(milliseconds);
+            var microsecondsSpans = expectedTimeSpan.ToMicroseconds();
+            var actualTimeSpan = TimeSpan.FromMilliseconds(microsecondsSpans / 1000.0);
+            Assert.Equal(expectedTimeSpan, actualTimeSpan);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
+++ b/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.IO;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class ZipkinSerializerTests
+    {
+        [Fact]
+        public void RoundTripRootSpanTest()
+        {
+            var parentSpanContext = new Mock<ISpanContext>();
+            var traceContext = new Mock<ITraceContext>();
+            var spanContext = new SpanContext(parentSpanContext.Object, traceContext.Object, serviceName: null);
+
+            var span = new Span(spanContext, start: null);
+            span.ServiceName = "ServiceName";
+            span.SetTag("k0", "v0");
+            span.SetTag("k1", "v1");
+            span.SetTag("k2", "v2");
+
+            var tracerSettings = new TracerSettings();
+            var serializerSpan = new ZipkinSerializer.ZipkinSpan(span, tracerSettings);
+
+            var serializer = new ZipkinSerializer();
+            using var ms = new MemoryStream();
+
+            serializer.Serialize(ms, new[] { new[] { span } }, tracerSettings);
+
+            ms.Position = 0;
+            var jsonText = new StreamReader(ms).ReadToEnd();
+            var actualTraces = JsonConvert.DeserializeObject<List<TestZipkinSpan>>(jsonText);
+
+            Assert.Single(actualTraces);
+
+            var actualSpan = actualTraces[0];
+            actualSpan.AssertZipkinSerializerSpan(serializerSpan);
+        }
+
+        public class TestZipkinSpan
+        {
+            public string Id { get; set; }
+
+            public string TraceId { get; set; }
+
+            public string ParentId { get; set; }
+
+            public string Name { get; set; }
+
+            public long Timestamp { get; set; }
+
+            public long Duration { get; set; }
+
+            public string Kind { get; set; }
+
+            public Dictionary<string, string> LocalEndpoint { get; set; }
+
+            public IDictionary<string, string> Tags { get; set; }
+
+            internal void AssertZipkinSerializerSpan(ZipkinSerializer.ZipkinSpan span)
+            {
+                Assert.Equal(Id, span.Id);
+                Assert.Equal(TraceId, span.TraceId);
+                Assert.Equal(ParentId, span.ParentId);
+                Assert.Equal(Name, span.Name);
+                Assert.Equal(Timestamp, span.Timestamp);
+                Assert.Equal(Duration, span.Duration);
+                Assert.Equal(Kind, span.Kind);
+                Assert.Equal(LocalEndpoint.Count, span.LocalEndpoint.Count);
+                Assert.Contains(
+                    LocalEndpoint,
+                    kvp => span.LocalEndpoint.TryGetValue(kvp.Key, out var value) && kvp.Value == value);
+                Assert.Equal(Tags.Count, span.Tags.Count);
+                Assert.Contains(
+                    Tags,
+                    kvp => span.Tags.TryGetValue(kvp.Key, out var value) && kvp.Value == value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a simple Zipkin exporter as a non-default option to export traces. 

This is a very simple implementation that mirrors code already existent on the repo, eg.: `Api.cs`. The goal is to be able to have a somewhat standard destination that we can start to use to experiment with changes.

In order to use it you have to set the following env vars.:

- OTEL_EXPORTER: set it to `zipkin` the default is the DD agent (`DatadogAgent`).
- DD_AGENT_TRACE_URL: set it to the proper Zipkin endpoint including the path: eg.: `http://localhost:9411/api/v2/spans`

These sets above are enough to get traces to a Zipkin docker running locally, eg.: `docker run -it --rm -p 9411:9411 openzipkin/zipkin`
