### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       - "area:vendors"
     ignore:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
+    open-pull-requests-limit: 0 # disable version updates
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace"
@@ -32,6 +33,7 @@ updates:
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
       ### End Datadog.Trace.csproj ignored dependencies
+    open-pull-requests-limit: 0 # disable version updates
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.ClrProfiler.Managed"
     schedule:
@@ -53,6 +55,7 @@ updates:
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
       ### End Datadog.Trace.csproj ignored dependencies
+    open-pull-requests-limit: 0 # disable version updates
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.OpenTracing"
     schedule:
@@ -74,6 +77,7 @@ updates:
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
       ### End Datadog.Trace.csproj ignored dependencies
+    open-pull-requests-limit: 0 # disable version updates
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.BenchmarkDotNet"
     schedule:
@@ -95,3 +99,4 @@ updates:
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
       ### End Datadog.Trace.csproj ignored dependencies
+    open-pull-requests-limit: 0 # disable version updates


### PR DESCRIPTION
Solves https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/158

Disable depandabot using following approach: https://docs.github.com/en/code-security/supply-chain-security/enabling-and-disabling-version-updates#example-disabling-version-updates-for-some-dependencies
to minimize merge conflicts when pulling changes from upstream

