### PR TITLE
Upgrade NuGet packages

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -109,7 +109,7 @@ public OpenTelemetry.Trace.TracerProviderBuilder ConfigureTracerProvider(OpenTel
 ```
 
 The plugin must use the same version of the `OpenTelemetry` as the
-OpenTelemetry .NET AutoInstrumentation. Current version is `1.2.0-beta1`.
+OpenTelemetry .NET AutoInstrumentation. Current version is `1.2.0-rc1`.
 
 ## Troubleshooting
 
@@ -177,7 +177,7 @@ These are ";" delimited lists that control the inclusion/exclusion of processes.
 On .NET Framework strong name signing can force multiple versions of the same assembly being loaded on the same process.
 This causes a separate hierarchy of Activity objects. If you are referencing packages in your application that use
 different version of the `System.Diagnostics.DiagnosticSource` than the `OpenTelemetry.Api` used by autoinstrumentation
-(`6.0.0-preview.6.21352.12`) you have to explicitly reference the `System.Diagnostics.DiagnosticSource` package in the correct version
+(`6.0.0`) you have to explicitly reference the `System.Diagnostics.DiagnosticSource` package in the correct version
 in your application (see [custom instrumentation section](#configure-custom-instrumentation)).
 This will cause automatic binding redirection to occur resolving the issue.
 

--- a/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
+++ b/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
@@ -10,16 +10,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-beta1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc8" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc8" Condition="'$(TargetFramework)' == 'net461'" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" Condition="'$(TargetFramework)' != 'net461'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-beta1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc1" />
     <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc8" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
   
 </Project>

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 

--- a/samples/OldReference/OldReference.csproj
+++ b/samples/OldReference/OldReference.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -7,10 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc8" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.ClrProfiler.Managed/OpenTelemetry.ClrProfiler.Managed.csproj
+++ b/src/OpenTelemetry.ClrProfiler.Managed/OpenTelemetry.ClrProfiler.Managed.csproj
@@ -5,18 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-beta1" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-beta1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc8" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc8" Condition="'$(TargetFramework)' == 'net461'" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-beta1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-beta1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-beta1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc1" />
     <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc8" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
+++ b/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
@@ -3,8 +3,8 @@
   <ItemGroup>
     <PackageReference Include="DotNet.Testcontainers" Version="1.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0-preview.7.21377.19" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="$(ApiVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
 
     <!-- Hack to fix SDK dependencies -->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.3" />

--- a/test/test-applications/integrations/Samples.StartupHook/Samples.StartupHook.csproj
+++ b/test/test-applications/integrations/Samples.StartupHook/Samples.StartupHook.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0-rc.2.21480.5" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/test/test-applications/integrations/Samples.StartupHook/Samples.StartupHook.csproj
+++ b/test/test-applications/integrations/Samples.StartupHook/Samples.StartupHook.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
@@ -52,7 +52,7 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.6.0.0-rc.2.21480.5\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.6.0.0\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -63,7 +63,7 @@
       <HintPath>..\..\..\..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0-rc.2.21480.5\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
@@ -41,7 +41,7 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-beta1\lib\net461\OpenTelemetry.Api.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-rc1\lib\net461\OpenTelemetry.Api.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc8\lib\net461\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
@@ -11,10 +11,10 @@
   <package id="OpenTelemetry.Api" version="1.2.0-beta1" targetFramework="net461" />
   <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc8" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
-  <package id="System.Diagnostics.DiagnosticSource" version="6.0.0-rc.2.21480.5" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
   <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0-rc.2.21480.5" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
-  <package id="OpenTelemetry.Api" version="1.2.0-beta1" targetFramework="net461" />
+  <package id="OpenTelemetry.Api" version="1.2.0-rc1" targetFramework="net461" />
   <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc8" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net461" />


### PR DESCRIPTION
Update `OpenTelemetry` from 1.2.0-beta1 to 1.2.0-rc1.
Update `System.Diagnostics.DiagnosticSource` to GA version 6.0.0.
