### PR TITLE
Fix tags and zipkin tags serialization

### DIFF
--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Agent
 
             private static IDictionary<string, string> BuildTags(Span span)
             {
-                var spanTags = span?.Tags?.GetAll();
+                var spanTags = span?.Tags?.GetAllTags();
                 if (spanTags == null || spanTags.Count == 0)
                 {
                     return EmptyTags;

--- a/src/Datadog.Trace/Agent/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/ZipkinSerializer.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
@@ -105,7 +104,7 @@ namespace Datadog.Trace.Agent
 
             private static IDictionary<string, string> BuildTags(Span span)
             {
-                var spanTags = span?.Tags?.Tags;
+                var spanTags = span?.Tags?.GetAll();
                 if (spanTags == null || spanTags.Count == 0)
                 {
                     return EmptyTags;

--- a/src/Datadog.Trace/Tagging/ITags.cs
+++ b/src/Datadog.Trace/Tagging/ITags.cs
@@ -6,7 +6,7 @@ namespace Datadog.Trace.Tagging
     {
         List<KeyValuePair<string, double>> Metrics { get; }
 
-        List<KeyValuePair<string, string>> Tags { get; }
+        List<KeyValuePair<string, string>> GetAll();
 
         string GetTag(string key);
 

--- a/src/Datadog.Trace/Tagging/ITags.cs
+++ b/src/Datadog.Trace/Tagging/ITags.cs
@@ -6,7 +6,7 @@ namespace Datadog.Trace.Tagging
     {
         List<KeyValuePair<string, double>> Metrics { get; }
 
-        List<KeyValuePair<string, string>> GetAll();
+        List<KeyValuePair<string, string>> GetAllTags();
 
         string GetTag(string key);
 

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -23,18 +23,24 @@ namespace Datadog.Trace.Tagging
 
             if (customTags != null)
             {
-                allTags.AddRange(customTags);
+                lock (customTags)
+                {
+                    allTags.AddRange(customTags);
+                }
             }
 
             if (additionalTags != null)
             {
-                foreach (var property in additionalTags)
+                lock (additionalTags)
                 {
-                    var value = property.Getter(this);
-
-                    if (value != null)
+                    foreach (var property in additionalTags)
                     {
-                        allTags.Add(new KeyValuePair<string, string>(property.Key, value));
+                        var value = property.Getter(this);
+
+                        if (value != null)
+                        {
+                            allTags.Add(new KeyValuePair<string, string>(property.Key, value));
+                        }
                     }
                 }
             }

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Tagging
 
         public List<KeyValuePair<string, double>> Metrics => Volatile.Read(ref _metrics);
 
-        public List<KeyValuePair<string, string>> GetAll()
+        public List<KeyValuePair<string, string>> GetAllTags()
         {
             var customTags = GetCustomTags();
             var additionalTags = GetAdditionalTags();
@@ -269,10 +269,7 @@ namespace Datadog.Trace.Tagging
 
         protected virtual IProperty<double?>[] GetAdditionalMetrics() => ArrayHelper.Empty<IProperty<double?>>();
 
-        private List<KeyValuePair<string, string>> GetCustomTags()
-        {
-            return Volatile.Read(ref _tags);
-        }
+        protected virtual IList<KeyValuePair<string, string>> GetCustomTags() => Volatile.Read(ref _tags);
 
         private int WriteTags(ref byte[] bytes, int offset)
         {

--- a/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.SetTag(Tags.Version, "v2.0");
             tags.SetTag("sample.2", "Temp 3");
 
-            var all = tags.GetAll();
+            var all = tags.GetAllTags();
             var distinctKeys = all.Select(x => x.Key).Distinct().Count();
 
             Assert.Equal(all.Count, distinctKeys);
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.SetTag("sample.1", values[3]);
             tags.SetTag("sample.2", values[4]);
 
-            ValidateTags(tags.GetAll(), values);
+            ValidateTags(tags.GetAllTags(), values);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tests.Tagging
             var tags = new EmptyTags();
             var values = ArrayHelper.Empty<string>();
 
-            ValidateTags(tags.GetAll(), values);
+            ValidateTags(tags.GetAllTags(), values);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -14,6 +14,32 @@ namespace Datadog.Trace.Tests.Tagging
     public class TagsListTests
     {
         [Fact]
+        public void SetTag_WillNotCauseDuplicates()
+        {
+            // Initialize common tags
+            var tags = new CommonTags()
+            {
+                Version = "v1.0",
+                Environment = "Test"
+            };
+
+            // Initialize custom tags
+            tags.SetTag("sample.1", "Temp 1");
+            tags.SetTag("sample.2", "Temp 2");
+
+            // Try set existing tag
+            tags.SetTag(Tags.Version, "v2.0");
+            tags.SetTag("sample.2", "Temp 3");
+
+            var all = tags.GetAll();
+            var distinctKeys = all.Select(x => x.Key).Distinct().Count();
+
+            Assert.Equal(all.Count, distinctKeys);
+            Assert.Single(all, x => x.Key == Tags.Version && x.Value == "v2.0");
+            Assert.Single(all, x => x.Key == "sample.2" && x.Value == "Temp 3");
+        }
+
+        [Fact]
         public void GetAll()
         {
             // Should be any actual implementation

--- a/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -43,18 +43,17 @@ namespace Datadog.Trace.Tests.Tagging
         public void GetAll()
         {
             // Should be any actual implementation
-            var tags = new HttpTags();
+            var tags = new CommonTags();
             var values = new[]
             {
-                "GET", "200", "Sample/Test", "value 1", "value 2"
+                "v1.0", "Test", "value 1", "value 2"
             };
 
-            tags.HttpMethod = values[0];
-            tags.HttpStatusCode = values[1];
-            tags.HttpUrl = values[2];
+            tags.Version = values[0];
+            tags.Environment = values[1];
 
-            tags.SetTag("sample.1", values[3]);
-            tags.SetTag("sample.2", values[4]);
+            tags.SetTag("sample.1", values[2]);
+            tags.SetTag("sample.2", values[3]);
 
             ValidateTags(tags.GetAllTags(), values);
         }

--- a/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
+++ b/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
@@ -17,11 +17,10 @@ namespace Datadog.Trace.Tests
             var traceContext = new Mock<ITraceContext>();
             var spanContext = new SpanContext(parentSpanContext.Object, traceContext.Object, serviceName: null);
 
-            var additionalTags = new HttpTags();
+            var additionalTags = new CommonTags();
 
-            additionalTags.HttpMethod = "GET";
-            additionalTags.HttpStatusCode = "200";
-            additionalTags.HttpUrl = "Sample/Test";
+            additionalTags.Version = "v1.0";
+            additionalTags.Environment = "Test";
 
             var span = new Span(spanContext, start: null, tags: additionalTags);
             span.ServiceName = "ServiceName";

--- a/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
+++ b/test/Datadog.Trace.Tests/ZipkinSerializerTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Datadog.Trace.Agent;
-using Datadog.Trace.Configuration;
+using Datadog.Trace.Tagging;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -17,7 +17,13 @@ namespace Datadog.Trace.Tests
             var traceContext = new Mock<ITraceContext>();
             var spanContext = new SpanContext(parentSpanContext.Object, traceContext.Object, serviceName: null);
 
-            var span = new Span(spanContext, start: null);
+            var additionalTags = new HttpTags();
+
+            additionalTags.HttpMethod = "GET";
+            additionalTags.HttpStatusCode = "200";
+            additionalTags.HttpUrl = "Sample/Test";
+
+            var span = new Span(spanContext, start: null, tags: additionalTags);
             span.ServiceName = "ServiceName";
             span.SetTag("k0", "v0");
             span.SetTag("k1", "v1");


### PR DESCRIPTION
### **Background**
The Tags getter was only referring to one set of custom set tags. Other tags coming from class 'TagsList' implementation state were missing. GetAdditional tags has protected access - so all AdditionalTags were missing on final serialization (except DD API).  

### **Solution**
Referring to CustomTags as manually set tags, left naming AdditionalTags. Builds up a new full set of tags when calling for GetAll method.
