### PR TITLE
WIP: Disable CI jobs that require Arm64 pool

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -502,6 +502,7 @@ jobs:
     condition: succeededOrFailed()
 
 - job: build_linux_profiler_arm64
+  condition: eq(0, 1) # Temporary workaround to disable this Job (OTel.NET Instr doesn't have an Arm64 pool)
   pool: Arm64
   workspace:
     clean: all
@@ -545,6 +546,7 @@ jobs:
     artifact: linux-tracer-home_arm
 
 - job: Linux_arm64
+  condition: eq(0, 1) # Temporary workaround to disable this Job (OTel.NET Instr doesn't have an Arm64 pool)
   pool: Arm64
   workspace:
     clean: all

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -100,6 +100,7 @@ jobs:
       DD_SERVICE_NAME: dd-tracer-dotnet
 
 - job: managed_linux_arm64
+  condition: eq(0, 1) # Temporary workaround to disable this Job (OTel.NET Instr doesn't have an Arm64 pool)
   pool: Arm64
   workspace:
     clean: all
@@ -277,6 +278,7 @@ jobs:
     displayName: build_profiler
 
 - job: linux_profiler_arm64
+  condition: eq(0, 1) # Temporary workaround to disable this Job (OTel.NET Instr doesn't have an Arm64 pool)
   pool: Arm64
   workspace:
     clean: all


### PR DESCRIPTION
Azure Pipelines CI is not running due to a pool that exists for upstream but not on this repo, trying to disable the jobs using this pool.
