### PR TITLE
PoC: tiny: improve wait-for-port in Windows

### DIFF
--- a/dev/wait-local-port.sh
+++ b/dev/wait-local-port.sh
@@ -14,7 +14,7 @@ uname_os() {
 port=$1
 
 serverPort() {
-  netstat -ano | grep $port
+  netstat -ano | grep 127.0.0.1:$port
 }
 
 waitForServer() {


### PR DESCRIPTION
Just to make it a bit more reliable.
