### PR TITLE
[PoC] Fix poc script on Linux

### DIFF
--- a/build/nuke/ArtifactNames.cs
+++ b/build/nuke/ArtifactNames.cs
@@ -1,0 +1,4 @@
+public static class ArtifactNames
+{
+    public const string NativeProfiler = "OpenTelemetry.AutoInstrumentation.ClrProfiler.Native";
+}

--- a/build/nuke/Build.Steps.Linux.cs
+++ b/build/nuke/Build.Steps.Linux.cs
@@ -44,7 +44,7 @@ partial class Build
 
             // Copy Native file
             CopyFileToDirectory(
-                NativeProfilerProject.Directory / "build" / "bin" / "OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so",
+                NativeProfilerProject.Directory / "build" / "bin" / $"{ArtifactNames.NativeProfiler}.so",
                 TracerHomeDirectory,
                 FileExistsPolicy.Overwrite);
         });

--- a/build/nuke/Build.Steps.Linux.cs
+++ b/build/nuke/Build.Steps.Linux.cs
@@ -44,7 +44,7 @@ partial class Build
 
             // Copy Native file
             CopyFileToDirectory(
-                NativeProfilerProject.Directory / "build" / "bin" / $"{NativeProfilerProject.Name}.so",
+                NativeProfilerProject.Directory / "build" / "bin" / "OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.so",
                 TracerHomeDirectory,
                 FileExistsPolicy.Overwrite);
         });

--- a/build/nuke/Build.Steps.MacOS.cs
+++ b/build/nuke/Build.Steps.MacOS.cs
@@ -30,7 +30,7 @@ partial class Build
 
             // Create home directory
             CopyFileToDirectory(
-                NativeProfilerProject.Directory / "bin" / $"{NativeProfilerProject.Name}.dylib",
+                NativeProfilerProject.Directory / "bin" / $"{ArtifactNames.NativeProfiler}.dylib",
                 TracerHomeDirectory,
                 FileExistsPolicy.Overwrite);
         });

--- a/build/nuke/Build.Steps.Windows.cs
+++ b/build/nuke/Build.Steps.Windows.cs
@@ -63,7 +63,7 @@ partial class Build
             foreach (var architecture in ArchitecturesForPlatform)
             {
                 var source = NativeProfilerProject.Directory / "bin" / BuildConfiguration / architecture.ToString() /
-                             "OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll";
+                             $"{ArtifactNames.NativeProfiler}.dll";
                 var dest = TracerHomeDirectory / $"win-{architecture}";
 
                 Logger.Info($"Copying '{source}' to '{dest}'");

--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -37,7 +37,7 @@ OS=$(uname_os)
 export COR_ENABLE_PROFILING="1"
 export COR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
 export COR_PROFILER_PATH="${CURDIR}/bin/tracer-home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
-if ["$OS" == "windows"]
+if [ "$OS" == "windows" ]
 then
     # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
     export COR_PROFILER_PATH_64="${CURDIR}/bin/tracer-home/win-x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
@@ -48,7 +48,7 @@ fi
 export CORECLR_ENABLE_PROFILING="1"
 export CORECLR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
 export CORECLR_PROFILER_PATH="${CURDIR}/bin/tracer-home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
-if ["$OS" == "windows"]
+if [ "$OS" == "windows" ]
 then
     # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
     export CORECLR_PROFILER_PATH_64="${CURDIR}/bin/tracer-home/win-x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"

--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -31,16 +31,29 @@ current_dir() {
 
 CURDIR=$(current_dir)
 SUFIX=$(native_sufix)
+OS=$(uname_os)
 
 # Enable .NET Framework Profiling API
 export COR_ENABLE_PROFILING="1"
 export COR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
 export COR_PROFILER_PATH="${CURDIR}/bin/tracer-home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
+if ["$OS" == "windows"]
+then
+    # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
+    export COR_PROFILER_PATH_64="${CURDIR}/bin/tracer-home/win-x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
+    export COR_PROFILER_PATH_32="${CURDIR}/bin/tracer-home/win-x86/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
+fi
 
 # Enable .NET Core Profiling API
 export CORECLR_ENABLE_PROFILING="1"
 export CORECLR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
 export CORECLR_PROFILER_PATH="${CURDIR}/bin/tracer-home/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
+if ["$OS" == "windows"]
+then
+    # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
+    export CORECLR_PROFILER_PATH_64="${CURDIR}/bin/tracer-home/win-x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
+    export CORECLR_PROFILER_PATH_32="${CURDIR}/bin/tracer-home/win-x86/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.${SUFIX}"
+fi
 
 # Configure OpenTelemetry Tracer 
 export OTEL_DOTNET_TRACER_HOME="${CURDIR}/bin/tracer-home"

--- a/poc.sh
+++ b/poc.sh
@@ -16,9 +16,6 @@ function finish {
 }
 trap finish EXIT
 
-# copy profiler to good location
-cp bin/tracer-home/win-x64/OpenTelemetry.AutoInstrumentation.ClrProfiler.Native.dll bin/tracer-home/
-
 # build plugin for HTTP server app
 dotnet publish -f $aspNetAppTargetFramework samples/Vendor.Distro/Vendor.Distro.csproj -o bin/tracer-home/$aspNetAppTargetFramework
 

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -253,20 +253,21 @@ endif()
 # ******************************************************
 # Define shared target
 # ******************************************************
+SET(TARGET_NAME "OpenTelemetry.AutoInstrumentation.ClrProfiler.Native")
 if (ISMACOS)
-    add_library("Datadog.Trace.ClrProfiler.Native" SHARED
+    add_library(${TARGET_NAME} SHARED
         dllmain.cpp
         interop.cpp
         ${GENERATED_OBJ_FILES}
     )
 else()
-    add_library("Datadog.Trace.ClrProfiler.Native" SHARED
+    add_library(${TARGET_NAME} SHARED
         dllmain.cpp
         interop.cpp
     )
 endif()
 
-set_target_properties("Datadog.Trace.ClrProfiler.Native" PROPERTIES PREFIX "")
+set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "")
 
 # Define linker libraries
-target_link_libraries("Datadog.Trace.ClrProfiler.Native" "Datadog.Trace.ClrProfiler.Native.static")
+target_link_libraries(${TARGET_NAME} "Datadog.Trace.ClrProfiler.Native.static")


### PR DESCRIPTION
There was a copy command on `poc.sh` that was Windows only and the rename of the CLR profiler binary was incomplete (still generating upstream name on non-Windows).