### PR TITLE
Document OTel SDK environment variables

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -8,14 +8,25 @@
 
 | Environment variable | Description | Default |
 |-|-|-|
-| `OTEL_SERVICE` | Application's default service name. |  |
-| `OTEL_ENV` | The value for the `environment` tag added to every span. |  |
-| `OTEL_VERSION` | The application's version that will populate `version` tag on spans. |  |
-| `OTEL_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"` |  |
 | `OTEL_TRACE_ENABLED` | Enable to activate the tracer. | `true` |
 | `OTEL_DOTNET_TRACER_FORCE` | Enable the tracer even if no integrations is set using `OTEL_INTEGRATIONS`. | `true` |
 | `OTEL_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `OTEL_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
+
+## Resource
+
+Resource is the immutable representation of the entity producing the telemetry.
+See [Resource semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions)
+for more details.
+
+| Environment variable | Description | Default |
+|-|-|-|
+| `OTEL_RESOURCE_ATTRIBUTES` | Key-value pairs to be used as resource attributes. See [Resource SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. | See [Resource semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value) for details. |
+| `OTEL_SERVICE_NAME` | Sets the value of the [`service.name`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service) resource attribute | | If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then `OTEL_SERVICE_NAME` takes precedence. |
+| `OTEL_SERVICE` | Application's default service name. **Deprected.** |  |
+| `OTEL_ENV` | The value for the `environment` tag added to every span. **Deprected.**  |  |
+| `OTEL_VERSION` | The application's version that will populate `version` tag on spans. **Deprected.** |  |
+| `OTEL_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"`. **Deprected.** |  |
 
 ## Instrumentations
 
@@ -30,7 +41,6 @@
 
 | Environment variable | Description | Default |
 |-|-|-|
-| `OTEL_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `zipkin`, `jeager`, `otlp`. | |
 | `OTEL_TRACE_LOG_DIRECTORY` | The directory of the .NET Tracer logs. Overrides the value in `OTEL_TRACE_LOG_PATH` if present. | _see below_ |
 | `OTEL_TRACE_LOG_PATH` | The path of the profiler log file. | _see below_ |
 | `OTEL_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` |
@@ -43,11 +53,29 @@ Default logs directory paths are:
 
 ### Exporters
 
+The exporter is used to output the telemetry.
+
 | Environment variable | Description | Default |
 |-|-|-|
+| `OTEL_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `zipkin`, `jeager`, `otlp`. | |
 | `OTEL_EXPORTER_JAEGER_AGENT_HOST` | Hostname for the Jaeger agent. | `localhost` |
 | `OTEL_EXPORTER_JAEGER_AGENT_PORT` | Port for the Jaeger agent. | `6831` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Target endpoint for OTLP exporter. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | `http://localhost:4318` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Key-value pairs to be used as headers associated with gRPC or HTTP requests. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | Maximum time the OTLP exporter will wait for each batch export. | `1000` (ms) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | The transport protocol. Supported values: `grpc`, `http/protobuf`. | `grpc` |
 | `OTEL_EXPORTER_ZIPKIN_ENDPOINT` | Zipkin URL. | `http://localhost:8126` |
+
+### Batch Span Processor
+
+The Batch Span Processor batches of finished spans before they are send by the exporter.
+
+| Environment variable | Description | Default |
+|-|-|-|
+| `OTEL_BSP_SCHEDULE_DELAY` | Delay interval between two consecutive exports. | `5000` (ms) |
+| `OTEL_BSP_EXPORT_TIMEOUT` | Maximum allowed time to export data. | `30000` (ms) |
+| `OTEL_BSP_MAX_QUEUE_SIZE` | Maximum queue size. | `2048` |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | Maximum batch size. Must be less than or equal to `OTEL_BSP_MAX_QUEUE_SIZE`. | `512` (ms) |
 
 ### Customization
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,7 +4,7 @@
 
 ## Configuration
 
-## General
+### General
 
 | Environment variable | Description | Default |
 |-|-|-|
@@ -13,7 +13,7 @@
 | `OTEL_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `OTEL_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 
-## Resource
+### Resource
 
 Resource is the immutable representation of the entity producing the telemetry.
 See [Resource semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions)
@@ -28,7 +28,7 @@ for more details.
 | `OTEL_VERSION` | The application's version that will populate `version` tag on spans. **Deprected.** |  |
 | `OTEL_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"`. **Deprected.** |  |
 
-## Instrumentations
+### Instrumentations
 
 | Environment variable | Description | Default |
 |-|-|-|
@@ -39,17 +39,17 @@ for more details.
 
 ### Logging
 
-| Environment variable | Description | Default |
-|-|-|-|
-| `OTEL_TRACE_LOG_DIRECTORY` | The directory of the .NET Tracer logs. Overrides the value in `OTEL_TRACE_LOG_PATH` if present. | _see below_ |
-| `OTEL_TRACE_LOG_PATH` | The path of the profiler log file. | _see below_ |
-| `OTEL_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` |
-| `OTEL_DOTNET_TRACER_CONSOLE_EXPORTER_ENABLED` | Defines whether the console exporter is enabled or not. | `true` |
-
 Default logs directory paths are:
 
 - Windows: `%ProgramData%\OpenTelemetry .NET AutoInstrumentation\logs`
 - Linux: `/var/log/opentelemetry/dotnet`
+
+| Environment variable | Description | Default |
+|-|-|-|
+| `OTEL_TRACE_LOG_DIRECTORY` | The directory of the .NET Tracer logs. Overrides the value in `OTEL_TRACE_LOG_PATH` if present. | _see above_ |
+| `OTEL_TRACE_LOG_PATH` | The path of the profiler log file. | _see above_ |
+| `OTEL_TRACE_DEBUG` | Enable to activate debugging mode for the tracer. | `false` |
+| `OTEL_DOTNET_TRACER_CONSOLE_EXPORTER_ENABLED` | Defines whether the console exporter is enabled or not. | `true` |
 
 ### Exporters
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -23,10 +23,6 @@ for more details.
 |-|-|-|
 | `OTEL_RESOURCE_ATTRIBUTES` | Key-value pairs to be used as resource attributes. See [Resource SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. | See [Resource semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value) for details. |
 | `OTEL_SERVICE_NAME` | Sets the value of the [`service.name`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service) resource attribute | | If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then `OTEL_SERVICE_NAME` takes precedence. |
-| `OTEL_SERVICE` | Application's default service name. **Deprected.** |  |
-| `OTEL_ENV` | The value for the `environment` tag added to every span. **Deprected.**  |  |
-| `OTEL_VERSION` | The application's version that will populate `version` tag on spans. **Deprected.** |  |
-| `OTEL_TAGS` | Comma-separated list of key-value pairs to specify global span tags. For example: `"key1:val1,key2:val2"`. **Deprected.** |  |
 
 ### Instrumentations
 

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -69,10 +69,16 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
             switch (settings.Exporter)
             {
                 case "zipkin":
-                    builder.AddZipkinExporter();
+                    builder.AddZipkinExporter(options =>
+                    {
+                        options.ExportProcessorType = ExportProcessorType.Simple; // workaround for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/290
+                    });
                     break;
                 case "jaeger":
-                    builder.AddJaegerExporter();
+                    builder.AddJaegerExporter(options =>
+                    {
+                        options.ExportProcessorType = ExportProcessorType.Simple; // workaround for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/290
+                    });
                     break;
                 case "otlp":
 #if NETCOREAPP3_1
@@ -81,7 +87,10 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
                     // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
                     AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 #endif
-                    builder.AddOtlpExporter();
+                    builder.AddOtlpExporter(options =>
+                    {
+                        options.ExportProcessorType = ExportProcessorType.Simple; // workaround for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/290
+                    });
                     break;
                 case "":
                 case null:

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -69,16 +69,10 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
             switch (settings.Exporter)
             {
                 case "zipkin":
-                    builder.AddZipkinExporter(options =>
-                    {
-                        options.ExportProcessorType = ExportProcessorType.Simple; // for PoC
-                    });
+                    builder.AddZipkinExporter();
                     break;
                 case "jaeger":
-                    builder.AddJaegerExporter(options =>
-                    {
-                        options.ExportProcessorType = ExportProcessorType.Simple; // for PoC
-                    });
+                    builder.AddJaegerExporter();
                     break;
                 case "otlp":
 #if NETCOREAPP3_1


### PR DESCRIPTION
Partially addresses https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/183 and https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/287

Changes proposed in this pull request:
- Document the OTel SDK environment variables supported in `1.2.0-beta1` (part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/183)
- Always use the simple span processor (see https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/290)
- Remove some env vars from docs (part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/287)