### PR TITLE
Add OTel status reporting to Zipkin Exporter

### DIFF
--- a/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToZipkinCollector.cs
@@ -7,41 +7,103 @@ using Xunit;
 
 namespace Datadog.Trace.IntegrationTests
 {
-    public class SendTracesToZipkinCollector
+    public class SendTracesToZipkinCollector : IDisposable
     {
         private readonly Tracer _tracer;
-        private readonly int collectorPort = 9411;
+        private readonly MockZipkinCollector _zipkinCollector;
 
         public SendTracesToZipkinCollector()
         {
-            var agentUri = new Uri("http://localhost:9411/api/v2/spans");
+            int collectorPort = 9411;
+            var agentUri = new Uri($"http://localhost:{collectorPort}/api/v2/spans");
             var exporter = new ZipkinExporter(agentUri);
             var exporterWriter = new ExporterWriter(exporter, new NullMetrics());
             _tracer = new Tracer(new TracerSettings(), exporterWriter, sampler: null, scopeManager: null, statsd: null);
+            _zipkinCollector = new MockZipkinCollector(collectorPort);
+        }
+
+        public void Dispose()
+        {
+            _zipkinCollector.Dispose();
         }
 
         [Fact]
         public void MinimalSpan()
         {
-            using (var zipkinCollector = new MockZipkinCollector(collectorPort))
+            const string operationName = "MyOperation";
+            using (var scope = _tracer.StartActive(operationName))
             {
-                var scope = _tracer.StartActive("Operation");
                 scope.Span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 scope.Span.SetTag("key", "value");
-                scope.Dispose();
-
-                var spans = zipkinCollector.WaitForSpans(1);
-
-                Assert.Single(spans);
-                var zspan = spans[0];
-                Assert.Equal(scope.Span.OperationName, zspan.Name);
-                Assert.True(zspan.Tags.TryGetValue("key", out var tagValue));
-                Assert.Equal("value", tagValue);
-
-                // The span.kind has an special treatment.
-                Assert.False(zspan.Tags.ContainsKey(Tags.SpanKind));
-                Assert.Equal("CLIENT", zspan.Kind);
             }
+
+            var zspan = RetrieveSpan();
+
+            Assert.Equal(operationName, zspan.Name);
+            Assert.True(zspan.Tags.TryGetValue("key", out var tagValue));
+            Assert.Equal("value", tagValue);
+
+            // The span.kind has an special treatment.
+            Assert.False(zspan.Tags.ContainsKey(Tags.SpanKind));
+            Assert.Equal("CLIENT", zspan.Kind);
+
+            Assert.False(zspan.Tags.ContainsKey("otel.status_code")); // MUST NOT be set if the status code is UNSET.
+            Assert.False(zspan.Tags.ContainsKey("error")); // MUST NOT be set if the status code is UNSET.
+        }
+
+        [Fact]
+        public void OkSpan()
+        {
+            using (var scope = _tracer.StartActive("Operation"))
+            {
+                scope.Span.Status = SpanStatus.Ok;
+            }
+
+            var zspan = RetrieveSpan();
+
+            Assert.True(zspan.Tags.TryGetValue("otel.status_code", out var tagValue));
+            Assert.Equal("OK", tagValue);
+            Assert.False(zspan.Tags.ContainsKey("error")); // MUST NOT be set if the status code is OK.
+        }
+
+        [Fact]
+        public void ErrorSpan()
+        {
+            using (var scope = _tracer.StartActive("Operation"))
+            {
+                scope.Span.Status = SpanStatus.Error;
+            }
+
+            var zspan = RetrieveSpan();
+
+            Assert.True(zspan.Tags.TryGetValue("otel.status_code", out var tagValue));
+            Assert.Equal("ERROR", tagValue);
+            Assert.True(zspan.Tags.TryGetValue("error", out var errorValue)); // MUST be set if the code is ERROR, use an empty string if Description has no value.
+            Assert.Equal(string.Empty, errorValue);
+        }
+
+        [Fact]
+        public void ErrorSpanWithDescription()
+        {
+            const string errorDescription = "some error";
+            using (var scope = _tracer.StartActive("Operation"))
+            {
+                scope.Span.Status = SpanStatus.Error.WithDescription(errorDescription);
+            }
+
+            var zspan = RetrieveSpan();
+
+            Assert.True(zspan.Tags.TryGetValue("otel.status_code", out var tagValue));
+            Assert.Equal("ERROR", tagValue);
+            Assert.True(zspan.Tags.TryGetValue("error", out var errorValue));
+            Assert.Equal(errorDescription, errorValue);
+        }
+
+        private MockZipkinCollector.Span RetrieveSpan()
+        {
+            var spans = _zipkinCollector.WaitForSpans(1);
+            Assert.Single(spans);
+            return spans[0];
         }
     }
 }


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/82 followup

## What

Report status in Zipkin exporter according to [Zipkin status OTel specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status).