### PR TITLE
Remove CMake downgrade on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Downgrade CMake
-        run: ./build/artifacts/downgrade-cmake-macos.sh
       - name: Update GitHub PATH
         run: |
           echo "/Applications/CMake.app/Contents/bin" >> $GITHUB_PATH


### PR DESCRIPTION
@open-telemetry/dotnet-instrumentation-maintainers I have no idea why I cannot commit to non-main branches that I have created 😄 