### PR TITLE
Add integration tests for B3 propagator

### DIFF
--- a/src/Datadog.Trace/Propagation/B3HttpHeaderNames.cs
+++ b/src/Datadog.Trace/Propagation/B3HttpHeaderNames.cs
@@ -1,6 +1,9 @@
 namespace Datadog.Trace.Propagation
 {
-    internal static class B3HttpHeaderNames
+    /// <summary>
+    /// Names of HTTP headers that can be used tracing inbound or outbound HTTP requests.
+    /// </summary>
+    public static class B3HttpHeaderNames
     {
         /// <summary>
         /// ID of a distributed trace.

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/PropagationTestHelpers.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/PropagationTestHelpers.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
             var ddTraceId = StringUtil.GetHeader(processResult.StandardOutput, DDHttpHeaderNames.TraceId);
             var ddParentSpanId = StringUtil.GetHeader(processResult.StandardOutput, DDHttpHeaderNames.ParentId);
 
-            Assert.Equal(expectedSpan.TraceId.ToString(CultureInfo.InvariantCulture), ddTraceId);
+            Assert.Equal(expectedSpan.TraceId.ToString(), ddTraceId);
             Assert.Equal(expectedSpan.SpanId.ToString(CultureInfo.InvariantCulture), ddParentSpanId);
 
             // Verify B3 headers
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
             var b3SpanId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3SpanId);
             var b3ParentSpanId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3ParentId);
 
-            Assert.Equal(expectedSpan.TraceId.ToString("x16", CultureInfo.InvariantCulture), b3TraceId);
+            Assert.Equal(expectedSpan.TraceId.ToString(), b3TraceId); // TODO: With DD Trace ID Convention, it will be in DD Trace ID format
             Assert.Equal(expectedSpan.SpanId.ToString("x16", CultureInfo.InvariantCulture), b3SpanId);
             Assert.Equal(expectedSpan.ParentId.Value.ToString("x16", CultureInfo.InvariantCulture), b3ParentSpanId);
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/PropagationTestHelpers.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/PropagationTestHelpers.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using Datadog.Trace.Propagation;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
+{
+    public static class PropagationTestHelpers
+    {
+        public static void AssertPropagationEnabled(MockTracerAgent.Span expectedSpan, ProcessResult processResult)
+        {
+            // Verify DD headers
+            var ddTraceId = StringUtil.GetHeader(processResult.StandardOutput, DDHttpHeaderNames.TraceId);
+            var ddParentSpanId = StringUtil.GetHeader(processResult.StandardOutput, DDHttpHeaderNames.ParentId);
+
+            Assert.Equal(expectedSpan.TraceId.ToString(CultureInfo.InvariantCulture), ddTraceId);
+            Assert.Equal(expectedSpan.SpanId.ToString(CultureInfo.InvariantCulture), ddParentSpanId);
+
+            // Verify B3 headers
+            var b3TraceId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3TraceId);
+            var b3SpanId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3SpanId);
+            var b3ParentSpanId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3ParentId);
+
+            Assert.Equal(expectedSpan.TraceId.ToString("x16", CultureInfo.InvariantCulture), b3TraceId);
+            Assert.Equal(expectedSpan.SpanId.ToString("x16", CultureInfo.InvariantCulture), b3SpanId);
+            Assert.Equal(expectedSpan.ParentId.Value.ToString("x16", CultureInfo.InvariantCulture), b3ParentSpanId);
+        }
+
+        public static void AssertPropagationDisabled(ProcessResult processResult)
+        {
+            // Verify common headers
+            var tracingEnabled = StringUtil.GetHeader(processResult.StandardOutput, CommonHttpHeaderNames.TracingEnabled);
+
+            Assert.Equal("false", tracingEnabled);
+
+            // Verify DD headers
+            var ddTraceId = StringUtil.GetHeader(processResult.StandardOutput, DDHttpHeaderNames.TraceId);
+            var ddParentSpanId = StringUtil.GetHeader(processResult.StandardOutput, DDHttpHeaderNames.ParentId);
+
+            Assert.Null(ddTraceId);
+            Assert.Null(ddParentSpanId);
+
+            // Verify B3 headers
+            var b3TraceId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3TraceId);
+            var b3SpanId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3SpanId);
+            var b3ParentSpanId = StringUtil.GetHeader(processResult.StandardOutput, B3HttpHeaderNames.B3ParentId);
+
+            Assert.Null(b3TraceId);
+            Assert.Null(b3SpanId);
+            Assert.Null(b3ParentSpanId);
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -12,6 +12,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("WebRequest", output)
         {
             SetEnvironmentVariable("OTEL_TRACE_SERVICE_MAPPING", "some-trace:not-used,http-client:my-custom-client");
+            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog;b3");
             SetServiceVersion("1.0.0");
         }
 

--- a/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/DistributedTracingApiController.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/DistributedTracingApiController.cs
@@ -39,7 +39,7 @@ namespace Samples.AspNetMvc5.Controllers
                         span.ServiceName,
                         span.OperationName,
                         span.ResourceName,
-                        span.TraceId,
+                        (ulong)span.TraceId.Lower, // TODO: Add support for 128bit
                         span.SpanId);
                 }
 

--- a/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/DistributedTracingMvcController.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/DistributedTracingMvcController.cs
@@ -38,7 +38,7 @@ namespace Samples.AspNetMvc5.Controllers
                         span.ServiceName,
                         span.OperationName,
                         span.ResourceName,
-                        span.TraceId,
+                        (ulong)span.TraceId.Lower, // TODO: Add support for 128bit
                         span.SpanId);
                 }
 

--- a/test/test-applications/integrations/Samples.WebRequest/Program.cs
+++ b/test/test-applications/integrations/Samples.WebRequest/Program.cs
@@ -88,7 +88,13 @@ namespace Samples.WebRequest
 
         private static void HandleHttpRequests(object state)
         {
-            var expectedHeaders = new[] { DDHttpHeaderNames.TraceId, DDHttpHeaderNames.ParentId, DDHttpHeaderNames.SamplingPriority };
+            var expectedHeaders = new[] {
+                // Datadog headers
+                DDHttpHeaderNames.TraceId, DDHttpHeaderNames.ParentId, DDHttpHeaderNames.SamplingPriority,
+
+                // B3 headers
+                B3HttpHeaderNames.B3TraceId, B3HttpHeaderNames.B3SpanId, B3HttpHeaderNames.B3ParentId, B3HttpHeaderNames.B3Sampled
+            };
 
             var listener = (HttpListener)state;
 

--- a/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
@@ -12,7 +12,8 @@
           "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll",
   
           "OTEL_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
-          "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+          "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+          "OTEL_PROPAGATORS": "datadog;b3"
         },
         "nativeDebugging": true
       }


### PR DESCRIPTION
### **Background**
This PR adds B3 propagator integration tests. Integration tests are based on multipropagator logic, so we can reuse the same header tests and save loads of power.