### PR TITLE
TraceProvider Dispose

### DIFF
--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -69,16 +69,10 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
             switch (settings.Exporter)
             {
                 case "zipkin":
-                    builder.AddZipkinExporter(options =>
-                    {
-                        options.ExportProcessorType = ExportProcessorType.Simple; // for PoC
-                    });
+                    builder.AddZipkinExporter();
                     break;
                 case "jaeger":
-                    builder.AddJaegerExporter(options =>
-                    {
-                        options.ExportProcessorType = ExportProcessorType.Simple; // for PoC
-                    });
+                    builder.AddJaegerExporter();
                     break;
                 case "otlp":
 #if NETCOREAPP3_1

--- a/src/OpenTelemetry.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Instrumentation.cs
@@ -113,13 +113,9 @@ namespace OpenTelemetry.ClrProfiler.Managed
                 return;
             }
 
-            if (_tracerProvider is not null)
-            {
-                _tracerProvider.Dispose();
-                _tracerProvider = null;
+            _tracerProvider.Dispose();
 
-                Log("OpenTelemetry tracer exit.");
-            }
+            Log("OpenTelemetry tracer exit.");
         }
 
         private static void Log(string message)


### PR DESCRIPTION
### What
Disposes the SDK tracer on AppDomain events.
Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/290

