### PR TITLE
PoC: Add support to testing OpenTracing integration

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -49,9 +49,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{BAF8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "samples\ConsoleApp\ConsoleApp.csproj", "{2A172931-3439-4563-A6E5-525924DC2F76}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed", "src\OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed\OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.csproj", "{6690361C-CCD8-42C4-A5CF-82D554B03A3D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed", "src\OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed\OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.csproj", "{6690361C-CCD8-42C4-A5CF-82D554B03A3D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp.SelfBootstrap", "samples\ConsoleApp.SelfBootstrap\ConsoleApp.SelfBootstrap.csproj", "{7EA51D34-8E0E-4548-8A7F-5C6F9C3533AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp.SelfBootstrap", "samples\ConsoleApp.SelfBootstrap\ConsoleApp.SelfBootstrap.csproj", "{7EA51D34-8E0E-4548-8A7F-5C6F9C3533AF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTracingLibrary", "samples\OpenTracingLibrary\OpenTracingLibrary.csproj", "{7220BDBB-084D-40B3-A710-19E3C7147185}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -155,6 +157,18 @@ Global
 		{7EA51D34-8E0E-4548-8A7F-5C6F9C3533AF}.Release|x64.Build.0 = Release|Any CPU
 		{7EA51D34-8E0E-4548-8A7F-5C6F9C3533AF}.Release|x86.ActiveCfg = Release|Any CPU
 		{7EA51D34-8E0E-4548-8A7F-5C6F9C3533AF}.Release|x86.Build.0 = Release|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Debug|x64.Build.0 = Debug|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Debug|x86.Build.0 = Debug|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Release|x64.ActiveCfg = Release|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Release|x64.Build.0 = Release|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Release|x86.ActiveCfg = Release|Any CPU
+		{7220BDBB-084D-40B3-A710-19E3C7147185}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -168,6 +182,7 @@ Global
 		{2A172931-3439-4563-A6E5-525924DC2F76} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{6690361C-CCD8-42C4-A5CF-82D554B03A3D} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{7EA51D34-8E0E-4548-8A7F-5C6F9C3533AF} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{7220BDBB-084D-40B3-A710-19E3C7147185} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/poc.sh
+++ b/poc.sh
@@ -6,7 +6,7 @@ cd $DIR
 
 aspNetAppTargetFramework=${aspNetAppTargetFramework:-netcoreapp3.1}
 consoleAppTargetFramework=${consoleAppTargetFramework:-netcoreapp3.1}
-OpenTracingWrapper=${OpenTracingWrapper:-false}
+openTracingWrapper=${openTracingWrapper:-false}
 
 function finish {
   docker stop jaeger # stop Jaeger

--- a/poc.sh
+++ b/poc.sh
@@ -6,6 +6,7 @@ cd $DIR
 
 aspNetAppTargetFramework=${aspNetAppTargetFramework:-netcoreapp3.1}
 consoleAppTargetFramework=${consoleAppTargetFramework:-netcoreapp3.1}
+OpenTracingWrapper=${OpenTracingWrapper:-false}
 
 function finish {
   docker stop jaeger # stop Jaeger

--- a/poc.sh
+++ b/poc.sh
@@ -6,7 +6,6 @@ cd $DIR
 
 aspNetAppTargetFramework=${aspNetAppTargetFramework:-netcoreapp3.1}
 consoleAppTargetFramework=${consoleAppTargetFramework:-netcoreapp3.1}
-openTracingWrapper=${openTracingWrapper:-false}
 
 function finish {
   docker stop jaeger # stop Jaeger

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net452;net46;net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <DefineConstants Condition="'$(OpenTracingWrapper)' == 'true'">$(DefinedConstants);OpenTracingWrapper</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
@@ -11,6 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(OpenTracingWrapper)' == 'true'">
+    <ProjectReference Include="..\OpenTracingLibrary\OpenTracingLibrary.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net452;net46;net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <DefineConstants Condition="'$(openTracingWrapper)' == 'true'">$(DefinedConstants);openTracingWrapper</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
@@ -14,7 +13,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(openTracingWrapper)' == 'true'">
+  <ItemGroup>
     <ProjectReference Include="..\OpenTracingLibrary\OpenTracingLibrary.csproj" />
   </ItemGroup>
 

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net452;net46;net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <DefineConstants Condition="'$(OpenTracingWrapper)' == 'true'">$(DefinedConstants);OpenTracingWrapper</DefineConstants>
+    <DefineConstants Condition="'$(openTracingWrapper)' == 'true'">$(DefinedConstants);openTracingWrapper</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
@@ -14,7 +14,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OpenTracingWrapper)' == 'true'">
+  <ItemGroup Condition="'$(openTracingWrapper)' == 'true'">
     <ProjectReference Include="..\OpenTracingLibrary\OpenTracingLibrary.csproj" />
   </ItemGroup>
 

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -13,7 +13,7 @@ namespace ConsoleApp
         {
             using (var activity = MyActivitySource.StartActivity("Main"))
             {
-#if OpenTracingWrapper
+#if openTracingWrapper
                 await OpenTracingLibrary.Wrapper.WithOpenTracingSpanAsync("client", RunAsync);
 #else
                 await RunAsync();

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -13,11 +13,7 @@ namespace ConsoleApp
         {
             using (var activity = MyActivitySource.StartActivity("Main"))
             {
-#if openTracingWrapper
                 await OpenTracingLibrary.Wrapper.WithOpenTracingSpanAsync("client", RunAsync);
-#else
-                await RunAsync();
-#endif
             }
 
             return 0;

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -14,18 +14,18 @@ namespace ConsoleApp
             using (var activity = MyActivitySource.StartActivity("Main"))
             {
 #if OpenTracingWrapper
-                OpenTracingLibrary.Wrapper.WithOpenTracingSpan("client", async () => await Run());
+                await OpenTracingLibrary.Wrapper.WithOpenTracingSpanAsync("client", RunAsync);
 #else
-                await Run();
+                await RunAsync();
 #endif
             }
 
             return 0;
         }
 
-        private static async Task Run()
+        private static async Task RunAsync()
         {
-            using (var activity = MyActivitySource.StartActivity("Run"))
+            using (var activity = MyActivitySource.StartActivity("RunAsync"))
             {
                 activity?.SetTag("foo", "bar");
 

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -13,6 +13,20 @@ namespace ConsoleApp
         {
             using (var activity = MyActivitySource.StartActivity("Main"))
             {
+#if OpenTracingWrapper
+                OpenTracingLibrary.Wrapper.WithOpenTracingSpan("client", async () => await Run());
+#else
+                await Run();
+#endif
+            }
+
+            return 0;
+        }
+
+        private static async Task Run()
+        {
+            using (var activity = MyActivitySource.StartActivity("Run"))
+            {
                 activity?.SetTag("foo", "bar");
 
                 var baseAddress = new Uri("https://www.example.com/");
@@ -24,10 +38,8 @@ namespace ConsoleApp
 
                 var client = new HttpClient();
                 Console.WriteLine("Calling client.GetAsync");
-                await regularHttpClient.GetAsync("http://127.0.0.1:8080");
+                await client.GetAsync("http://127.0.0.1:8080");
                 Console.WriteLine("Called client.GetAsync");
-
-                return 0;
             }
         }
     }

--- a/samples/OpenTracingLibrary/OpenTracingLibrary.csproj
+++ b/samples/OpenTracingLibrary/OpenTracingLibrary.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;net462;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTracing" Version="0.12.1" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OpenTracingLibrary/Wrapper.cs
+++ b/samples/OpenTracingLibrary/Wrapper.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using OpenTracing.Util;
 
 namespace OpenTracingLibrary
 {
     public static class Wrapper
     {
-        public static void WithOpenTracingSpan(string spanKind, Action action)
+        public static async Task WithOpenTracingSpanAsync(string spanKind, Func<Task> wrapped)
         {
             var tracer = GlobalTracer.Instance;
             Console.WriteLine($">>>>>>>>>>>>>>>>>>>>>>> OpenTracing.{tracer}");
@@ -16,7 +17,7 @@ namespace OpenTracingLibrary
             {
                 try
                 {
-                    action();
+                    await wrapped();
                     scope.Span.Log("action success");
                     scope.Span.SetTag("action.success", true);
                 }

--- a/samples/OpenTracingLibrary/Wrapper.cs
+++ b/samples/OpenTracingLibrary/Wrapper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenTracing.Util;
+
+namespace OpenTracingLibrary
+{
+    public static class Wrapper
+    {
+        public static void WithOpenTracingSpan(string spanKind, Action action)
+        {
+            var tracer = GlobalTracer.Instance;
+            Console.WriteLine($">>>>>>>>>>>>>>>>>>>>>>> OpenTracing.{tracer}");
+            using (var scope = tracer.BuildSpan("OpenTracing Span")
+                .WithTag("span.kind", spanKind)
+                .StartActive())
+            {
+                try
+                {
+                    action();
+                    scope.Span.Log("action success");
+                    scope.Span.SetTag("action.success", true);
+                }
+                catch (Exception ex)
+                {
+                    scope.Span.SetTag("error", true);
+                    var eventData = new Dictionary<string, object>
+                    {
+                        { "event", "error" },
+                        { "error.kind", "Exception" },
+                        { "error.object", ex },
+                        { "stack", ex.StackTrace.ToString() },
+                    };
+                    scope.Span.Log(eventData);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -28,7 +28,7 @@
     <LIB_PATH>lib\</LIB_PATH>
     <LIB_PLATFORM Condition="'$(Platform)'=='x64'">x64</LIB_PLATFORM>
     <LIB_PLATFORM Condition="'$(Platform)'=='Win32' OR '$(Platform)'=='x86'">x86</LIB_PLATFORM>
-    <LIB_INCLUDES>$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\include;$(LIB_PATH)spdlog\include</LIB_INCLUDES>
+    <LIB_INCLUDES>$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\include;$(LIB_PATH)spdlog\include</LIB_INCLUDES>
     <LIB_BINARIES Condition="'$(Configuration)'=='Release'">$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\lib\fmt.lib</LIB_BINARIES>
     <LIB_BINARIES Condition="'$(Configuration)'=='Debug'">$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\debug\lib\fmtd.lib</LIB_BINARIES>
   </PropertyGroup>
@@ -69,25 +69,21 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>bin\$(Configuration)\$(Platform)\static\</OutDir>
     <IntDir>obj\$(Configuration)\$(Platform)\static\</IntDir>
-    <IncludePath>$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>bin\$(Configuration)\x86\static\</OutDir>
     <IntDir>obj\$(Configuration)\x86\static\</IntDir>
-    <IncludePath>$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>bin\$(Configuration)\$(Platform)\static\</OutDir>
     <IntDir>obj\$(Configuration)\$(Platform)\static\</IntDir>
-    <IncludePath>$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>bin\$(Configuration)\x86\static\</OutDir>
     <IntDir>obj\$(Configuration)\x86\static\</IntDir>
-    <IncludePath>$(CORECLR_PATH)\src\pal\prebuilt\inc;$(CORECLR_PATH)\src\inc;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/Instrumentation.cs
@@ -2,6 +2,8 @@
 using System.Diagnostics;
 using System.Threading;
 using OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.Configuration;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Shims.OpenTracing;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed
@@ -11,17 +13,17 @@ namespace OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed
     /// </summary>
     public static class Instrumentation
     {
+        private static readonly Process _process = Process.GetCurrentProcess();
         private static int _firstInitialization = 1;
 
         private static TracerProvider _tracerProvider;
 
         /// <summary>
-        /// Initialize
+        /// Initialize the OpenTelemetry SDK with a pre-defined set of exporters, shims, and
+        /// instrumentations.
         /// </summary>
         public static void Initialize()
         {
-            var p = Process.GetCurrentProcess();
-            Console.WriteLine($">>>>>>>>>>>>>>>>>>>>>>> Process: {p.ProcessName}({p.Id}), starting");
             if (Interlocked.Exchange(ref _firstInitialization, value: 0) != 1)
             {
                 // Initialize() was already called before
@@ -43,14 +45,38 @@ namespace OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed
                         .AddSource("OpenTelemetry.AutoInstrumentation.*");
 
                     _tracerProvider = builder.Build();
-                    Console.WriteLine($">>>>>>>>>>>>>>>>>>>>>>> Process: {p.ProcessName}({p.Id}), initialized");
+                    Log("OpenTelemetry SDK loaded.");
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // TODO: Should we have our own logger like datadog has?
+                Log($"OpenTelemetry SDK load exception: {ex}");
                 throw;
             }
+
+            try
+            {
+                // Instantiate the OpenTracing shim. The underlying OpenTelemetry tracer will create
+                // spans using the "OpenTelemetry.AutoInstrumentation.OpenTracingShim" source.
+                var openTracingShim = new TracerShim(
+                    _tracerProvider.GetTracer("OpenTelemetry.AutoInstrumentation.OpenTracingShim"),
+                    Propagators.DefaultTextMapPropagator);
+
+                // This registration must occur prior to any reference to the OpenTracing tracer:
+                // otherwise the no-op tracer is going to be used by OpenTracing instead.
+                OpenTracing.Util.GlobalTracer.Register(openTracingShim);
+                Log("OpenTracingShim loaded.");
+            }
+            catch (Exception ex)
+            {
+                Log($"OpenTracingShim exception: {ex}");
+                throw;
+            }
+        }
+
+        private static void Log(string message)
+        {
+            Console.WriteLine($">>>>>>>>>>>>>>>>>>>>>>> Process: {_process.ProcessName}({_process.Id}): {message}");
         }
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/Instrumentation.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed
                         .AddSource("OpenTelemetry.AutoInstrumentation.*");
 
                     _tracerProvider = builder.Build();
-                    Log("OpenTelemetry SDK loaded.");
+                    Log("OpenTelemetry tracer initialized.");
                 }
             }
             catch (Exception ex)

--- a/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc4" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.0-rc4" Condition="'$(TargetFramework)' != 'net452'" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.0.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc3" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Added another env var to the PoC script, `openTracingWrapper` to test the integration with `OpenTelemetry.Shims.OpenTracing`. This adds an extra span to have the extra layer in between but I think give better visibility and covers the cases of the OT spans as parent and child.
