### PR TITLE
Improve workflow trigger for Build artifacts

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,5 +1,10 @@
 name: Build artifacts
-on: [ push, pull_request ]
+on: 
+  push: 
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   alpine_build:


### PR DESCRIPTION
## Why

Currently, the artifacts are built twice in PRs.
Let's get rid of the noise and reduce the wasteful energy consumption 😉 
Example: 
![image](https://user-images.githubusercontent.com/5067549/116457926-4a333d00-a864-11eb-9dc9-97c9617362c1.png)

I am fixing it as it was clearly my fault. See: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/134#discussion_r620978174

Unfortunately I have not found any easy fix for it: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662

I was experimenting on my toy projects/organizations...

## What

Run the workflow for:
- main branch
- pull requests targeting the main branch
- on-demand: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
(can be used if someone does not want to create a PR)

## Testing

You can see that even on this PR we have only the `pull_request` trigger