### PR TITLE
Remove Unsafe package

### DIFF
--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6" PrivateAssets="All" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
   </ItemGroup>
 
   <!-- Below this point is reserved for vendor items -->

--- a/src/Datadog.Trace/TraceId.cs
+++ b/src/Datadog.Trace/TraceId.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 
 namespace Datadog.Trace
 {
@@ -72,15 +71,9 @@ namespace Datadog.Trace
         /// <returns>Instance of randomly generated <see cref="TraceId"/>.</returns>
         public static TraceId CreateRandom()
         {
-            var higherBytes = new byte[8];
-            var lowerBytes = new byte[8];
-
             var randomNumberGenerator = RandomNumberGenerator.Current;
-            Unsafe.WriteUnaligned(ref higherBytes[0],  randomNumberGenerator.Next());
-            Unsafe.WriteUnaligned(ref lowerBytes[0], randomNumberGenerator.Next());
-
-            var higher = BitConverter.ToInt64(higherBytes, startIndex: 0) & 0x7FFFFFFFFFFFFFFF;
-            var lower = BitConverter.ToInt64(lowerBytes, startIndex: 0) & 0x7FFFFFFFFFFFFFFF;
+            var higher = randomNumberGenerator.Next() & 0x7FFFFFFFFFFFFFFF;
+            var lower = randomNumberGenerator.Next() & 0x7FFFFFFFFFFFFFFF;
 
             return new TraceId(higher, lower);
         }
@@ -91,12 +84,8 @@ namespace Datadog.Trace
         /// <returns>Instance of randomly generated <see cref="TraceId"/>.</returns>
         public static TraceId CreateRandomDataDogCompatible()
         {
-            var lowerBytes = new byte[8];
-
             var randomNumberGenerator = RandomNumberGenerator.Current;
-            Unsafe.WriteUnaligned(ref lowerBytes[0], randomNumberGenerator.Next());
-
-            var lower = (ulong)BitConverter.ToInt64(lowerBytes, startIndex: 0) & 0x7FFFFFFFFFFFFFFF;
+            var lower = (ulong)randomNumberGenerator.Next() & 0x7FFFFFFFFFFFFFFF;
 
             return new TraceId(lower);
         }


### PR DESCRIPTION
Changing code a bit to get rid of the System.Runtime.CompilerServices.Unsafe package. This should resolve [Issue#127](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/127).