### PR TITLE
Add OpenTracing call to sample app for shim verification

### DIFF
--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -45,7 +45,12 @@ namespace ConsoleApp
                 Console.WriteLine("Called client.GetAsync");
             }
             
-            var request = new HttpRequestMessage { RequestUri = new Uri("https://www.example.com/"), Method = HttpMethod.Post, Content = new StringContent(string.Empty, Encoding.UTF8), };
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri("https://www.example.com/"),
+                Method = HttpMethod.Post,
+                Content = new StringContent(string.Empty, Encoding.UTF8),
+            };
 
             var tracer = GlobalTracer.Instance;
             using (var scope = tracer.BuildSpan("Client POST " + request.RequestUri)
@@ -67,18 +72,6 @@ namespace ConsoleApp
                 var responseContent = await response.Content.ReadAsStringAsync();
                 scope.Span.SetTag("response.content", responseContent);
                 scope.Span.SetTag("response.length", responseContent.Length);
-
-                foreach (var header in response.Headers)
-                {
-                    if (header.Value is IEnumerable<object> enumerable)
-                    {
-                        scope.Span.SetTag($"http.header.{header.Key}", string.Join(",", enumerable));
-                    }
-                    else
-                    {
-                        scope.Span.SetTag($"http.header.{header.Key}", header.Value.ToString());
-                    }
-                }
             }
         }
     }

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -70,7 +70,6 @@ namespace ConsoleApp
                 scope.Span.SetTag("http.status_code", (int)response.StatusCode);
 
                 var responseContent = await response.Content.ReadAsStringAsync();
-                scope.Span.SetTag("response.content", responseContent);
                 scope.Span.SetTag("response.length", responseContent.Length);
             }
         }


### PR DESCRIPTION
*What*
Adding manual OpenTracing instrumentation code to sample app.

*Why*
We should still support OpenTracing manual instrumentation.

*Testing*
Testes on Linux poc-otel-sdk branch. The span is there in the correct trace.
<img width="1997" alt="Screenshot 2021-06-11 at 15 32 10" src="https://user-images.githubusercontent.com/77062266/121695584-7aa90080-cacb-11eb-910c-b1749fa6435a.png">
<img width="730" alt="Screenshot 2021-06-11 at 15 33 38" src="https://user-images.githubusercontent.com/77062266/121695644-87c5ef80-cacb-11eb-8953-d2d829e4af89.png">


