### PR TITLE
Rename default OTel branch to main

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
       - refs/tags/*
 
 variables:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
   paths:
     exclude:
       - docs/*
@@ -9,7 +9,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
       - release/*
   paths:
     exclude:

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
       - refs/tags/*
 pr: none
 
@@ -253,11 +253,11 @@ stages:
       env:
         SECRET: $(AWS_SECRET_ACCESS_KEY)
 
-    # by default, run this step on master branch only.
+    # by default, run this step on main branch only.
     # use "push_artifacts_to_s3" to override:
     #   "true": run this step
     #   "false": do NOT run this step
-    #   else: run this stage if branch is master
+    #   else: run this stage if branch is main
 
     - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
       displayName: Upload deb, MSI, index.txt to s3
@@ -267,6 +267,6 @@ stages:
           ne(variables['push_artifacts_to_s3'], 'false'),
           or(
             eq(variables['push_artifacts_to_s3'], 'true'),
-            eq(variables['Build.SourceBranch'], 'refs/heads/master')
+            eq(variables['Build.SourceBranch'], 'refs/heads/main')
           )
         )

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 #####################################################
 #
 # Learn about membership in OpenTelemetry community:
-#  https://github.com/open-telemetry/community/blob/master/community-membership.md
+#  https://github.com/open-telemetry/community/blob/main/community-membership.md
 # 
 #
 # Learn about CODEOWNERS file format: 

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ Approvers ([@open-telemetry/dotnet-instrumentation-approvers](https://github.com
 - [Tony Redondo](https://github.com/tonyredondo), Datadog
 - [Zach Montoya](https://github.com/zacharycmontoya), Datadog
 
-Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md).
+Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,9 +4,9 @@
 # https://aka.ms/yaml
 
 trigger:
-- master
+- main
 pr:
-- master
+- main
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Contributor Code of Conduct
 
 This project follows the code of conduct used by the
-OpenTelemetry [community](https://github.com/open-telemetry/community/blob/master/code-of-conduct.md).
+OpenTelemetry [community](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,12 +25,12 @@ Join the meeting or get in touch on
 
 Even though, anybody can contribute, there are benefits of being a member of
 our community. See to the [community membership
-document](https://github.com/open-telemetry/community/blob/master/community-membership.md)
+document](https://github.com/open-telemetry/community/blob/main/community-membership.md)
 on how to become a
-[**Member**](https://github.com/open-telemetry/community/blob/master/community-membership.md#member),
-[**Approver**](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
+[**Member**](https://github.com/open-telemetry/community/blob/main/community-membership.md#member),
+[**Approver**](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
 and
-[**Maintainer**](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).
+[**Maintainer**](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
 
 ## Report a bug or requesting feature
 
@@ -45,9 +45,9 @@ Reporting bugs is an important contribution. Please make sure to include:
 ### Before you start
 
 Please read the
-[contribution guide](https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md)
+[contribution guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
 and the
-[code of conduct](https://github.com/open-telemetry/community/blob/master/code-of-conduct.md).
+[code of conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
 for general practices of the OpenTelemetry project.
 
 Select a good issue from the links below (ordered by difficulty/complexity):


### PR DESCRIPTION
Initial step to rename the default branch to main.

Part of #39
