### PR TITLE
Refactor after upstream catchup

### DIFF
--- a/src/Datadog.Trace/Abstractions/IMetrics.cs
+++ b/src/Datadog.Trace/Abstractions/IMetrics.cs
@@ -1,0 +1,14 @@
+namespace Datadog.Trace.Abstractions
+{
+    internal interface IMetrics
+    {
+        /// <summary>
+        /// Increments the specified counter.
+        /// </summary>
+        /// <param name="statName">The name of the metric.</param>
+        /// <param name="value">The amount of increment.</param>
+        /// <param name="sampleRate">Percentage of metric to be sent.</param>
+        /// <param name="tags">Array of tags to be added to the data.</param>
+        void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null);
+    }
+}

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Abstractions;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
-using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.Agent
 {
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Agent
         private static readonly ArraySegment<byte> EmptyPayload;
 
         private readonly ConcurrentQueue<WorkItem> _pendingTraces = new ConcurrentQueue<WorkItem>();
-        private readonly IDogStatsd _statsd;
+        private readonly IMetrics _metrics;
         private readonly Task _flushTask;
         private readonly Task _serializationTask;
         private readonly TaskCompletionSource<bool> _processExit = new TaskCompletionSource<bool>();
@@ -53,10 +53,10 @@ namespace Datadog.Trace.Agent
             EmptyPayload = new ArraySegment<byte>(data);
         }
 
-        public AgentWriter(IApi api, IDogStatsd statsd, bool automaticFlush = true, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100)
+        public AgentWriter(IApi api, IMetrics metrics, bool automaticFlush = true, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100)
         {
             _api = api;
-            _statsd = statsd;
+            _metrics = metrics;
             _batchInterval = batchInterval;
 
             var formatterResolver = SpanFormatterResolver.Instance;
@@ -104,11 +104,8 @@ namespace Datadog.Trace.Agent
                 }
             }
 
-            if (_statsd != null)
-            {
-                _statsd.Increment(TracerMetricNames.Queue.EnqueuedTraces);
-                _statsd.Increment(TracerMetricNames.Queue.EnqueuedSpans, trace.Length);
-            }
+            _metrics.Increment(TracerMetricNames.Queue.EnqueuedTraces);
+            _metrics.Increment(TracerMetricNames.Queue.EnqueuedSpans, trace.Length);
         }
 
         public async Task FlushAndCloseAsync()
@@ -256,11 +253,8 @@ namespace Datadog.Trace.Agent
 
             try
             {
-                if (_statsd != null)
-                {
-                    _statsd.Increment(TracerMetricNames.Queue.DequeuedTraces, buffer.TraceCount);
-                    _statsd.Increment(TracerMetricNames.Queue.DequeuedSpans, buffer.SpanCount);
-                }
+                _metrics.Increment(TracerMetricNames.Queue.DequeuedTraces, buffer.TraceCount);
+                _metrics.Increment(TracerMetricNames.Queue.DequeuedSpans, buffer.SpanCount);
 
                 if (buffer.TraceCount > 0)
                 {
@@ -331,11 +325,8 @@ namespace Datadog.Trace.Agent
             // All the buffers are full :( drop the trace
             Log.Warning("Trace buffer is full. Dropping a trace.");
 
-            if (_statsd != null)
-            {
-                _statsd.Increment(TracerMetricNames.Queue.DroppedTraces);
-                _statsd.Increment(TracerMetricNames.Queue.DroppedSpans, trace.Length);
-            }
+            _metrics.Increment(TracerMetricNames.Queue.DroppedTraces);
+            _metrics.Increment(TracerMetricNames.Queue.DroppedSpans, trace.Length);
         }
 
         private void SerializeTracesLoop()

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -10,7 +10,7 @@ using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.Agent
 {
-    internal class AgentWriter : IAgentWriter
+    internal class AgentWriter : ITraceWriter
     {
 #if NET45
         private const TaskCreationOptions TaskOptions = TaskCreationOptions.None;

--- a/src/Datadog.Trace/Agent/DogStatsdMetrics.cs
+++ b/src/Datadog.Trace/Agent/DogStatsdMetrics.cs
@@ -1,0 +1,20 @@
+using Datadog.Trace.Abstractions;
+using Datadog.Trace.Vendors.StatsdClient;
+
+namespace Datadog.Trace.Agent
+{
+    internal class DogStatsdMetrics : IMetrics
+    {
+        private readonly IDogStatsd _dogStatsd;
+
+        public DogStatsdMetrics(IDogStatsd dogStatsd)
+        {
+            _dogStatsd = dogStatsd;
+        }
+
+        public void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null)
+        {
+            _dogStatsd.Increment(statName, value, sampleRate, tags);
+        }
+    }
+}

--- a/src/Datadog.Trace/Agent/ExporterWriter.cs
+++ b/src/Datadog.Trace/Agent/ExporterWriter.cs
@@ -8,7 +8,7 @@ using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.Agent
 {
-    internal class ExporterWriter : IAgentWriter
+    internal class ExporterWriter : ITraceWriter
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ExporterWriter>();
 

--- a/src/Datadog.Trace/Agent/ExporterWriterBuffer.cs
+++ b/src/Datadog.Trace/Agent/ExporterWriterBuffer.cs
@@ -20,14 +20,19 @@ namespace Datadog.Trace.Agent
         {
             lock (_items)
             {
-                if (_count >= _items.Length)
+                if (_count < _items.Length)
                 {
-                    // drop the trace as the buffer is full
+                    _items[_count++] = item;
+                    return true;
+                }
+                else
+                {
+                    // drop a random trace.
+                    // note that Random.Next() is NOT thread-safe,
+                    // but we are running this inside a lock
+                    _items[_random.Next(_items.Length)] = item;
                     return false;
                 }
-
-                _items[_count++] = item;
-                return true;
             }
         }
 

--- a/src/Datadog.Trace/Agent/ExporterWriterBuffer.cs
+++ b/src/Datadog.Trace/Agent/ExporterWriterBuffer.cs
@@ -20,19 +20,14 @@ namespace Datadog.Trace.Agent
         {
             lock (_items)
             {
-                if (_count < _items.Length)
+                if (_count >= _items.Length)
                 {
-                    _items[_count++] = item;
-                    return true;
-                }
-                else
-                {
-                    // drop a random trace.
-                    // note that Random.Next() is NOT thread-safe,
-                    // but we are running this inside a lock
-                    _items[_random.Next(_items.Length)] = item;
+                    // drop the trace as the buffer is full
                     return false;
                 }
+
+                _items[_count++] = item;
+                return true;
             }
         }
 

--- a/src/Datadog.Trace/Agent/ITraceWriter.cs
+++ b/src/Datadog.Trace/Agent/ITraceWriter.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
-    internal interface IAgentWriter
+    internal interface ITraceWriter
     {
         void WriteTrace(Span[] trace);
 

--- a/src/Datadog.Trace/Agent/NullMetrics.cs
+++ b/src/Datadog.Trace/Agent/NullMetrics.cs
@@ -1,0 +1,11 @@
+using Datadog.Trace.Abstractions;
+
+namespace Datadog.Trace.Agent
+{
+    internal class NullMetrics : IMetrics
+    {
+        public void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null)
+        {
+        }
+    }
+}

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace
         private readonly IScopeManager _scopeManager;
         private readonly Timer _heartbeatTimer;
 
-        private readonly IAgentWriter _agentWriter;
+        private readonly ITraceWriter _agentWriter;
 
         static Tracer()
         {
@@ -77,7 +77,7 @@ namespace Datadog.Trace
         {
         }
 
-        internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd)
+        internal Tracer(TracerSettings settings, ITraceWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd)
         {
             // update the count of Tracer instances
             Interlocked.Increment(ref _liveTracerCount);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/OtelScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/OtelScopeFactoryTests.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             var settings = new TracerSettings();
             settings.Convention = ConventionType.OpenTelemetry;
-            var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ISampler>(), scopeManager: null, statsd: null);
+            var tracer = new Tracer(settings, Mock.Of<ITraceWriter>(), Mock.Of<ISampler>(), scopeManager: null, statsd: null);
 
             using (var scope = ScopeFactory.CreateOutboundHttpScope(tracer, input.Method, new Uri(input.Uri), new IntegrationInfo((int)IntegrationIds.HttpMessageHandler), out var tags))
             {

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // Set up Tracer
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // Set up Tracer
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
@@ -111,7 +111,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // Set up Tracer
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.IntegrationTests
             var endpoint = new Uri("http://localhost:8126");
             _httpRecorder = new RecordHttpHandler();
             var api = new Api(endpoint, apiRequestFactory: null, statsd: null);
-            var agentWriter = new AgentWriter(api, statsd: null);
+            var agentWriter = new AgentWriter(api, new NullMetrics());
 
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.IntegrationTests
         {
             var agentUri = new System.Uri("http://localhost:9411/api/v2/spans");
             var exporter = new ZipkinExporter(agentUri);
-            var exporterWriter = new ExporterWriter(exporter, statsd: null);
+            var exporterWriter = new ExporterWriter(exporter, new NullMetrics());
             _tracer = new Tracer(new TracerSettings(), exporterWriter, sampler: null, scopeManager: null, statsd: null);
         }
 

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
             var endpoint = new Uri("http://localhost:8126");
             _httpRecorder = new RecordHttpHandler();
             var api = new Api(endpoint, apiRequestFactory: null, statsd: null);
-            var agentWriter = new AgentWriter(api, statsd: null);
+            var agentWriter = new AgentWriter(api, new NullMetrics());
 
             var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
             _tracer = new OpenTracingTracer(tracer);

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.OpenTracing.Tests
                 ServiceName = DefaultServiceName
             };
 
-            var writerMock = new Mock<IAgentWriter>(MockBehavior.Strict);
+            var writerMock = new Mock<ITraceWriter>(MockBehavior.Strict);
             var samplerMock = new Mock<ISampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         public OpenTracingSpanTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         public OpenTracingTracerTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task FlushTwice()
         {
-            var w = new AgentWriter(_api.Object, metrics: null);
+            var w = new AgentWriter(_api.Object, new NullMetrics());
             await w.FlushAndCloseAsync();
             await w.FlushAndCloseAsync();
         }
@@ -63,7 +63,7 @@ namespace Datadog.Trace.Tests
             // The flush thread should be able to recover from an error when calling the API
             // Also, it should free the faulty buffer
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, metrics: null);
+            var agent = new AgentWriter(api.Object, new NullMetrics());
 
             var mutex = new ManualResetEventSlim();
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Tests
         {
             // Make sure that the agent is able to switch to the secondary buffer when the primary is full/busy
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, metrics: null);
+            var agent = new AgentWriter(api.Object, new NullMetrics());
 
             var barrier = new Barrier(2);
 
@@ -151,7 +151,7 @@ namespace Datadog.Trace.Tests
             var sizeOfTrace = ComputeSizeOfTrace(CreateTrace(1));
 
             // Make the buffer size big enough for a single trace
-            var agent = new AgentWriter(api.Object, metrics: null, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
+            var agent = new AgentWriter(api.Object, new NullMetrics(), automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
             agent.WriteTrace(CreateTrace(1));
             agent.WriteTrace(CreateTrace(1));
@@ -227,7 +227,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public Task WakeUpSerializationTask()
         {
-            var agent = new AgentWriter(Mock.Of<IApi>(), metrics: null, batchInterval: 0);
+            var agent = new AgentWriter(Mock.Of<IApi>(), new NullMetrics(), batchInterval: 0);
 
             // To reduce flackyness, first we make sure the serialization thread is started
             WaitForDequeue(agent);

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Tests
         public ApiTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
         private static Tracer GetTracer()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/ExporterWriterBufferTests.cs
+++ b/test/Datadog.Trace.Tests/ExporterWriterBufferTests.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Tests
 
             Assert.False(buffer.Push(101));
 
-            // Check NONE element of the buffer was replaced
+            // Check that one random element of the queue was replaced
             var vals = buffer.Pop();
             var replaced = 0;
             for (int i = 0; i < 100; i++)
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests
                 }
             }
 
-            Assert.Equal(0, replaced);
+            Assert.Equal(1, replaced);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/ExporterWriterBufferTests.cs
+++ b/test/Datadog.Trace.Tests/ExporterWriterBufferTests.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Tests
 
             Assert.False(buffer.Push(101));
 
-            // Check that one random element of the queue was replaced
+            // Check NONE element of the buffer was replaced
             var vals = buffer.Pop();
             var replaced = 0;
             for (int i = 0; i < 100; i++)
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests
                 }
             }
 
-            Assert.Equal(1, replaced);
+            Assert.Equal(0, replaced);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/ExporterWriterTests.cs
+++ b/test/Datadog.Trace.Tests/ExporterWriterTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Tests
             tracer.Setup(x => x.DefaultServiceName).Returns("Default");
 
             _exporter = new Mock<IExporter>();
-            _exporterWriter = new ExporterWriter(_exporter.Object, statsd: null);
+            _exporterWriter = new ExporterWriter(_exporter.Object, new NullMetrics());
 
             var parentSpanContext = new Mock<ISpanContext>();
             var traceContext = new Mock<ITraceContext>();
@@ -44,7 +44,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task FlushTwice()
         {
-            var w = new ExporterWriter(_exporter.Object, statsd: null);
+            var w = new ExporterWriter(_exporter.Object, new NullMetrics());
             await w.FlushAndCloseAsync();
             await w.FlushAndCloseAsync();
         }

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Tests.Logging
         internal static Tracer InitializeTracer(bool enableLogsInjection)
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             settings.LogsInjectionEnabled = enableLogsInjection;

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Tests
     public class SpanTests
     {
         private readonly ITestOutputHelper _output;
-        private readonly Mock<IAgentWriter> _writerMock;
+        private readonly Mock<ITraceWriter> _writerMock;
         private readonly Tracer _tracer;
 
         public SpanTests(ITestOutputHelper output)
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Tests
             _output = output;
 
             var settings = new TracerSettings();
-            _writerMock = new Mock<IAgentWriter>();
+            _writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -12,12 +12,12 @@ namespace Datadog.Trace.Tests
 {
     public class TracerSettingsTests
     {
-        private readonly Mock<IAgentWriter> _writerMock;
+        private readonly Mock<ITraceWriter> _writerMock;
         private readonly Mock<ISampler> _samplerMock;
 
         public TracerSettingsTests()
         {
-            _writerMock = new Mock<IAgentWriter>();
+            _writerMock = new Mock<ITraceWriter>();
             _samplerMock = new Mock<ISampler>();
         }
 

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests
         public TracerTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -16,7 +16,7 @@ namespace Benchmarks.Trace
     {
         private const int SpanCount = 1000;
 
-        private static readonly IAgentWriter AgentWriter;
+        private static readonly ITraceWriter AgentWriter;
         private static readonly Span[] Spans;
         private static readonly Span[] EnrichedSpans;
 

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -29,7 +29,7 @@ namespace Benchmarks.Trace
 
             var api = new Api(settings.AgentUri, new FakeApiRequestFactory(), statsd: null);
 
-            AgentWriter = new AgentWriter(api, statsd: null, automaticFlush: false);
+            AgentWriter = new AgentWriter(api, new NullMetrics(), automaticFlush: false);
 
             Spans = new Span[SpanCount];
             EnrichedSpans = new Span[SpanCount];

--- a/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
+++ b/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
@@ -5,7 +5,7 @@ using Datadog.Trace.Agent;
 
 namespace Benchmarks.Trace
 {
-    class DummyAgentWriter : IAgentWriter
+    class DummyAgentWriter : ITraceWriter
     {
         private static readonly Task<bool> PingTask = Task.FromResult(true);
 


### PR DESCRIPTION
## Why

A few refactorings that I propose after reviewing https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/70/commits/2669bb542b066258865346ba31f6a045de70928f

## What

1. Rename `IAgentWriter` to `ITraceWriter`.

I think this name is better. And the fact that there is no `TraceWritter` class shows that it a real abstraction (not something artificial just to have test doubles in unit tests).

2. Introduce `IMetrics`.

Thanks to it the `ITraceWriter` implementations do not need to have `if (_statsd != null)`.
It is also a little step to decouple the code from `DogStatsd`.
