### PR TITLE
Add GH job for MacOS

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,47 +6,21 @@ on:
       - 'v*.*.*'
   pull_request:
   workflow_dispatch:
-
 jobs:
-
-  macos:
-    name: MacOS Build
-    runs-on: macos-10.15
+  build:
+    strategy:
+      matrix:
+        os: [ windows-2019, ubuntu-20.04, macos-10.15 ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - uses: microsoft/setup-msbuild@v1.0.2
+      if: ${{ runner.os == 'Windows' }}
     - run: brew install make
-    - run: ./build/docker/build.sh
+      if: ${{ runner.os == 'macOS' }}
+    - name: Build Managed and Native
       env:
         buildConfiguration: Release
-    - run: ./build/docker/Datadog.Trace.ClrProfiler.Native.sh
-      env:
-        buildConfiguration: Release
-
-  linux:
-    name: Linux Build
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - run: ./build/docker/build.sh
-      env:
-        buildConfiguration: Release
-    - run: ./build/docker/Datadog.Trace.ClrProfiler.Native.sh
-      env:
-        buildConfiguration: Release
-
-  windows:
-    name: Windows Build
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - uses: microsoft/setup-msbuild@v1.0.2
-      - run: dotnet build -c %buildConfiguration% src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-        shell: cmd
-        env:
-          buildConfiguration: Release
-      - run: nuget restore src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.vcxproj -SolutionDirectory .
-        shell: cmd
-      - run: msbuild.exe Datadog.Trace.proj -t:BuildCpp -p:Configuration=%buildConfiguration% -p:Platform=x64
-        shell: cmd
-        env:
-          buildConfiguration: Release
+      run: |
+        ./build/docker/build.sh
+        ./build/docker/Datadog.Trace.ClrProfiler.Native.sh

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,3 +1,4 @@
+name: workflow
 on: 
   push: 
     branches: [ poc-otel-sdk ]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,16 +1,28 @@
-name: Build artifacts
+name: Build
 on: 
   push: 
     branches: [ poc-otel-sdk ]
     tags:
       - 'v*.*.*'
   pull_request:
-    branches: [ poc-otel-sdk ]
   workflow_dispatch:
 
 jobs:
 
-  linux_build:
+  macos:
+    name: MacOS Build
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+    - run: brew install make
+    - run: ./build/docker/build.sh
+      env:
+        buildConfiguration: Release
+    - run: ./build/docker/Datadog.Trace.ClrProfiler.Native.sh
+      env:
+        buildConfiguration: Release
+
+  linux:
     name: Linux Build
     runs-on: ubuntu-20.04
     steps:
@@ -22,7 +34,7 @@ jobs:
       env:
         buildConfiguration: Release
 
-  windows_build:
+  windows:
     name: Windows Build
     runs-on: windows-2019
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,3 @@
-name: Build
 on: 
   push: 
     branches: [ poc-otel-sdk ]
@@ -7,7 +6,7 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  build:
+  ci:
     strategy:
       matrix:
         os: [ windows-2019, ubuntu-20.04, macos-10.15 ]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Build Managed and Native
       env:
         buildConfiguration: Release
+      shell: bash
       run: |
         ./build/docker/build.sh
         ./build/docker/Datadog.Trace.ClrProfiler.Native.sh


### PR DESCRIPTION
## Why

A proper CI pipeline is always handy.

## What

- Add build for MacOS
- Unify the build for all OSes

