### PR TITLE
Fix leftovers after renaming profiler

### DIFF
--- a/.azure-pipelines/setup_tracer.ps1
+++ b/.azure-pipelines/setup_tracer.ps1
@@ -58,7 +58,7 @@ else
 
     $otel_tracer_msbuild = "$otel_tracer_home/netstandard2.0/OpenTelemetry.AutoInstrumentation.MSBuild.dll"
     $otel_tracer_integrations = "$otel_tracer_home/integrations.json"
-    $otel_tracer_profiler_64 = "$otel_tracer_home/Datadog.Trace.ClrProfiler.Native.so"
+    $otel_tracer_profiler_64 = "$otel_tracer_home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so"
 }
 
 # Set all environment variables to attach the profiler to the following pipeline steps

--- a/build/docker/linux-build.dockerfile
+++ b/build/docker/linux-build.dockerfile
@@ -66,11 +66,11 @@ ARG PUBLISH_FOLDER
 ARG TRACER_HOME
 COPY --from=build-managed ${WORKSPACE} ${WORKSPACE}
 WORKDIR ${WORKSPACE}/src/Datadog.Trace.ClrProfiler.Native/build
-RUN cmake .. && make && cp -f ./bin/Datadog.Trace.ClrProfiler.Native.so ${PUBLISH_FOLDER}/
+RUN cmake .. && make && cp -f ./bin/Datadog.Trace.ClrProfiler.Native.so ${PUBLISH_FOLDER}/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so
 RUN mkdir -p /var/log/opentelemetry/dotnet
 RUN touch /var/log/opentelemetry/dotnet/dotnet-tracer-native.log
 WORKDIR ${PUBLISH_FOLDER}
-RUN echo "#!/bin/bash\n set -euxo pipefail\n export CORECLR_ENABLE_PROFILING=\"1\"\n export CORECLR_PROFILER=\"{918728DD-259F-4A6A-AC2B-B85E1B658318}\"\n export OTEL_DOTNET_TRACER_HOME=\"${TRACER_HOME}\"\n export CORECLR_PROFILER_PATH=\"\${OTEL_DOTNET_TRACER_HOME}/Datadog.Trace.ClrProfiler.Native.so\"\n export OTEL_INTEGRATIONS=\"\${OTEL_DOTNET_TRACER_HOME}/integrations.json\"\n eval \"\$@\"\n" > dd-trace.bash
+RUN echo "#!/bin/bash\n set -euxo pipefail\n export CORECLR_ENABLE_PROFILING=\"1\"\n export CORECLR_PROFILER=\"{918728DD-259F-4A6A-AC2B-B85E1B658318}\"\n export OTEL_DOTNET_TRACER_HOME=\"${TRACER_HOME}\"\n export CORECLR_PROFILER_PATH=\"\${OTEL_DOTNET_TRACER_HOME}/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so\"\n export OTEL_INTEGRATIONS=\"\${OTEL_DOTNET_TRACER_HOME}/integrations.json\"\n eval \"\$@\"\n" > dd-trace.bash
 RUN chmod +x dd-trace.bash
 
 
@@ -83,8 +83,8 @@ COPY --from=build-native /var/log/datadog/ /var/log/datadog/
 
 FROM build-native as native-linux-binary
 ARG PUBLISH_FOLDER
-COPY --from=build-native ${PUBLISH_FOLDER}/Datadog.Trace.ClrProfiler.Native.so Datadog.Trace.ClrProfiler.Native.so
-CMD cp -f Datadog.Trace.ClrProfiler.Native.so /home/linux-x64/Datadog.Trace.ClrProfiler.Native.so
+COPY --from=build-native ${PUBLISH_FOLDER}/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so
+CMD cp -f OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so /home/linux-x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so
 
 
 FROM build-managed-base as dotnet-sdk-with-dd-tracer

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2653,7 +2653,7 @@ void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assembl
     for(auto i = 0; i < imgCount; i++) {
         const std::string name = std::string(_dyld_get_image_name(i));
 
-        if (name.rfind("Datadog.Trace.ClrProfiler.Native.dylib") != std::string::npos) {
+        if (name.rfind("OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dylib") != std::string::npos) {
             const mach_header_64* header = (const struct mach_header_64 *) _dyld_get_image_header(i);
 
             unsigned long dllSize;

--- a/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -43,11 +43,11 @@ namespace Datadog.Trace.Tools.Runner
             }
             else if (platform == Platform.Linux)
             {
-                tracerProfiler64 = FileExists(Path.Combine(tracerHome, "linux-x64", "Datadog.Trace.ClrProfiler.Native.so"));
+                tracerProfiler64 = FileExists(Path.Combine(tracerHome, "linux-x64", "OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so"));
             }
             else if (platform == Platform.MacOS)
             {
-                tracerProfiler64 = FileExists(Path.Combine(tracerHome, "osx-x64", "Datadog.Trace.ClrProfiler.Native.dylib"));
+                tracerProfiler64 = FileExists(Path.Combine(tracerHome, "osx-x64", "OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dylib"));
             }
 
             var envVars = new Dictionary<string, string>

--- a/test/test-applications/integrations/Samples.FakeDbCommand/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/Properties/launchSettings.json
@@ -4,12 +4,12 @@
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
-        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
-        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "OTEL_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",

--- a/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Properties/launchSettings.json
@@ -4,12 +4,12 @@
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
-        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
-        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "OTEL_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",

--- a/test/test-applications/integrations/Samples.OracleMDA.Core/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.OracleMDA.Core/Properties/launchSettings.json
@@ -4,12 +4,12 @@
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
-        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
-        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "OTEL_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",

--- a/test/test-applications/integrations/Samples.OracleMDA/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.OracleMDA/Properties/launchSettings.json
@@ -4,12 +4,12 @@
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
-        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
-        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "OTEL_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",

--- a/test/test-applications/integrations/Samples.SQLite.Core/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.SQLite.Core/Properties/launchSettings.json
@@ -4,12 +4,12 @@
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
-        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
-        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
 
         "OTEL_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",


### PR DESCRIPTION
There were some leftovers after series of renaming PRs that we found out were not changed (some of them are new from upstream merge). So here they are.
