### PR TITLE
Add running docker-compose after pull from upstream to the instruction

### DIFF
--- a/docs/PULL_FROM_UPSTREAM.md
+++ b/docs/PULL_FROM_UPSTREAM.md
@@ -14,7 +14,12 @@
     * Run unit tests, commit any needed fixes, repeat until passing unit tests
     * Update versions and integrations json by running: ` cd \build\tools\PrepareRelease && dotnet run -- versions integrations` (remember to revert wcf and other windows-only frameworks if you are using different platform)
     * Run integration tests, commit any needed fixes, until passing integrations tests
-    * Run `docker-compose run build`, `docker-compose run Profiler` and `docker-compose run package` to verify `.sh` files are valid after the merge.
+    * Run each of the following commands and commit any needed fixes, until it passes:
+       - `docker-compose run --rm build`
+       - `docker-compose run --rm Profiler`
+       - `docker-compose run --rm IntegrationTests`
+       - `docker-compose run --rm package`
+
 6. If squashing cherry-pick from upstream to pass CLA check:
     * `git rebase -i <squash_sha>^`
     * Select top one as "pick" all coming from upstream as "squash" and let the ones that you made to fix build and test as "pick" so it is easier to review them separately.

--- a/docs/PULL_FROM_UPSTREAM.md
+++ b/docs/PULL_FROM_UPSTREAM.md
@@ -13,7 +13,6 @@
     * Old profiler ID: 846F5F1C-F9AE-4B07-969E-05C26BC060D8 (happens in launch.settings for new apps).
     * Run unit tests, commit any needed fixes, repeat until passing unit tests
     * Update versions and integrations json by running: ` cd \build\tools\PrepareRelease && dotnet run -- versions integrations` (remember to revert wcf and other windows-only frameworks if you are using different platform)
-    * Run integration tests, commit any needed fixes, until passing integrations tests
     * Run each of the following commands and commit any needed fixes, until it passes:
        - `docker-compose run --rm build`
        - `docker-compose run --rm Profiler`

--- a/docs/PULL_FROM_UPSTREAM.md
+++ b/docs/PULL_FROM_UPSTREAM.md
@@ -14,6 +14,7 @@
     * Run unit tests, commit any needed fixes, repeat until passing unit tests
     * Update versions and integrations json by running: ` cd \build\tools\PrepareRelease && dotnet run -- versions integrations` (remember to revert wcf and other windows-only frameworks if you are using different platform)
     * Run integration tests, commit any needed fixes, until passing integrations tests
+    * Run `docker-compose run build`, `docker-compose run Profiler` and `docker-compose run package` to verify `.sh` files are valid after the merge.
 6. If squashing cherry-pick from upstream to pass CLA check:
     * `git rebase -i <squash_sha>^`
     * Select top one as "pick" all coming from upstream as "squash" and let the ones that you made to fix build and test as "pick" so it is easier to review them separately.


### PR DESCRIPTION
**What**
Added point about building and packing the profiler using docker-compose for .sh files verification.

**Why**
There was an error in `package.sh` after the last pull from upstream that was not caught in the review and tests. This step should guard us from that in future.


