### PR TITLE
Add OTel status reporting to Jaeger Exporter

### DIFF
--- a/src/Datadog.Trace/Agent/Jaeger/ConverterExtensions.cs
+++ b/src/Datadog.Trace/Agent/Jaeger/ConverterExtensions.cs
@@ -57,6 +57,20 @@ namespace Datadog.Trace.Agent.Jaeger
                 PooledList<JaegerTag>.Add(ref list, ToJaegerTag(new KeyValuePair<string, object>(item.Key, item.Value)));
             }
 
+            // report span status according to https://github.com/open-telemetry/opentelemetry-specification/blob/59bbfb781bb403902e7be79966a6576c47eb704b/specification/trace/sdk_exporters/jaeger.md#status
+            switch (span.Status.StatusCode)
+            {
+                case StatusCode.Ok:
+                    PooledList<JaegerTag>.Add(ref list, new JaegerTag("otel.status_code", JaegerTagType.STRING, vStr: "OK"));
+                    break;
+                case StatusCode.Error:
+                    PooledList<JaegerTag>.Add(ref list, new JaegerTag("error", JaegerTagType.BOOL, vBool: true));
+                    PooledList<JaegerTag>.Add(ref list, new JaegerTag("otel.status_code", JaegerTagType.STRING, vStr: "ERROR"));
+                    var description = span.Status.Description ?? string.Empty;
+                    PooledList<JaegerTag>.Add(ref list, new JaegerTag("otel.status_description", JaegerTagType.STRING, vStr: description));
+                    break;
+            }
+
             return list;
         }
 

--- a/src/Datadog.Trace/Agent/Zipkin/ZipkinSerializer.cs
+++ b/src/Datadog.Trace/Agent/Zipkin/ZipkinSerializer.cs
@@ -111,6 +111,7 @@ namespace Datadog.Trace.Agent
                     }
                 }
 
+                // report span status according to https://github.com/open-telemetry/opentelemetry-specification/blob/59bbfb781bb403902e7be79966a6576c47eb704b/specification/trace/sdk_exporters/zipkin.md#status
                 switch (span?.Status.StatusCode)
                 {
                     case StatusCode.Ok:

--- a/test/Datadog.Trace.Tests/Agent/Jaeger/ConverterExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/Agent/Jaeger/ConverterExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.Tests.Agent.Jaeger
     public class ConverterExtensionsTests
     {
         [Fact]
-        public void JaegerTraceExporter_SetResource_CreatesTags()
+        public void ToJaegerSpan()
         {
             var parentSpanContext = Mock.Of<ISpanContext>(c => c.SpanId == SpanIdGenerator.ThreadInstance.CreateNew());
             var span = SpanFactory.CreateSpan(parentSpanContext);
@@ -37,6 +37,56 @@ namespace Datadog.Trace.Tests.Agent.Jaeger
             Assert.Single(tags, t => t.Key == "k1" && t.VStr == "v1");
             Assert.Single(tags, t => t.Key == Tags.Env && t.VStr == "Test");
             Assert.Single(tags, t => t.Key == Tags.Version && t.VStr == "v1.0");
+        }
+
+        [Fact]
+        public void ToJaegerTags_StatusUnset()
+        {
+            var span = SpanFactory.CreateSpan();
+
+            var tags = span.ToJaegerTags();
+
+            Assert.DoesNotContain(tags, t => t.Key == "otel.status_code"); // MUST NOT be set if the status code is UNSET.
+            Assert.DoesNotContain(tags, t => t.Key == "otel.status_description"); // MUST NOT be set if the status code is UNSET.
+        }
+
+        [Fact]
+        public void ToJaegerTags_StatusOk()
+        {
+            var span = SpanFactory.CreateSpan();
+            span.Status = SpanStatus.Ok;
+
+            var tags = span.ToJaegerTags();
+
+            Assert.Contains(tags, t => t.Key == "otel.status_code" && t.VStr == "OK");
+            Assert.DoesNotContain(tags, t => t.Key == "otel.status_description"); // MUST NOT be set if the status code is OK.
+        }
+
+        [Fact]
+        public void ToJaegerTags_StatusError()
+        {
+            var span = SpanFactory.CreateSpan();
+            span.Status = SpanStatus.Error;
+
+            var tags = span.ToJaegerTags();
+
+            Assert.Contains(tags, t => t.Key == "otel.status_code" && t.VStr == "ERROR");
+            Assert.Contains(tags, t => t.Key == "otel.status_description" && t.VStr == string.Empty); // MUST be set if the code is ERROR, use an empty string if Description has no value.
+            Assert.Contains(tags, t => t.Key == "error" && t.VBool.Value);
+        }
+
+        [Fact]
+        public void ToJaegerTags_StatusErrorWithDescription()
+        {
+            const string errorDescription = "some error";
+            var span = SpanFactory.CreateSpan();
+            span.Status = SpanStatus.Error.WithDescription(errorDescription);
+
+            var tags = span.ToJaegerTags();
+
+            Assert.Contains(tags, t => t.Key == "otel.status_code" && t.VStr == "ERROR");
+            Assert.Contains(tags, t => t.Key == "otel.status_description" && t.VStr == errorDescription);
+            Assert.Contains(tags, t => t.Key == "error" && t.VBool.Value);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Agent/Jaeger/JaegerExporterTests.cs
+++ b/test/Datadog.Trace.Tests/Agent/Jaeger/JaegerExporterTests.cs
@@ -8,14 +8,14 @@ namespace Datadog.Trace.Tests.Agent.Jaeger
     public class JaegerExporterTests
     {
         [Fact]
-        public void JaegerTraceExporter_ctor_NullServiceNameAllowed()
+        public void Ctor_NullServiceNameAllowed()
         {
             var jaegerTraceExporter = BuildExporter();
             Assert.NotNull(jaegerTraceExporter);
         }
 
         [Fact]
-        public void JaegerTraceExporter_SetResource_UpdatesServiceName()
+        public void SetResource_UpdatesServiceName()
         {
             var jaegerTraceExporter = BuildExporter();
             var process = jaegerTraceExporter.Process;
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Tests.Agent.Jaeger
         }
 
         [Fact]
-        public void JaegerTraceExporter_BuildBatchesToTransmit_FlushedBatch()
+        public void BuildBatchesToTransmit_FlushedBatch()
         {
             // Arrange
             var jaegerExporter = BuildExporter(175);


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/119 followup

## What

Report span status in Jaeger exporter according to [Jaeger exporter OTel specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jager.md).

Also, some little tests refactoring (test names).