### PR TITLE
Synchronize initialization in ServiceFabric instrumentation

### DIFF
--- a/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
+++ b/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ServiceFabric
         private static readonly Logging.IDatadogLogger Log = Logging.DatadogLogging.GetLoggerFor(typeof(ServiceRemotingClient));
 
         private static int _firstInitialization = 1;
-        private static bool _initialized;
+        private static volatile bool _initialized;
 
         /// <summary>
         /// Start tracing ServiceRemotingClientEvents.

--- a/src/Datadog.Trace/ServiceFabric/ServiceRemotingService.cs
+++ b/src/Datadog.Trace/ServiceFabric/ServiceRemotingService.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.ServiceFabric
         private static readonly Logging.IDatadogLogger Log = Logging.DatadogLogging.GetLoggerFor(typeof(ServiceRemotingService));
 
         private static int _firstInitialization = 1;
-        private static bool _initialized;
+        private static volatile bool _initialized;
 
         /// <summary>
         /// Start tracing ServiceRemotingServiceEvents.


### PR DESCRIPTION
## Why

`initialized` field is not synchronized at all which can lead to loss of traces.

## What

Initialization is the only use-case where I find using `volatile` to be OK.
http://www.albahari.com/threading/part4.aspx#_Memory_Barriers_and_Volatility
