### PR TITLE
Add `OTEL_DOTNET_TRACER_FORCE` env var

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -48,7 +48,7 @@ Use these environment variables to configure the tracing library:
 | `OTEL_SERVICE` | Application's default service name. |  |
 | `OTEL_ENV` | The value for the `environment` tag added to every span. |  |
 | `OTEL_TRACE_ENABLED` | Enable to activate the tracer. | `true` |
-| `OTEL_DOTNET_TRACER_FORCE` | Enable the tracer even of no integrations is set using `OTEL_INTEGRATIONS`. | `true` |
+| `OTEL_DOTNET_TRACER_FORCE` | Enable the tracer even if no integrations is set using `OTEL_INTEGRATIONS`. | `true` |
 | `OTEL_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` |
 | `OTEL_TRACE_AGENT_URL` | The URL to where send the traces for `Zipkin` and `DatadogAgent` exporters (see: `OTEL_EXPORTER`). | `http://localhost:8126` |
 | `OTEL_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |  |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -47,9 +47,10 @@ Use these environment variables to configure the tracing library:
 | `OTEL_TRACE_PARTIAL_FLUSH_MIN_SPANS` | The minimum number of closed spans in a trace before it's partially flushed. `OTEL_TRACE_PARTIAL_FLUSH_ENABLED` has to be enabled for this to take effect. | `500` |
 | `OTEL_SERVICE` | Application's default service name. |  |
 | `OTEL_ENV` | The value for the `environment` tag added to every span. |  |
-| `OTEL_TRACE_ENABLED` | Enable to activate the tracer. | `true` | 
-| `OTEL_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` | 
-| `OTEL_TRACE_AGENT_URL` | The URL to where send the traces for `Zipkin` and `DatadogAgent` exporters (see: `OTEL_EXPORTER`). | `http://localhost:8126` | 
+| `OTEL_TRACE_ENABLED` | Enable to activate the tracer. | `true` |
+| `OTEL_DOTNET_TRACER_FORCE` | Enable the tracer even of no integrations is set using `OTEL_INTEGRATIONS`. | `true` |
+| `OTEL_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` |
+| `OTEL_TRACE_AGENT_URL` | The URL to where send the traces for `Zipkin` and `DatadogAgent` exporters (see: `OTEL_EXPORTER`). | `http://localhost:8126` |
 | `OTEL_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |  |
 | `OTEL_LOGS_INJECTION` | Enable to inject trace IDs, span IDs, service name and environment into logs. This requires a compatible logger or manual configuration. | `false` | `OTEL_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `DatadogAgent`, `Zipkin`, `Jeager`. | `DatadogAgent` |
 | `OTEL_MAX_LOGFILE_SIZE` | The maximum size for tracer log files, in bytes. | `10 MB` |

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -439,7 +439,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   std::vector<IntegrationMethod> filtered_integrations = IsCallTargetEnabled() ?
       integration_methods_ : FilterIntegrationsByCaller(integration_methods_, module_info.assembly);
 
-  if (filtered_integrations.empty()) {
+  if (!IsTracingForced() && filtered_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it
     Debug("ModuleLoadFinished skipping module (filtered by caller): ", module_id, " ", module_info.assembly.name);
     return S_OK;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -687,8 +687,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
 
     first_jit_compilation_app_domains.insert(module_metadata->app_domain_id);
 
-    hr = RunILStartupHook(module_metadata->metadata_emit, module_id,
-                          function_token);
+    hr = RunILStartupHook(module_id, function_token);
 
     if (FAILED(hr)) {
       Warn("JITCompilationStarted: Call to RunILStartupHook() failed for ", module_id, " ", function_token);
@@ -1654,9 +1653,7 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
 //
 // Startup methods
 //
-HRESULT CorProfiler::RunILStartupHook(
-    const ComPtr<IMetaDataEmit2>& metadata_emit, const ModuleID module_id,
-    const mdToken function_token) {
+HRESULT CorProfiler::RunILStartupHook(const ModuleID module_id, const mdToken function_token) {
   mdMethodDef ret_method_token;
   auto hr = GenerateVoidILStartupMethod(module_id, &ret_method_token);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -117,7 +117,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   // get path to integration definition JSON files
   const WSTRING integrations_paths = GetEnvironmentValue(environment::integrations_path);
 
-  if (integrations_paths.empty()) {
+  if (!IsTracingForced() && integrations_paths.empty()) {
     Warn("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", environment::integrations_path,
          " environment variable not set.");
     return E_FAIL;
@@ -150,8 +150,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   integration_methods_ =
       FlattenIntegrations(integrations, is_calltarget_enabled);
 
-    // check if there are any enabled integrations left
-  if (integration_methods_.empty()) {
+  // check if there are any enabled integrations left
+  if (!IsTracingForced() && integration_methods_.empty()) {
     Warn("DATADOG TRACER DIAGNOSTICS - Profiler disabled: no enabled integrations found.");
     return E_FAIL;
   } else {

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -83,9 +83,8 @@ class CorProfiler : public CorProfilerBase {
   //
   // Startup methods
   //
-  HRESULT RunILStartupHook(const ComPtr<IMetaDataEmit2>&,
-                             const ModuleID module_id,
-                             const mdToken function_token);
+  HRESULT RunILStartupHook(const ModuleID module_id,
+                           const mdToken function_token);
   HRESULT GenerateVoidILStartupMethod(const ModuleID module_id,
                            mdMethodDef* ret_method_token);
   HRESULT AddIISPreStartInitFlags(const ModuleID module_id,

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -10,6 +10,7 @@ namespace trace {
 
   inline WSTRING env_vars_to_display[]{
     environment::tracing_enabled,
+    environment::tracing_force,
     environment::debug_enabled,
     environment::calltarget_enabled,
     environment::profiler_home_path,

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -13,6 +13,11 @@ const WSTRING tracing_enabled = WStr("OTEL_TRACE_ENABLED");
 // Sets whether debug mode is enabled. Default is false.
 const WSTRING debug_enabled = WStr("OTEL_TRACE_DEBUG");
 
+// Sets whether we force the instrumentation
+// even if nothing is supposed to be instrumented according to integration definition JSON files.
+// Default is true.
+const WSTRING tracing_force = WStr("OTEL_DOTNET_TRACER_FORCE");
+
 // Sets the paths to integration definition JSON files.
 // Supports multiple values separated with comma, for example:
 // "C:\Program Files\OpenTelemetry .NET AutoInstrumentation\integrations.json,D:\temp\test_integrations.json"

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
@@ -62,6 +62,11 @@ bool IsTracingDisabled() {
   CheckIfFalse(GetEnvironmentValue(environment::tracing_enabled));
 }
 
+bool IsTracingForced() {
+  ToBooleanWithDefault(GetEnvironmentValue(environment::tracing_force),
+    true);
+}
+
 bool IsAzureAppServices() {
   CheckIfTrue(GetEnvironmentValue(environment::azure_app_services));
 }


### PR DESCRIPTION
Adds `OTEL_DOTNET_TRACER_FORCE` (enabled by default) so that the .NET Profiler invokes `RunILStartupHook` during the first "acceptable" JIT compilation.

It is a hacky/dirty implementation. Just to make it work. I am open to suggestions on how to improve it.