### PR TITLE
Fix Datadog.Trace.ClrProfiler.Native.sh

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -71,7 +71,7 @@ jobs:
     displayName: docker-compose run Profiler
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler
+      dockerComposeCommand: run -e buildConfiguration=$(buildConfiguration) Profiler 
 
   - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
     artifact: linux-tracer-home
@@ -171,7 +171,7 @@ jobs:
     displayName: docker-compose run Profiler.Alpine
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler.Alpine
+      dockerComposeCommand: run -e buildConfiguration=$(buildConfiguration) Profiler.Alpine
 
   - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
     artifact: alpine-linux-tracer-home

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
+
 mkdir -p /var/log/datadog/dotnet
 touch /var/log/datadog/dotnet/dotnet-tracer-native.log
 

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -3,8 +3,11 @@ set -euxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
+
 mkdir -p /var/log/opentelemetry/dotnet
-touch /var/log/opentelemetry/dotnet/dotnet-tracer-native.log
+touch /var/log/opentelemetry/dotnet/dotnet-tracer-native.logog
 
 dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
 

--- a/build/docker/Datadog.Trace.ClrProfiler.Native.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.Native.sh
@@ -10,13 +10,13 @@ PUBLISH_OUTPUT_NET31="$( pwd )/src/bin/managed-publish/netcoreapp3.1"
 
 cd src/Datadog.Trace.ClrProfiler.Native
 mkdir -p build
-(cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release && make)
+(cd build && cmake ../ -DCMAKE_BUILD_TYPE=${buildConfiguration:-Debug}  && make)
 
-mkdir -p bin/Release/x64
-cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/Release/x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so
+mkdir -p bin/${buildConfiguration:-Debug}/x64
+cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/${buildConfiguration:-Debug}/x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so
 
-mkdir -p bin/Release/x64/netstandard2.0
-cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/Release/x64/netstandard2.0/
+mkdir -p bin/${buildConfiguration:-Debug}/x64/netstandard2.0
+cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/${buildConfiguration:-Debug}/x64/netstandard2.0/
 
-mkdir -p bin/Release/x64/netcoreapp3.1
-cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/Release/x64/netcoreapp3.1/
+mkdir -p bin/${buildConfiguration:-Debug}/x64/netcoreapp3.1
+cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/${buildConfiguration:-Debug}/x64/netcoreapp3.1/

--- a/build/docker/Datadog.Trace.ClrProfiler.Native.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.Native.sh
@@ -7,16 +7,17 @@ cd "$DIR/../.."
 
 PUBLISH_OUTPUT_NET2="$( pwd )/src/bin/managed-publish/netstandard2.0"
 PUBLISH_OUTPUT_NET31="$( pwd )/src/bin/managed-publish/netcoreapp3.1"
+BUILD_TYPE=${buildConfiguration:-Debug}
 
 cd src/Datadog.Trace.ClrProfiler.Native
 mkdir -p build
-(cd build && cmake ../ -DCMAKE_BUILD_TYPE=${buildConfiguration:-Debug}  && make)
+(cd build && cmake ../ -DCMAKE_BUILD_TYPE=${BUILD_TYPE}  && make)
 
-mkdir -p bin/${buildConfiguration:-Debug}/x64
-cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/${buildConfiguration:-Debug}/x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so
+mkdir -p bin/${BUILD_TYPE}/x64
+cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/${BUILD_TYPE}/x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so
 
-mkdir -p bin/${buildConfiguration:-Debug}/x64/netstandard2.0
-cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/${buildConfiguration:-Debug}/x64/netstandard2.0/
+mkdir -p bin/${BUILD_TYPE}/x64/netstandard2.0
+cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/${BUILD_TYPE}/x64/netstandard2.0/
 
-mkdir -p bin/${buildConfiguration:-Debug}/x64/netcoreapp3.1
-cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/${buildConfiguration:-Debug}/x64/netcoreapp3.1/
+mkdir -p bin/${BUILD_TYPE}/x64/netcoreapp3.1
+cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/${BUILD_TYPE}/x64/netcoreapp3.1/

--- a/build/docker/build.arm64.sh
+++ b/build/docker/build.arm64.sh
@@ -5,7 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 cd "$DIR/../.."
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
 PUBLISH_OUTPUT="$( pwd )/src/bin/managed-publish"
+
 mkdir -p "$PUBLISH_OUTPUT/netstandard2.0"
 mkdir -p "$PUBLISH_OUTPUT/netcoreapp3.1"
 

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -5,7 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 cd "$DIR/../.."
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
 PUBLISH_OUTPUT="$( pwd )/src/bin/managed-publish"
+
 mkdir -p "$PUBLISH_OUTPUT/netstandard2.0"
 mkdir -p "$PUBLISH_OUTPUT/netcoreapp3.1"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,8 @@ services:
       context: ./
       dockerfile: ./build/docker/native.alpine.dockerfile
     image: datadog-native-alpine
+    environment: 
+    - buildConfiguration=${buildConfiguration}
     command: /project/build/docker/Datadog.Trace.ClrProfiler.Native.sh
     volumes:
     - ./:/project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,8 @@ services:
       context: ./
       dockerfile: ./build/docker/native.dockerfile
     image: datadog-native
+    environment: 
+    - buildConfiguration=${buildConfiguration}
     command: /project/build/docker/Datadog.Trace.ClrProfiler.Native.sh
     volumes:
     - ./:/project


### PR DESCRIPTION
## Why

The docker-compose.yml and scripts where probably only tested in Azure Pieplines.
I think it was not tested locally.
`docker-compose run --rm build && docker-compose run --rm Profiler && docker-compose run --rm IntegrationTests` was not working properly.

## What

Use `$buildConfiguration` in `Datadog.Trace.ClrProfiler.Native.sh` and `docker-compose.yml`.