### PR TITLE
Disable Datadog Agent in Azure Pipelines

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -33,9 +33,10 @@ stages:
     workspace:
       clean: all
 
-    # Enable the Datadog Agent service for this job
-    services:
-      # dd_agent: dd_agent # disable Datadog Agent as we do not have to test it in OpenTelemetry
+    # DO NOT enable Datadog Agent as we do not have to test it in OpenTelemetry
+    # # Enable the Datadog Agent service for this job
+    # services:
+    #   dd_agent: dd_agent
     variables:
       tracerHomeName: windows-tracer-home
       tracerHome: $(System.DefaultWorkingDirectory)/src/bin/$(tracerHomeName)

--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -35,7 +35,7 @@ stages:
 
     # Enable the Datadog Agent service for this job
     services:
-      dd_agent: dd_agent
+      # dd_agent: dd_agent # disable Datadog Agent as we do not have to test it in OpenTelemetry
     variables:
       tracerHomeName: windows-tracer-home
       tracerHome: $(System.DefaultWorkingDirectory)/src/bin/$(tracerHomeName)

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -83,9 +83,10 @@ jobs:
   pool:
     vmImage: windows-2019
 
-  # Enable the Datadog Agent service for this job
-  services:
-    # dd_agent: dd_agent # disable Datadog Agent as we do not have to test it in OpenTelemetry
+  # DO NOT enable Datadog Agent as we do not have to test it in OpenTelemetry
+  # # Enable the Datadog Agent service for this job
+  # services:
+  #   dd_agent: dd_agent
 
   steps:
   - download: current

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -85,7 +85,7 @@ jobs:
 
   # Enable the Datadog Agent service for this job
   services:
-    dd_agent: dd_agent
+    # dd_agent: dd_agent # disable Datadog Agent as we do not have to test it in OpenTelemetry
 
   steps:
   - download: current

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -39,9 +39,10 @@ jobs:
   pool:
     vmImage: $(imageName)
 
-  # Enable the Datadog Agent service for this job
-  services:
-    # dd_agent: dd_agent # disable Datadog Agent as we do not have to test it in OpenTelemetry
+  # DO NOT enable Datadog Agent as we do not have to test it in OpenTelemetry
+  # # Enable the Datadog Agent service for this job
+  # services:
+  #   dd_agent: dd_agent
 
   steps:
 

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
   # Enable the Datadog Agent service for this job
   services:
-    dd_agent: dd_agent
+    # dd_agent: dd_agent # disable Datadog Agent as we do not have to test it in OpenTelemetry
 
   steps:
 


### PR DESCRIPTION
## Why

Fixes #44
Done according to comments from https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/48.

## What

- Remove usage of Datadog Agent to make the CI passing.

## Other Findings

Thr unit tests should start passing when https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/52 is merged as well.

I believe only changes in `unit-test.yml` do something at the moment. The `benchmark.yml` and `runner.yml` are most probably not configured at all. Not sure if we should enable these pipelines as well.