### PR TITLE
Create nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This PR should fix problems such as:
```
Error NU1101: Unable to find package Microsoft.NETFramework.ReferenceAssemblies. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages
```

Seems to be related to [this issue](https://github.com/actions/virtual-environments/issues/3038) which relates to GitHub actions, but as AzDo runs on the same underlying infrastructure, probably the same problem.

Apparently, this is a commonly-reported intermittent issue related to "ambient state" on the builder causing nuget.org to be omitted from the NuGet "Feeds used" (https://github.com/actions/virtual-environments/issues/1090)). Add the nuget.org packageSource explicitly using `nuget.config` to avoid the issue, as recommended by:

- https://github.com/actions/setup-dotnet/issues/155
- https://github.com/actions/virtual-environments/issues/3038
- https://github.com/NuGet/Home/issues/10586

PR copied from: https://github.com/DataDog/dd-trace-dotnet/pull/1353