### PR TITLE
Remove OpenTelemetry.Instrumentation.AdditionalDeps library from runtime store

### DIFF
--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -328,7 +328,8 @@ partial class Build
                                        // Remove OpenTelemetry.Instrumentation.AdditionalDeps entry from target section.
                                        depsJsonContent = Regex.Replace(depsJsonContent, "\"OpenTelemetry(.+)AdditionalDeps.dll(.+?)},\r\n(.+?)\"", "\"", RegexOptions.IgnoreCase | RegexOptions.Singleline);
                                        // Remove OpenTelemetry.Instrumentation.AdditionalDeps entry from library section and write to file.
-                                       File.WriteAllText(file, Regex.Replace(depsJsonContent, "\"OpenTelemetry(.+?)},\r\n(.+?)\"", "\"", RegexOptions.IgnoreCase | RegexOptions.Singleline));
+                                       depsJsonContent = Regex.Replace(depsJsonContent, "\"OpenTelemetry(.+?)},\r\n(.+?)\"", "\"", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                                       File.WriteAllText(file, depsJsonContent);
                                    });
         });
 

--- a/src/OpenTelemetry.Instrumentation.AdditionalDeps/Package.xml
+++ b/src/OpenTelemetry.Instrumentation.AdditionalDeps/Package.xml
@@ -3,10 +3,6 @@
     <RestoreSources>https://api.nuget.org/v3/index.json;$(TracerHomePath)\AdditionalDeps;</RestoreSources>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Condition="'$(TracerHomePath)' != ''" Include="OpenTelemetry.Instrumentation.AdditionalDeps" Version="*" />
-  </ItemGroup>
-
   <Target Name="_ResolveTargetingPackAssetsForStore"
           AfterTargets="ResolvePackageAssets"
           DependsOnTargets="ResolveTargetingPackAssets" />


### PR DESCRIPTION
Follow up: #272 [Comment](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/272#discussion_r752660686)

This PR removes below 2 sections from `OpenTelemetry.Instrumentation.AdditionalDeps.deps.json` and folders that gets created for `OpenTelemetry.Instrumentation.AdditionalDeps` in runtime store.

```json

"OpenTelemetry.Instrumentation.AdditionalDeps/1.0.0": {
  "dependencies": {
    "System.Diagnostics.DiagnosticSource": "6.0.0"
  },
  "runtime": {
    "lib/netcoreapp3.1/OpenTelemetry.Instrumentation.AdditionalDeps.dll": {}
  }
},


"OpenTelemetry.Instrumentation.AdditionalDeps/1.0.0": {
  "type": "project",
  "serviceable": false,
  "sha512": ""
},

```