### PR TITLE
Add Security Scan: CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,39 @@
+name: "CodeQL Analysis"
+on:
+  workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 1 * * *'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['csharp']
+        
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
# Motivation
This PR is a follow-up to issue open-telemetry/oteps#144

[CodeQL](https://github.com/github/codeql-action) is GitHub's static analysis engine which scans repos for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities to ensure that every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users.

## Changes
-  This PR adds [CodeQL](https://github.com/github/codeql-action) security checks to the repository
- After every run the workflow will upload the results to GitHub. 

[Current CodeQL run from fork](https://github.com/open-o11y/opentelemetry-dotnet-instrumentation/runs/2633035117?check_suite_focus=true)

#### Workflow Triggers
- daily cron job at 1:30 am
- workflow_dispatch (in the case that the maintainers want to trigger a manual security check)