### PR TITLE
Document required HttpModule for ASP.NET instrumentation

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,22 +28,10 @@
 
 ### ASP.NET (.NET Framework) Instrumentation
 
-ASP.NET instrumentation on .NET Framework requires adding an additional HttpModule
-to your web server. This additional HttpModule is shipped as part of
-[`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/).
-The following shows changes required to your `Web.config` when using IIS web server.
-
-```xml
-<system.webServer>
-    <modules>
-        <add
-            name="TelemetryHttpModule"
-            type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule,
-                OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule"
-            preCondition="integratedMode,managedHandler" />
-    </modules>
-</system.webServer>
-```
+ASP.NET instrumentation on .NET Framework requires installing the
+[`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
+NuGet package on the instrumented project.
+More info [here](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.AspNet#step-2-modify-webconfig).
 
 ### Logging
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,25 @@
 | `OTEL_DOTNET_TRACER_DISABLED_INSTRUMENTATIONS` | The instrumentations set via `OTEL_DOTNET_TRACER_INSTRUMENTATIONS` value and `OTEL_INTEGRATIONS` configuration file you want to disable, separated by a comma. | |
 | `OTEL_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` |  Sets whether to intercept method calls when the caller method is inside a domain-neutral assembly. This is recommended when instrumenting IIS applications. | `false` |
 
+### ASP.NET (.NET Framework) Instrumentation
+
+ASP.NET instrumentation on .NET Framework requires adding an additional HttpModule
+to your web server. This additional HttpModule is shipped as part of
+[`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/).
+The following shows changes required to your `Web.config` when using IIS web server.
+
+```xml
+<system.webServer>
+    <modules>
+        <add
+            name="TelemetryHttpModule"
+            type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule,
+                OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule"
+            preCondition="integratedMode,managedHandler" />
+    </modules>
+</system.webServer>
+```
+
 ### Logging
 
 | Environment variable | Description | Default |


### PR DESCRIPTION
Partially addresses https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/183

The HttpModule is used in `Samples.AspNet`. See: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/09ea838561d4e8d466c0ee53e975fd3cd0c89848/test/test-applications/integrations/aspnet/Samples.AspNet/Web.config#L81-L84