### PR TITLE
Add support for OTel Status

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/GraphQL/GraphQLCommon.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/GraphQL/GraphQLCommon.cs
@@ -98,9 +98,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
 
             if (errorCount > 0)
             {
-                span.Error = true;
-
-                span.SetTag(Trace.Tags.ErrorMsg, $"{errorCount} error(s)");
+                var message = $"{errorCount} error(s)";
+                span.Status = SpanStatus.Error.WithDescription(message);
+                span.SetTag(Trace.Tags.ErrorMsg, message);
                 span.SetTag(Trace.Tags.ErrorType, errorType);
                 span.SetTag(Trace.Tags.ErrorStack, ConstructErrorMessage(executionErrors));
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -132,7 +132,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                             case UnitTestResultOutcome.NotFound:
                             case UnitTestResultOutcome.Timeout:
                                 scope.Span.SetTag(TestTags.Status, TestTags.StatusFail);
-                                scope.Span.Error = true;
+                                scope.Span.Status = SpanStatus.Error.WithDescription(unitTestResult.ErrorMessage);
                                 scope.Span.SetTag(Tags.ErrorMsg, unitTestResult.ErrorMessage);
                                 scope.Span.SetTag(Tags.ErrorStack, unitTestResult.ErrorStackTrace);
                                 break;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -307,9 +307,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             if (errorCount > 0)
             {
-                span.Error = true;
-
-                span.SetTag(Trace.Tags.ErrorMsg, $"{errorCount} error(s)");
+                var message = $"{errorCount} error(s)";
+                span.Status = SpanStatus.Error.WithDescription(message);
+                span.SetTag(Trace.Tags.ErrorMsg, message);
                 span.SetTag(Trace.Tags.ErrorType, errorType);
                 span.SetTag(Trace.Tags.ErrorStack, ConstructErrorMessage(executionErrors));
             }

--- a/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -133,7 +133,7 @@ namespace Datadog.Trace.MSBuild
                 _buildSpan.SetTag(BuildTags.BuildStatus, e.Succeeded ? BuildTags.BuildSucceededStatus : BuildTags.BuildFailedStatus);
                 if (!e.Succeeded)
                 {
-                    _buildSpan.Error = true;
+                    _buildSpan.Status = SpanStatus.Error;
                 }
 
                 _buildSpan.SetTag(BuildTags.BuildEndMessage, e.Message);
@@ -202,7 +202,7 @@ namespace Datadog.Trace.MSBuild
                     projectSpan.SetTag(BuildTags.BuildStatus, e.Succeeded ? BuildTags.BuildSucceededStatus : BuildTags.BuildFailedStatus);
                     if (!e.Succeeded)
                     {
-                        projectSpan.Error = true;
+                        projectSpan.Status = SpanStatus.Error;
                     }
 
                     projectSpan.SetTag(BuildTags.BuildEndMessage, e.Message);
@@ -242,7 +242,7 @@ namespace Datadog.Trace.MSBuild
                     string stack = null;
                     string subCategory = e.Subcategory;
 
-                    projectSpan.Error = true;
+                    projectSpan.Status = SpanStatus.Error.WithDescription(message);
                     projectSpan.SetTag(BuildTags.ErrorMessage, message);
                     projectSpan.SetTag(BuildTags.ErrorType, type);
                     projectSpan.SetTag(BuildTags.ErrorCode, code);

--- a/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.OpenTracing
 
             if (key == global::OpenTracing.Tag.Tags.Error.Key)
             {
-                Span.Error = value == bool.TrueString;
+                Span.Status = value == bool.TrueString ? SpanStatus.Error : SpanStatus.Ok;
                 return this;
             }
 

--- a/src/Datadog.Trace/Abstractions/ISpan.cs
+++ b/src/Datadog.Trace/Abstractions/ISpan.cs
@@ -13,11 +13,6 @@ namespace Datadog.Trace.Abstractions
         /// </summary>
         SpanStatus Status { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether this span represents an error.
-        /// </summary>
-        bool Error { get; set; }
-
         ISpan SetTag(string key, string value);
 
         string GetTag(string key);

--- a/src/Datadog.Trace/Abstractions/ISpan.cs
+++ b/src/Datadog.Trace/Abstractions/ISpan.cs
@@ -9,6 +9,11 @@ namespace Datadog.Trace.Abstractions
         string Type { get; set; }
 
         /// <summary>
+        /// Gets or sets the span's execution status
+        /// </summary>
+        SpanStatus Status { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this span represents an error.
         /// </summary>
         bool Error { get; set; }

--- a/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 len++;
             }
 
-            if (value.Error)
+            if (value.Status.StatusCode == StatusCode.Error)
             {
                 len++;
             }
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, (ulong)value.Context.ParentId);
             }
 
-            if (value.Error)
+            if (value.Status.StatusCode == StatusCode.Error)
             {
                 offset += MessagePackBinary.WriteString(ref bytes, offset, "error");
                 offset += MessagePackBinary.WriteByte(ref bytes, offset, 1);

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -344,7 +344,7 @@ namespace Datadog.Trace.DiagnosticListeners
             if (scope != null)
             {
                 // if we had an unhandled exception, the status code is already updated
-                if (!scope.Span.Error && arg.TryDuckCast<HttpRequestInStopStruct>(out var httpRequest))
+                if (scope.Span.Status.StatusCode != StatusCode.Error && arg.TryDuckCast<HttpRequestInStopStruct>(out var httpRequest))
                 {
                     HttpContext httpContext = httpRequest.HttpContext;
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -83,12 +83,16 @@ namespace Datadog.Trace.ExtensionMethods
             // Check the customers http statuses that should be marked as errors
             if (Tracer.Instance.Settings.IsErrorStatusCode(statusCode, isServer))
             {
-                span.Error = true;
-
                 // if an error message already exists (e.g. from a previous exception), don't replace it
                 if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorMsg)))
                 {
-                    span.SetTag(Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");
+                    var message = $"The HTTP response has status code {statusCodeString}.";
+                    span.Status = SpanStatus.Error.WithDescription(message);
+                    span.SetTag(Tags.ErrorMsg, message);
+                }
+                else
+                {
+                    span.Status = SpanStatus.Error;
                 }
             }
         }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -64,6 +64,11 @@ namespace Datadog.Trace
         public bool Error { get; set; }
 
         /// <summary>
+        /// Gets or sets the span's execution status
+        /// </summary>
+        public SpanStatus Status { get; set; }
+
+        /// <summary>
         /// Gets or sets the service name.
         /// </summary>
         public string ServiceName
@@ -112,6 +117,7 @@ namespace Datadog.Trace
             sb.AppendLine($"Type: {Type}");
             sb.AppendLine($"Start: {StartTime}");
             sb.AppendLine($"Duration: {Duration}");
+            sb.AppendLine($"Status: {Status}");
             sb.AppendLine($"Error: {Error}");
             sb.AppendLine($"Meta: {Tags}");
 

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -59,11 +59,6 @@ namespace Datadog.Trace
         public string Type { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this span represents an error
-        /// </summary>
-        public bool Error { get; set; }
-
-        /// <summary>
         /// Gets or sets the span's execution status
         /// </summary>
         public SpanStatus Status { get; set; }
@@ -118,7 +113,6 @@ namespace Datadog.Trace
             sb.AppendLine($"Start: {StartTime}");
             sb.AppendLine($"Duration: {Duration}");
             sb.AppendLine($"Status: {Status}");
-            sb.AppendLine($"Error: {Error}");
             sb.AppendLine($"Meta: {Tags}");
 
             return sb.ToString();
@@ -284,8 +278,6 @@ namespace Datadog.Trace
         /// <param name="exception">The exception.</param>
         public void SetException(Exception exception)
         {
-            Error = true;
-
             if (exception != null)
             {
                 // for AggregateException, use the first inner exception until we can support multiple errors.
@@ -296,9 +288,14 @@ namespace Datadog.Trace
                     exception = aggregateException.InnerExceptions[0];
                 }
 
+                Status = SpanStatus.Error.WithDescription(exception.Message);
                 SetTag(Trace.Tags.ErrorMsg, exception.Message);
                 SetTag(Trace.Tags.ErrorStack, exception.ToString());
                 SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
+            }
+            else
+            {
+                Status = SpanStatus.Error;
             }
         }
 

--- a/src/Datadog.Trace/SpanStatus.cs
+++ b/src/Datadog.Trace/SpanStatus.cs
@@ -1,0 +1,119 @@
+namespace Datadog.Trace
+{
+    /// <summary>
+    /// Span execution status.
+    /// </summary>
+    public readonly struct SpanStatus : System.IEquatable<SpanStatus>
+    {
+        /// <summary>
+        /// The operation completed successfully.
+        /// </summary>
+        public static readonly SpanStatus Ok = new SpanStatus(StatusCode.Ok);
+
+        /// <summary>
+        /// The default status.
+        /// </summary>
+        public static readonly SpanStatus Unset = new SpanStatus(StatusCode.Unset);
+
+        /// <summary>
+        /// The operation contains an error.
+        /// </summary>
+        public static readonly SpanStatus Error = new SpanStatus(StatusCode.Error);
+
+        internal SpanStatus(StatusCode statusCode, string description = null)
+        {
+            this.StatusCode = statusCode;
+            this.Description = description;
+        }
+
+        /// <summary>
+        /// Gets the canonical code from this status.
+        /// </summary>
+        public StatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets the status description.
+        /// </summary>
+        /// <remarks>
+        /// Note: Status Description is only valid for <see
+        /// cref="StatusCode.Error"/> Status and will be ignored for all other
+        /// <see cref="Trace.StatusCode"/> values. See the <a
+        /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status">
+        /// Status API</a> for details.
+        /// </remarks>
+        public string Description { get; }
+
+        /// <summary>
+        /// Compare two <see cref="SpanStatus"/> for equality.
+        /// </summary>
+        /// <param name="status1">First Status to compare.</param>
+        /// <param name="status2">Second Status to compare.</param>
+        public static bool operator ==(SpanStatus status1, SpanStatus status2) => status1.Equals(status2);
+
+        /// <summary>
+        /// Compare two <see cref="SpanStatus"/> for not equality.
+        /// </summary>
+        /// <param name="status1">First Status to compare.</param>
+        /// <param name="status2">Second Status to compare.</param>
+        public static bool operator !=(SpanStatus status1, SpanStatus status2) => !status1.Equals(status2);
+
+        /// <summary>
+        /// Returns a new instance of a status with the description populated.
+        /// </summary>
+        /// <remarks>
+        /// Note: Status Description is only valid for <see
+        /// cref="StatusCode.Error"/> Status and will be ignored for all other
+        /// <see cref="Trace.StatusCode"/> values. See the <a
+        /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status">Status
+        /// API</a> for details.
+        /// </remarks>
+        /// <param name="description">Description of the status.</param>
+        /// <returns>New instance of the status class with the description populated.</returns>
+        public SpanStatus WithDescription(string description)
+        {
+            if (this.StatusCode != StatusCode.Error || this.Description == description)
+            {
+                return this;
+            }
+
+            return new SpanStatus(this.StatusCode, description);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is SpanStatus))
+            {
+                return false;
+            }
+
+            var that = (SpanStatus)obj;
+            return this.StatusCode == that.StatusCode && this.Description == that.Description;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            var result = 1;
+            result = (31 * result) + this.StatusCode.GetHashCode();
+            result = (31 * result) + (this.Description?.GetHashCode() ?? 0);
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return nameof(SpanStatus)
+                + "{"
+                + nameof(this.StatusCode) + "=" + this.StatusCode + ", "
+                + nameof(this.Description) + "=" + this.Description
+                + "}";
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(SpanStatus other)
+        {
+            return this.StatusCode == other.StatusCode && this.Description == other.Description;
+        }
+    }
+}

--- a/src/Datadog.Trace/SpanStatus.cs
+++ b/src/Datadog.Trace/SpanStatus.cs
@@ -1,3 +1,4 @@
+// taken from: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Trace/Status.cs
 namespace Datadog.Trace
 {
     /// <summary>

--- a/src/Datadog.Trace/StatusCode.cs
+++ b/src/Datadog.Trace/StatusCode.cs
@@ -1,3 +1,4 @@
+// taken from: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Trace/StatusCode.cs
 namespace Datadog.Trace
 {
     /// <summary>

--- a/src/Datadog.Trace/StatusCode.cs
+++ b/src/Datadog.Trace/StatusCode.cs
@@ -1,0 +1,23 @@
+namespace Datadog.Trace
+{
+    /// <summary>
+    /// Canonical result code of span execution.
+    /// </summary>
+    public enum StatusCode
+    {
+        /// <summary>
+        /// The default status.
+        /// </summary>
+        Unset = 0,
+
+        /// <summary>
+        /// The operation completed successfully.
+        /// </summary>
+        Ok = 1,
+
+        /// <summary>
+        /// The operation contains an error.
+        /// </summary>
+        Error = 2,
+    }
+}

--- a/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             Assert.Equal(SpanKinds.Server, span.GetTag(Tags.SpanKind));
             Assert.Equal(TracerConstants.Language, span.GetTag(Tags.Language));
             Assert.Equal(((int)statusCode).ToString(), span.GetTag(Tags.HttpStatusCode));
-            Assert.Equal(isError, span.Error);
+            Assert.Equal(isError, span.Status.StatusCode == StatusCode.Error);
 
             if (expectedTags is not null)
             {

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
@@ -203,7 +203,7 @@ namespace Datadog.Trace.OpenTracing.Tests
                                                .WithTag(global::OpenTracing.Tag.Tags.Error.Key, true)
                                                .Start();
 
-            Assert.True(span.DDSpan.Error);
+            Assert.Equal(SpanStatus.Error, span.DDSpan.Status);
         }
 
         [Fact]

--- a/test/Datadog.Trace.TestHelpers/MsgPackHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/MsgPackHelpers.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.TestHelpers
             Assert.Equal(expected.Type, actual.Type());
             Assert.Equal(expected.StartTime.ToUnixTimeNanoseconds(), actual.StartTime());
             Assert.Equal(expected.Duration.ToNanoseconds(), actual.Duration());
-            if (expected.Error)
+            if (expected.Status.StatusCode == StatusCode.Error)
             {
                 Assert.Equal("1", actual.Error());
             }

--- a/test/Datadog.Trace.TestHelpers/TestSpan.cs
+++ b/test/Datadog.Trace.TestHelpers/TestSpan.cs
@@ -12,8 +12,6 @@ namespace Datadog.Trace.TestHelpers
 
         public SpanStatus Status { get; set; }
 
-        public bool Error { get; set; }
-
         private Dictionary<string, string> Tags { get; } = new Dictionary<string, string>();
 
         ISpan ISpan.SetTag(string key, string value)
@@ -30,8 +28,7 @@ namespace Datadog.Trace.TestHelpers
 
         public void SetException(Exception exception)
         {
-            Error = true;
-
+            Status = SpanStatus.Error.WithDescription(exception.Message);
             SetTagInternal(Trace.Tags.ErrorMsg, exception.Message);
             SetTagInternal(Trace.Tags.ErrorStack, exception.StackTrace);
             SetTagInternal(Trace.Tags.ErrorType, exception.GetType().ToString());

--- a/test/Datadog.Trace.TestHelpers/TestSpan.cs
+++ b/test/Datadog.Trace.TestHelpers/TestSpan.cs
@@ -10,6 +10,8 @@ namespace Datadog.Trace.TestHelpers
 
         public string Type { get; set; }
 
+        public SpanStatus Status { get; set; }
+
         public bool Error { get; set; }
 
         private Dictionary<string, string> Tags { get; } = new Dictionary<string, string>();

--- a/test/Datadog.Trace.Tests/SpanStatusTests.cs
+++ b/test/Datadog.Trace.Tests/SpanStatusTests.cs
@@ -1,0 +1,104 @@
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class SpanStatusTests
+    {
+        [Fact]
+        public void Status_Ok()
+        {
+            Assert.Equal(StatusCode.Ok, SpanStatus.Ok.StatusCode);
+            Assert.Null(SpanStatus.Ok.Description);
+        }
+
+        [Fact]
+        public void CheckingDefaultStatus()
+        {
+            Assert.Equal(default, SpanStatus.Unset);
+        }
+
+        [Fact]
+        public void CreateStatus_Error_WithDescription()
+        {
+            var status = SpanStatus.Error.WithDescription("This is an error.");
+            Assert.Equal(StatusCode.Error, status.StatusCode);
+            Assert.Equal("This is an error.", status.Description);
+        }
+
+        [Fact]
+        public void CreateStatus_Ok_WithDescription()
+        {
+            var status = SpanStatus.Ok.WithDescription("This is will not be set.");
+            Assert.Equal(StatusCode.Ok, status.StatusCode);
+            Assert.Null(status.Description);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var status1 = new SpanStatus(StatusCode.Ok);
+            var status2 = new SpanStatus(StatusCode.Ok);
+            object status3 = new SpanStatus(StatusCode.Ok);
+
+            Assert.Equal(status1, status2);
+            Assert.True(status1 == status2);
+            Assert.True(status1.Equals(status3));
+        }
+
+        [Fact]
+        public void Equality_WithDescription()
+        {
+            var status1 = new SpanStatus(StatusCode.Error, "error");
+            var status2 = new SpanStatus(StatusCode.Error, "error");
+
+            Assert.Equal(status1, status2);
+            Assert.True(status1 == status2);
+        }
+
+        [Fact]
+        public void Not_Equality()
+        {
+            var status1 = new SpanStatus(StatusCode.Ok);
+            var status2 = new SpanStatus(StatusCode.Error);
+            object notStatus = 1;
+
+            Assert.NotEqual(status1, status2);
+            Assert.True(status1 != status2);
+            Assert.False(status1.Equals(notStatus));
+        }
+
+        [Fact]
+        public void Not_Equality_WithDescription1()
+        {
+            var status1 = new SpanStatus(StatusCode.Ok, "ok");
+            var status2 = new SpanStatus(StatusCode.Error, "error");
+
+            Assert.NotEqual(status1, status2);
+            Assert.True(status1 != status2);
+        }
+
+        [Fact]
+        public void Not_Equality_WithDescription2()
+        {
+            var status1 = new SpanStatus(StatusCode.Ok);
+            var status2 = new SpanStatus(StatusCode.Error, "error");
+
+            Assert.NotEqual(status1, status2);
+            Assert.True(status1 != status2);
+        }
+
+        [Fact]
+        public void TestToString()
+        {
+            var status = new SpanStatus(StatusCode.Ok);
+            Assert.Equal($"SpanStatus{{StatusCode={status.StatusCode}, Description={status.Description}}}", status.ToString());
+        }
+
+        [Fact]
+        public void TestGetHashCode()
+        {
+            var status = new SpanStatus(StatusCode.Ok);
+            Assert.NotEqual(0, status.GetHashCode());
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/SpanStatusTests.cs
+++ b/test/Datadog.Trace.Tests/SpanStatusTests.cs
@@ -1,3 +1,4 @@
+// taken from: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/test/OpenTelemetry.Tests/Trace/StatusTest.cs
 using Xunit;
 
 namespace Datadog.Trace.Tests


### PR DESCRIPTION
## Why

From [specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span):
> After the Span is created, it SHOULD be possible to [...] set the Status

## What

1. Add `Status` with `StatusCode` and `Description` to `Span` per: [specs - set status](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status)
2. Refactor to use `Span.Status` instead of `Span.Error`. All existing instrumentations should work (sic!).

### Constraints

This PR does not respect:

>The status code SHOULD remain unset, except for the following circumstances:

This is tracked under https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/85

## Next PRs

1. Report status in Zipkin exporter. See: [zipkin status](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status)
1. Report status in Jaeger exporter. See: [jaeger status](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#status)
1. Handle Outboud HTTP request status as defined in [OTEL specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status)
1. Add support for OTel exceptions (and stuff related with it like update exporters and the outbound HTTP instrumentation)
1. https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/85
