### PR TITLE
Upgrade NuGet packages

### DIFF
--- a/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
+++ b/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,16 +10,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-alpha1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-alpha1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc7" Condition="'$(TargetFramework)' == 'net461'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc7" Condition="'$(TargetFramework)' != 'net461'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-alpha1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.1.0" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc7" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.6.21352.12" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc8" Condition="'$(TargetFramework)' == 'net461'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" Condition="'$(TargetFramework)' != 'net461'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc8" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
   
 </Project>

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.6.21352.12" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 

--- a/samples/OldReference/OldReference.csproj
+++ b/samples/OldReference/OldReference.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.12.3" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-alpha1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc7" />
+    <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc8" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.6.21352.12" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/Samples.StartupHook.AspNetCoreMvc31/Samples.StartupHook.AspNetCoreMvc31.csproj
+++ b/samples/Samples.StartupHook.AspNetCoreMvc31/Samples.StartupHook.AspNetCoreMvc31.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.6.21352.12" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
   
 </Project>

--- a/src/OpenTelemetry.ClrProfiler.Managed/OpenTelemetry.ClrProfiler.Managed.csproj
+++ b/src/OpenTelemetry.ClrProfiler.Managed/OpenTelemetry.ClrProfiler.Managed.csproj
@@ -5,18 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-alpha2" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-alpha2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-alpha2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc7" Condition="'$(TargetFramework)' == 'net461'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc7" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-alpha2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-alpha2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-alpha2" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc7" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc8" Condition="'$(TargetFramework)' == 'net461'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc8" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/test/OpenTelemetry.ClrProfiler.Managed.Bootstrapping.Tests/OpenTelemetry.ClrProfiler.Managed.Bootstrapping.Tests.csproj
+++ b/test/OpenTelemetry.ClrProfiler.Managed.Bootstrapping.Tests/OpenTelemetry.ClrProfiler.Managed.Bootstrapping.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/OpenTelemetry.ClrProfiler.Managed.Loader.Tests/OpenTelemetry.ClrProfiler.Managed.Loader.Tests.csproj
+++ b/test/OpenTelemetry.ClrProfiler.Managed.Loader.Tests/OpenTelemetry.ClrProfiler.Managed.Loader.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
+++ b/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0-preview.7.21377.19" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.13.1</ApiVersion>
-    <DefineConstants Condition="'$(ApiVersion)'>='2.7.0'">$(DefineConstants);MONGODB_2_7</DefineConstants>
-    <DefineConstants Condition="'$(ApiVersion)'>='2.2.0'">$(DefineConstants);MONGODB_2_2</DefineConstants>
+    <DefineConstants Condition="'$(ApiVersion)'&gt;='2.7.0'">$(DefineConstants);MONGODB_2_7</DefineConstants>
+    <DefineConstants Condition="'$(ApiVersion)'&gt;='2.2.0'">$(DefineConstants);MONGODB_2_2</DefineConstants>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="$(ApiVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
 
 </Project>

--- a/test/test-applications/integrations/Samples.StartupHook/Samples.StartupHook.csproj
+++ b/test/test-applications/integrations/Samples.StartupHook/Samples.StartupHook.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0-rc.2.21480.5" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.7.21377.19" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgrading the OpenTelemetry and S.D.DS packages.

This supersedes the related version bump opened by the bot. 