### PR TITLE
Use FluentAssertions

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/OtelScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/OtelScopeFactoryTests.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Text;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                     HttpUrlTag = span.GetTag("http.url"),
                 };
 
-                Assert.Equal(expected, actual);
+                actual.Should().BeEquivalentTo(expected);
             }
         }
 
@@ -43,18 +43,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             public string OperationName;
             public string HttpMethodTag;
             public string HttpUrlTag;
-
-            public override string ToString()
-            {
-                var sb = new StringBuilder();
-                sb.Append(Environment.NewLine);
-                foreach (var field in GetType().GetFields())
-                {
-                    sb.Append($"{field.Name}: {field.GetValue(this)}{Environment.NewLine}");
-                }
-
-                return sb.ToString();
-            }
         }
 
         public class TestData : TheoryData<Input, Result>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
## Why

Per:
- https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/63#discussion_r586833118
- https://cloud-native.slack.com/archives/C01NR1YLSE7/p1614798483036900

## What

Introduce https://fluentassertions.com/ to make the assertions simpler and assertion failure messages clearer.
Example output from a failed test:

```
[xUnit.net 00:00:00.86]     Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests.OutboundHttp(input: Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests+Input, expected: Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests+Result) [FAIL]
  Failed Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests.OutboundHttp(input: Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests+Input, expected: Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests+Result) [220 ms]
  Error Message:
   Expected actual to be 

Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests+Result
{
   HttpMethodTag = "GET"
   HttpUrlTag = "https://example.com:8080/path/to/file.aspx?query=1#fragment"
   OperationName = "HTTP GET"
}, but found 

Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests+Result
{
   HttpMethodTag = "GET"
   HttpUrlTag = "asdasdasdhttps://example.com:8080/path/to/file.aspx?query=1#fragment"
   OperationName = "HTTP GET"
}.

With configuration:
- Use declared types and members
- Compare enums by value
- Match member by name (or throw)
- Without automatic conversion.
- Be strict about the order of items in byte arrays

  Stack Trace:
     at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
   at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
   at FluentAssertions.Execution.CollectingAssertionStrategy.ThrowIfAny(IDictionary`2 context)
   at FluentAssertions.Equivalency.EquivalencyValidator.AssertEquality(EquivalencyValidationContext context)
   at FluentAssertions.Primitives.ObjectAssertions.BeEquivalentTo[TExpectation](TExpectation expectation, Func`2 config, String because, Object[] becauseArgs)
   at FluentAssertions.Primitives.ObjectAssertions.BeEquivalentTo[TExpectation](TExpectation expectation, String because, Object[] becauseArgs)
   at Datadog.Trace.ClrProfiler.Managed.Tests.OtelScopeFactoryTests.OutboundHttp(Input input, Result expected) in /workspaces/opentelemetry-dotnet-instrumentation/test/Datadog.Trace.ClrProfiler.Managed.Tests/OtelScopeFactoryTests.cs:line 31
```

with just a single line:
```
actual.Should().BeEquivalentTo(expected);
```

Before we had to override the `ToString()` to have the output more readable. FluentAssertions does it for us.
And it is a popular library https://www.nuget.org/packages/FluentAssertions/5.10.3 has 16 222 276 downloads in the moment when this PR is submitted.

