### PR TITLE
Fix OTLP Exporter for .NET Core 3.1

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -76,6 +76,12 @@ namespace OpenTelemetry.AutoInstrumentation.ClrProfiler.Managed.Configuration
                     });
                     break;
                 case "otlp":
+#if NETCOREAPP3_1
+                    // Adding the OtlpExporter creates a GrpcChannel.
+                    // This switch must be set before creating a GrpcChannel/HttpClient when calling an insecure gRPC service.
+                    // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
+                    AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+#endif
                     builder.AddOtlpExporter(
                         options =>
                         {


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet/tree/b663b654a07a1440945a31c5c07b160dfc464fbf/src/OpenTelemetry.Exporter.OpenTelemetryProtocol#special-case-when-using-insecure-channel

## What 

Fix OTLP Exporter for .NET Core 3.1 when an insecure channel is used.

## Testing

After setting `OTEL_EXPORTER="otlp"` and running `./poc.sh` (.NET Core 3.1) here is what we can in OTel Collector:

```
2021-08-13T08:10:11.169Z        INFO    loggingexporter/logging_exporter.go:41  TracesExporter  {"#spans": 7}
2021-08-13T08:10:11.169Z        DEBUG   loggingexporter/logging_exporter.go:51  ResourceSpans #0
Resource labels:
     -> service.name: STRING(aspnet-server)
     -> service.version: STRING(1.0.0)
     -> service.instance.id: STRING(5649763b-3bce-4029-bca4-54fac3be633a)
InstrumentationLibrarySpans #0
InstrumentationLibrary OpenTelemetry.AutoInstrumentation.MongoDB 0.0.1
Span #0
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : 09825d1d7064cf4e
    ID             : 81a64fbf8fe9b018
    Name           : mongodb.query
    Kind           : SPAN_KIND_INTERNAL
    Start time     : 2021-08-13 08:10:06.6916229 +0000 UTC
    End time       : 2021-08-13 08:10:06.7038422 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> span.kind: STRING(Client)
     -> component: STRING(MongoDb)
     -> mongodb.name: STRING(admin)
     -> mongodb.query: STRING({ "buildInfo" : 1 })
     -> mongodb.collection: STRING(1)
     -> out.host: STRING(localhost)
     -> out.port: STRING(27017)
     -> version: STRING(1.0.0)
Span #1
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : 09825d1d7064cf4e
    ID             : 6a0fbb6afe5d8e11
    Name           : mongodb.query
    Kind           : SPAN_KIND_INTERNAL
    Start time     : 2021-08-13 08:10:06.691631 +0000 UTC
    End time       : 2021-08-13 08:10:06.7038444 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> span.kind: STRING(Client)
     -> component: STRING(MongoDb)
     -> mongodb.name: STRING(admin)
     -> mongodb.query: STRING({ "buildInfo" : 1 })
     -> mongodb.collection: STRING(1)
     -> out.host: STRING(localhost)
     -> out.port: STRING(27017)
     -> version: STRING(1.0.0)
Span #2
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : 09825d1d7064cf4e
    ID             : b8f277ff854c182e
    Name           : mongodb.query
    Kind           : SPAN_KIND_INTERNAL
    Start time     : 2021-08-13 08:10:06.8525155 +0000 UTC
    End time       : 2021-08-13 08:10:06.8539242 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> span.kind: STRING(Client)
     -> component: STRING(MongoDb)
     -> mongodb.name: STRING(admin)
     -> mongodb.query: STRING({ "buildInfo" : 1 })
     -> mongodb.collection: STRING(1)
     -> out.host: STRING(localhost)
     -> out.port: STRING(27017)
     -> version: STRING(1.0.0)
Span #3
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : 09825d1d7064cf4e
    ID             : 790c2f259c836069
    Name           : mongodb.query
    Kind           : SPAN_KIND_INTERNAL
    Start time     : 2021-08-13 08:10:06.8589202 +0000 UTC
    End time       : 2021-08-13 08:10:06.9416817 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> span.kind: STRING(Client)
     -> component: STRING(MongoDb)
     -> mongodb.name: STRING(admin)
     -> mongodb.query: STRING({ "listDatabases" : 1 })
     -> mongodb.collection: STRING(1)
     -> out.host: STRING(localhost)
     -> out.port: STRING(27017)
     -> version: STRING(1.0.0)
Span #4
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : 09825d1d7064cf4e
    ID             : e6ab338ef0553416
    Name           : mongodb.query
    Kind           : SPAN_KIND_INTERNAL
    Start time     : 2021-08-13 08:10:06.971015 +0000 UTC
    End time       : 2021-08-13 08:10:06.9767086 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> span.kind: STRING(Client)
     -> component: STRING(MongoDb)
     -> mongodb.name: STRING(local)
     -> mongodb.query: STRING({ "find" : "startup_log", "filter" : { }, "limit" : 1 })
     -> mongodb.collection: STRING(startup_log)
     -> out.host: STRING(localhost)
     -> out.port: STRING(27017)
     -> version: STRING(1.0.0)
InstrumentationLibrarySpans #1
InstrumentationLibrary OpenTelemetry.Instrumentation.AspNetCore 1.0.0.0
Span #0
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : e8317e668666e74e
    ID             : 09825d1d7064cf4e
    Name           : api/mongo
    Kind           : SPAN_KIND_SERVER
    Start time     : 2021-08-13 08:10:06.0557045 +0000 UTC
    End time       : 2021-08-13 08:10:07.056806 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> http.host: STRING(127.0.0.1:8080)
     -> http.method: STRING(GET)
     -> http.path: STRING(/api/mongo)
     -> http.url: STRING(http://127.0.0.1:8080/api/mongo)
     -> http.route: STRING(api/mongo)
     -> http.status_code: INT(200)
Span #1
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : 0f2f997b27156627
    ID             : 34d55ff5440e1705
    Name           : api/redis
    Kind           : SPAN_KIND_SERVER
    Start time     : 2021-08-13 08:10:07.0708186 +0000 UTC
    End time       : 2021-08-13 08:10:07.0881566 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> http.host: STRING(127.0.0.1:8080)
     -> http.method: STRING(GET)
     -> http.path: STRING(/api/redis)
     -> http.url: STRING(http://127.0.0.1:8080/api/redis)
     -> http.route: STRING(api/redis)
     -> http.status_code: INT(200)

2021-08-13T08:10:21.219Z        INFO    loggingexporter/logging_exporter.go:41  TracesExporter  {"#spans": 1}
2021-08-13T08:10:21.219Z        DEBUG   loggingexporter/logging_exporter.go:51  ResourceSpans #0
Resource labels:
     -> service.name: STRING(aspnet-server)
     -> service.version: STRING(1.0.0)
     -> service.instance.id: STRING(5649763b-3bce-4029-bca4-54fac3be633a)
InstrumentationLibrarySpans #0
InstrumentationLibrary OpenTelemetry.StackExchange.Redis 1.0.0.0
Span #0
    Trace ID       : 9131be48a9e7409afe4bd440eb0964db
    Parent ID      : 34d55ff5440e1705
    ID             : 0780ed1c254c1997
    Name           : SET
    Kind           : SPAN_KIND_CLIENT
    Start time     : 2021-08-13 08:10:07.0778986 +0000 UTC
    End time       : 2021-08-13 08:10:07.0871717 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message :
Attributes:
     -> db.system: STRING(redis)
     -> db.redis.flags: STRING(DemandMaster)
     -> db.statement: STRING(SET)
     -> net.peer.name: STRING(localhost)
     -> net.peer.port: INT(6379)
     -> db.redis.database_index: INT(0)
     -> peer.service: STRING(localhost:6379)
Events:
SpanEvent #0
     -> Name: Enqueued
     -> Timestamp: 2021-08-13 08:10:07.0840115 +0000 UTC
     -> DroppedAttributesCount: 0
SpanEvent #1
     -> Name: Sent
     -> Timestamp: 2021-08-13 08:10:07.0847803 +0000 UTC
     -> DroppedAttributesCount: 0
SpanEvent #2
     -> Name: ResponseReceived
     -> Timestamp: 2021-08-13 08:10:07.0870512 +0000 UTC
     -> DroppedAttributesCount: 0
```