### PR TITLE
Fix Datadog.Trace.Minimal.sln for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,8 +259,11 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
 # vscode
 .vscode/
+.devcontainer/
+
 # Benchmark results
 BenchmarkDotNet.Artifacts/
 
@@ -272,8 +275,6 @@ deploy/AzureAppServices/
 !build/artifacts
 
 # macOS temporal files
-*..DS_Store
-.DS_Store/*
 .DS_Store
 
 # profiler output files

--- a/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks></TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45</TargetFrameworks>
 
     <!-- NuGet -->

--- a/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45</TargetFrameworks>
 
     <!-- NuGet -->
     <Version>1.23.0</Version>

--- a/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <!-- NuGet -->
     <Version>1.18.4-prerelease</Version>
     <Title>Datadog APM</Title>

--- a/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
+++ b/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <!-- Microsoft.ServiceFabric.Services.Remoting only supports x64 -->

--- a/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Tool.csproj
+++ b/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Tool.csproj
@@ -5,7 +5,7 @@
     <Title>Datadog APM Auto-instrumentation Runner</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dd-trace</ToolCommandName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,8 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;$(TargetFrameworks)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- NuGet packages -->

--- a/src/OpenTelemetry.DynamicActivityBinding/OpenTelemetry.DynamicActivityBinding.csproj
+++ b/src/OpenTelemetry.DynamicActivityBinding/OpenTelemetry.DynamicActivityBinding.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
-    <TargetFrameworks>net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
  
   <PropertyGroup>

--- a/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc21/Samples.AspNetCoreMvc21.csproj
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc21/Samples.AspNetCoreMvc21.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Samples.AspNetCoreMvc</RootNamespace>
   </PropertyGroup>
 

--- a/test/test-applications/integrations/Samples.MultiDomainHost.Runner/Samples.MultiDomainHost.Runner.csproj
+++ b/test/test-applications/integrations/Samples.MultiDomainHost.Runner/Samples.MultiDomainHost.Runner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/Samples.DatabaseHelper.NetFramework20.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/Samples.DatabaseHelper.NetFramework20.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net20</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>

--- a/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpNoRedirects/Samples.MultiDomainHost.App.NuGetHttpNoRedirects.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpNoRedirects/Samples.MultiDomainHost.App.NuGetHttpNoRedirects.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>

--- a/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpWithRedirects/Samples.MultiDomainHost.App.NuGetHttpWithRedirects.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpWithRedirects/Samples.MultiDomainHost.App.NuGetHttpWithRedirects.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>

--- a/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetJsonWithRedirects/Samples.MultiDomainHost.App.NuGetJsonWithRedirects.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetJsonWithRedirects/Samples.MultiDomainHost.App.NuGetJsonWithRedirects.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>

--- a/test/test-applications/integrations/dependency-libs/Samples.WebRequestHelper.NetFramework20/Samples.WebRequestHelper.NetFramework20.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.WebRequestHelper.NetFramework20/Samples.WebRequestHelper.NetFramework20.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net20</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net20</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/test/test-applications/regression/AspNetMvcCorePerformance/AspNetMvcCorePerformance.csproj
+++ b/test/test-applications/regression/AspNetMvcCorePerformance/AspNetMvcCorePerformance.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>

--- a/test/test-applications/regression/OrleansCrash/OrleansCrash.csproj
+++ b/test/test-applications/regression/OrleansCrash/OrleansCrash.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
+++ b/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/test/test-applications/regression/dependency-libs/AppDomain.Instance/AppDomain.Instance.csproj
+++ b/test/test-applications/regression/dependency-libs/AppDomain.Instance/AppDomain.Instance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <IsPackable>false</IsPackable>

--- a/test/test-applications/regression/dependency-libs/ApplicationWithLog4Net/ApplicationWithLog4Net.csproj
+++ b/test/test-applications/regression/dependency-libs/ApplicationWithLog4Net/ApplicationWithLog4Net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <IsPackable>false</IsPackable>

--- a/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.Abstractions/Datadog.StackExchange.Redis.Abstractions.csproj
+++ b/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.Abstractions/Datadog.StackExchange.Redis.Abstractions.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Datadog.StackExchange.Redis.StrongName.csproj
+++ b/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Datadog.StackExchange.Redis.StrongName.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Datadog.StackExchange.Redis.csproj
+++ b/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Datadog.StackExchange.Redis.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

It is a good practice to be able to use VS Code for open-source projects. At least because this is the only free IDE that works on Linux and AFAIK the only tool that can be used to develop inside a container (https://code.visualstudio.com/docs/remote/containers).
Here is the reason why it currently does not work: https://github.com/OmniSharp/omnisharp-vscode/issues/1783

## What

Fixes the project files by removing .NET Framework targets from non-Windows systems.
Thanks to it, it is possible to use ` Datadog.Trace.Minimal.sln` for development in VS Code.

## Not covered

There would be more stuff to do to make `Datadog.Trace.sln`  with VS Code. At least change some `.csproj` files  from the old format to the new .NET Core `csproj` format. These changes would require more work and testing.
This might be helpful: https://www.hanselman.com/blog/upgrading-an-existing-net-project-files-to-the-lean-new-csproj-format-from-net-core