### PR TITLE
Remove set -euo pipefail from envvars.sh

### DIFF
--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 uname_os() {
     os=$(uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Removing `set -euo pipefail` which causes a lot of trouble if one uses the script like this: `source dev/envvars.sh` 

