### PR TITLE
Change variables separator to comma

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,7 +26,7 @@ Use these environment variables to configure the tracing library:
 | `OTEL_TRACE_BATCH_INTERVAL` | The batch interval in milliseconds for the serialization queue. | `100` |
 | `OTEL_MAX_TRACES_PER_SECOND` | The number of traces allowed to be submitted per second. | `100` |
 | `OTEL_TRACE_STARTUP_LOGS` | Enable to activate diagnostic log at stratup. | `true` |
-| `OTEL_TRACE_SAMPLING_RULES` | Semi-colon separated list of sampling rules taht enabled custom sampling rules based on regular expressions. The rule is matched in order of specification. The first match in a list is used. The item "sample_rate" is required in decimal format. The item "service" is optional in regular expression format, to match on service name. The item "name" is optional in regular expression format, to match on operation name. | `'[{"sample_rate":0.5, "service":"cart.*"}];[{"sample_rate":0.2, "name":"http.request"}]'` |
+| `OTEL_TRACE_SAMPLING_RULES` | Comma separated list of sampling rules taht enabled custom sampling rules based on regular expressions. The rule is matched in order of specification. The first match in a list is used. The item "sample_rate" is required in decimal format. The item "service" is optional in regular expression format, to match on service name. The item "name" is optional in regular expression format, to match on operation name. | `'[{"sample_rate":0.5, "service":"cart.*"}],[{"sample_rate":0.2, "name":"http.request"}]'` |
 | `OTEL_TRACE_SAMPLE_RATE` | The global rate for the sampler. |  |
 | `OTEL_DOGSTATSD_PORT` | The port of the targeted StatsD server. | `8125` |
 | `OTEL_TRACE_METRICS_ENABLED` | Enable to activate internal metrics sent to DogStatsD. | `false` |
@@ -55,12 +55,12 @@ Use these environment variables to configure the tracing library:
 | `OTEL_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |
 | `OTEL_TRACE_LOG_PATH` | The path of the profiler log file. | Linux: `/var/log/OTEL/dotnet/dotnet-profiler.log`<br>Windows: `%ProgramData%"\OTEL .NET Tracing\logs\dotnet-profiler.log` |
 | `OTEL_DIAGNOSTIC_SOURCE_ENABLED` | Enable to generate troubleshooting logs with the `System.Diagnostics.DiagnosticSource` class. | `true` |
-| `OTEL_DISABLED_INTEGRATIONS` | The integrations you want to disable, if any, separated by a semi-colon. These are the supported integrations: AspNetMvc, AspNetWebApi2, DbCommand, ElasticsearchNet5, ElasticsearchNet6, GraphQL, HttpMessageHandler, IDbCommand, MongoDb, NpgsqlCommand, OpenTracing, ServiceStackRedis, SqlCommand, StackExchangeRedis, Wcf, WebRequest |  |
+| `OTEL_DISABLED_INTEGRATIONS` | The integrations you want to disable, if any, separated by a comma. These are the supported integrations: AspNetMvc, AspNetWebApi2, DbCommand, ElasticsearchNet5, ElasticsearchNet6, GraphQL, HttpMessageHandler, IDbCommand, MongoDb, NpgsqlCommand, OpenTracing, ServiceStackRedis, SqlCommand, StackExchangeRedis, Wcf, WebRequest |  |
 | `OTEL_CONVENTION` | Sets the semantic and trace id conventions for the tracer. Available values are: `Datadog` (64bit trace id), `OpenTelemetry` (128 bit trace id). |  `Datadog` |
-| `OTEL_PROPAGATORS` | Semicolon separated list of the propagators for the tracer. Available propagators are: `Datadog`, `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `Datadog` |
+| `OTEL_PROPAGATORS` | Comma separated list of the propagators for the tracer. Available propagators are: `Datadog`, `B3`, `W3C`. The Tracer will try to execute extraction in the given order. | `Datadog` |
 | `OTEL_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` |  Sets whether to intercept method calls when the caller method is inside a domain-neutral assembly. This is recommended when instrumenting IIS applications. | `false` |
-| `OTEL_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |  |
-| `OTEL_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with semi-colons, for example: `MyApp.exe;dotnet.exe` |  |
+| `OTEL_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
+| `OTEL_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 
 
 ### Linux

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -14,8 +14,8 @@ const WSTRING tracing_enabled = WStr("OTEL_TRACE_ENABLED");
 const WSTRING debug_enabled = WStr("OTEL_TRACE_DEBUG");
 
 // Sets the paths to integration definition JSON files.
-// Supports multiple values separated with semi-colons, for example:
-// "C:\Program Files\OpenTelemetry .NET AutoInstrumentation\integrations.json;D:\temp\test_integrations.json"
+// Supports multiple values separated with comma, for example:
+// "C:\Program Files\OpenTelemetry .NET AutoInstrumentation\integrations.json,D:\temp\test_integrations.json"
 const WSTRING integrations_path = WStr("OTEL_INTEGRATIONS");
 
 // Sets the path to the profiler's home directory, for example:
@@ -24,14 +24,14 @@ const WSTRING profiler_home_path = WStr("OTEL_DOTNET_TRACER_HOME");
 
 // Sets the filename of executables the profiler can attach to.
 // If not defined (default), the profiler will attach to any process.
-// Supports multiple values separated with semi-colons, for example:
-// "MyApp.exe;dotnet.exe"
+// Supports multiple values separated with comma, for example:
+// "MyApp.exe,dotnet.exe"
 const WSTRING include_process_names = WStr("OTEL_PROFILER_PROCESSES");
 
 // Sets the filename of executables the profiler cannot attach to.
 // If not defined (default), the profiler will attach to any process.
-// Supports multiple values separated with semi-colons, for example:
-// "MyApp.exe;dotnet.exe"
+// Supports multiple values separated with comma, for example:
+// "MyApp.exe,dotnet.exe"
 const WSTRING exclude_process_names = WStr("OTEL_PROFILER_EXCLUDE_PROCESSES");
 
 // Sets the Agent's host. Default is localhost.
@@ -53,8 +53,8 @@ const WSTRING service_version = WStr("OTEL_VERSION");
 
 // Sets a list of integrations to disable. All other integrations will remain
 // enabled. If not set (default), all integrations are enabled. Supports
-// multiple values separated with semi-colons, for example:
-// "ElasticsearchNet;AspNetWebApi2"
+// multiple values separated with comma, for example:
+// "ElasticsearchNet,AspNetWebApi2"
 const WSTRING disabled_integrations = WStr("OTEL_DISABLED_INTEGRATIONS");
 
 // Sets the path for the profiler's log file.

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -79,7 +79,7 @@ std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name,
 }
 
 std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name) {
-  return GetEnvironmentValues(name, L';');
+  return GetEnvironmentValues(name, L',');
 }
 
 constexpr char HexMap[] = {'0', '1', '2', '3', '4', '5', '6', '7',

--- a/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -32,7 +32,7 @@ WSTRING GetEnvironmentValue(const WSTRING &name);
 std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name,
                                           const wchar_t delim);
 
-// GetEnvironmentValues calls GetEnvironmentValues with a semicolon delimiter.
+// GetEnvironmentValues calls GetEnvironmentValues with a comma delimiter.
 std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name);
 
 // Convert Hex to string

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key for a list of integrations to disable. All other integrations remain enabled.
         /// Default is empty (all integrations are enabled).
-        /// Supports multiple values separated with semi-colons.
+        /// Supports multiple values separated with comma.
         /// </summary>
         /// <seealso cref="TracerSettings.DisabledIntegrationNames"/>
         public const string DisabledIntegrations = "OTEL_DISABLED_INTEGRATIONS";
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key for a list of AdoNet types that will be excluded from automatic instrumentation.
         /// Default is empty (all AdoNet types are included in automatic instrumentation).
-        /// Supports multiple values separated with semi-colons.
+        /// Supports multiple values separated with comma.
         /// </summary>
         /// <seealso cref="TracerSettings.AdoNetExcludedTypes"/>
         public const string AdoNetExcludedTypes = "OTEL_TRACE_ADONET_EXCLUDED_TYPES";
@@ -171,7 +171,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Configuration key for setting custom sampling rules based on regular expressions.
-        /// Semi-colon separated list of sampling rules.
+        /// Comma separated list of sampling rules.
         /// The rule is matched in order of specification. The first match in a list is used.
         ///
         /// Per entry:
@@ -191,7 +191,7 @@ namespace Datadog.Trace.Configuration
         /// To give a rate of 10% to all traces
         ///   '[{"sample_rate":0.1}]'
         ///
-        /// To configure multiple rules, separate by semi-colon and order from most specific to least specific:
+        /// To configure multiple rules, separate by comma and order from most specific to least specific:
         ///   '[{"sample_rate":0.5, "service":"cart.*"}, {"sample_rate":0.2, "name":"http.request"}, {"sample_rate":1.0, "service":"background", "name":"sql.query"}, {"sample_rate":0.1}]'
         ///
         /// If no rules are specified, or none match, default internal sampling logic will be used.
@@ -296,7 +296,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key for the propagators to be used.
         /// Default is <c>Datadog</c>.
-        /// Supports multiple values separated with semi-colons.
+        /// Supports multiple values separated with comma.
         /// <seealso cref="TracerSettings.Propagators"/>
         /// </summary>
         public const string Propagators = "OTEL_PROPAGATORS";

--- a/src/Datadog.Trace/Configuration/ConfigurationSourceExtensions.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationSourceExtensions.cs
@@ -6,7 +6,7 @@ namespace Datadog.Trace.Configuration
 {
     internal static class ConfigurationSourceExtensions
     {
-        private const char Separator = ';';
+        private const char Separator = ',';
 
         public static IEnumerable<string> GetStrings(this IConfigurationSource source, string key)
         {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "fake";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "Samples.FakeDbCommand.FakeCommand;System.Data.Common.DbCommand;System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "Samples.FakeDbCommand.FakeCommand,System.Data.Common.DbCommand,System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");
 
             string packageVersion = PackageVersions.MicrosoftDataSqlClient.First()[0] as string;
             int agentPort = TcpPortProvider.GetOpenPort();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NET452
+#if !NET452
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Core.Tools;
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SQLite.SQLiteCommand;Microsoft.Data.Sqlite.SqliteCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SQLite.SQLiteCommand,Microsoft.Data.Sqlite.SqliteCommand");
 
             string packageVersion = PackageVersions.MicrosoftDataSqlite.First()[0] as string;
             int agentPort = TcpPortProvider.GetOpenPort();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "mysql";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");
 
             string packageVersion = PackageVersions.Npgsql.First()[0] as string;
             int agentPort = TcpPortProvider.GetOpenPort();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -113,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,Microsoft.Data.SqlClient.SqlCommand,MySql.Data.MySqlClient.MySqlCommand,Npgsql.NpgsqlCommand");
 
             string packageVersion = PackageVersions.SystemDataSqlClient.First()[0] as string;
             int agentPort = TcpPortProvider.GetOpenPort();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NET452
+#if !NET452
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Core.Tools;
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
 
-            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SQLite.SQLiteCommand;Microsoft.Data.Sqlite.SqliteCommand");
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SQLite.SQLiteCommand,Microsoft.Data.Sqlite.SqliteCommand");
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public HttpMessageHandlerTests(ITestOutputHelper output)
             : base("HttpMessageHandler", output)
         {
-            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog;b3");
+            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog,b3");
             SetEnvironmentVariable("OTEL_HTTP_CLIENT_ERROR_STATUSES", "400-499, 502,-343,11-53, 500-500-200");
             SetServiceVersion("1.0.0");
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("WebRequest", output)
         {
             SetEnvironmentVariable("OTEL_TRACE_SERVICE_MAPPING", "some-trace:not-used,http-client:my-custom-client");
-            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog;b3");
+            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog,b3");
             SetServiceVersion("1.0.0");
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("WebRequest.NetFramework20", output)
         {
             SetServiceVersion("1.0.0");
-            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog;b3");
+            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog,b3");
         }
 
         [Theory]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("WebRequest", output)
         {
             SetServiceVersion("1.0.0");
-            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog;b3");
+            SetEnvironmentVariable("OTEL_PROPAGATORS", "datadog,b3");
         }
 
         [Theory]

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
@@ -189,7 +189,7 @@ TEST(IntegrationLoaderTest, LoadsFromEnvironment) {
     )TEXT";
   f.close();
 
-  auto name = tmpname1.wstring() + L";" + tmpname2.wstring();
+  auto name = tmpname1.wstring() + L"," + tmpname2.wstring();
 
   SetEnvironmentVariableW(trace::environment::integrations_path.data(), name.data());
 

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceExtensionsTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             yield return new object[] { new NameValueCollection { { "example1", "value1" } }, "example2", ArrayHelper.Empty<TestEnum>() };
             yield return new object[] { new NameValueCollection { { "example1", "value1" } }, "example1", ArrayHelper.Empty<TestEnum>() };
-            yield return new object[] { new NameValueCollection { { "example1", "TestValue2;TestValue3;;" } }, "example1", new[] { TestEnum.TestValue2, TestEnum.TestValue3 } };
+            yield return new object[] { new NameValueCollection { { "example1", "TestValue2,TestValue3,," } }, "example1", new[] { TestEnum.TestValue2, TestEnum.TestValue3 } };
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             var collection = new NameValueCollection
             {
-                { "example1", "value1;value2;;" }
+                { "example1", "value1,value2,," }
             };
             var cs = new NameValueConfigurationSource(collection);
             var result = ConfigurationSourceExtensions.GetStrings(cs, "example1");

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -75,9 +75,9 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.ServiceName, "web-service", CreateFunc(s => s.ServiceName), "web-service" };
             yield return new object[] { "OTEL_SERVICE_NAME", "web-service", CreateFunc(s => s.ServiceName), "web-service" };
 
-            yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1;integration2;;INTEGRATION2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
+            yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1,integration2,,INTEGRATION2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
 
-            yield return new object[] { ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand;SYSTEM.DATA.SQLCLIENT.SQLCOMMAND;;System.Data.SqlClient.SqlConnection", CreateFunc(s => s.AdoNetExcludedTypes.Count), 2 };
+            yield return new object[] { ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand,SYSTEM.DATA.SQLCLIENT.SQLCOMMAND,,System.Data.SqlClient.SqlConnection", CreateFunc(s => s.AdoNetExcludedTypes.Count), 2 };
 
             yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags), TagsK1V1K2V2 };
             yield return new object[] { ConfigurationKeys.GlobalTags, "keyonly:,nocolon,:,:valueonly,k2:v2", CreateFunc(s => s.GlobalTags), TagsK2V2 };

--- a/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
@@ -13,7 +13,7 @@
   
           "OTEL_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
           "OTEL_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
-          "OTEL_PROPAGATORS": "datadog;b3"
+          "OTEL_PROPAGATORS": "datadog,b3"
         },
         "nativeDebugging": true
       }


### PR DESCRIPTION
### Background
Regarding to the OTel compliance issue (https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/154).
Change separator `;` to `,`.