### PR TITLE
Do not replace a random trace if buffer is full

### DIFF
--- a/src/Datadog.Trace/Agent/ExporterWriterBuffer.cs
+++ b/src/Datadog.Trace/Agent/ExporterWriterBuffer.cs
@@ -20,19 +20,14 @@ namespace Datadog.Trace.Agent
         {
             lock (_items)
             {
-                if (_count < _items.Length)
+                if (_count >= _items.Length)
                 {
-                    _items[_count++] = item;
-                    return true;
-                }
-                else
-                {
-                    // drop a random trace.
-                    // note that Random.Next() is NOT thread-safe,
-                    // but we are running this inside a lock
-                    _items[_random.Next(_items.Length)] = item;
+                    // drop the trace as the buffer is full
                     return false;
                 }
+
+                _items[_count++] = item;
+                return true;
             }
         }
 

--- a/test/Datadog.Trace.Tests/ExporterWriterBufferTests.cs
+++ b/test/Datadog.Trace.Tests/ExporterWriterBufferTests.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Tests
 
             Assert.False(buffer.Push(101));
 
-            // Check that one random element of the queue was replaced
+            // Check NONE element of the buffer was replaced
             var vals = buffer.Pop();
             var replaced = 0;
             for (int i = 0; i < 100; i++)
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests
                 }
             }
 
-            Assert.Equal(1, replaced);
+            Assert.Equal(0, replaced);
         }
     }
 }


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/74#discussion_r590659538

## What

 `ExporterWriter` does NOT replace any trace if the buffer is full.

AFAIK this is how `AgentWriter` works and IMO it makes more sense. If the system cannot send traces then it may mean that something is going on strange and better not to lose the traces when something strange is happening. Traces from suspicious moments is more important than most recent stuff.