### PR TITLE
Test if CMake downgrade is still needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Downgrade CMake
-        run: ./build/artifacts/downgrade-cmake-macos.sh
       - name: Update GitHub PATH
         run: |
           echo "/Applications/CMake.app/Contents/bin" >> $GITHUB_PATH


### PR DESCRIPTION
We may run this from time to time to monitor when CMake downgrade will not be needed.