### PR TITLE
Update documentation with latest bytecode instrumentation information

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,10 +1,7 @@
 Component,Origin,License,Copyright
-Datadog.Trace,https://github.com/neuecc/MessagePack-CSharp,MIT,Copyright (c) 2017 Yoshifumi Kawai and contributors
-Datadog.Trace,https://github.com/damianh/LibLog,MIT,Copyright (C) 2011-2017 Damian Hickey
 Datadog.Trace,https://github.com/serilog/serilog,Apache-2.0,Copyright (c) 2013-2018 Serilog Contributors
 Datadog.Trace,https://github.com/serilog/serilog-sinks-file,Apache-2.0,Copyright (c) 2016 Serilog Contributors
 Datadog.Trace,https://github.com/JamesNK/Newtonsoft.Json,MIT,Copyright (c) 2007 James Newton-King
-OpenTelemetry.ClrProfiler.Managed,https://github.com/kevin-montrose/Sigil,MS-PL,2013-2016 Kevin Montrose
 OpenTelemetry.ClrProfiler.Native,https://github.com/dotnet/runtime,MIT,Copyright (c) .NET Foundation and contributors. All rights reserved.
 OpenTelemetry.ClrProfiler.Native,https://github.com/Microsoft/clr-samples,MIT,Copyright (c) .NET Foundation and contributors. All rights reserved.
 OpenTelemetry.ClrProfiler.Native,https://github.com/MicrosoftArchive/clrprofiler,MIT,Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -12,6 +9,4 @@ OpenTelemetry.ClrProfiler.Native,https://github.com/nlohmann/json,MIT,Copyright 
 OpenTelemetry.ClrProfiler.Native,https://github.com/dropbox/miniutf,MIT,"Copyright (c) 2013 Dropbox, Inc."
 OpenTelemetry.ClrProfiler.Native,https://github.com/gabime/spdlog,MIT,Copyright (c) 2016 Gabi Melman.
 OpenTelemetry.ClrProfiler.Native,https://github.com/fmtlib/fmt,MIT,"Copyright (c) 2012 - present, Victor Zverovich"
-Datadog.Trace.OpenTracing,https://github.com/opentracing/opentracing-csharp,MIT,Copyright 2016-2017 The OpenTracing Authors
-Datadog.Trace.OpenTracing,https://github.com/opentracing-contrib/csharp-netcore,Apache-2.0,
 (all),https://github.com/DataDog/dd-trace-dotnet,Apache-2.0,

--- a/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
@@ -2104,17 +2104,17 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
     hr = metadata_emit->DefineMemberRef(system_appdomain_type_ref, WStr("SetData"), appdomain_set_data_signature,
                                         sizeof(appdomain_set_data_signature), &appdomain_set_data_member_ref);
 
-    // Define "Datadog_IISPreInitStart" string
+    // Define "OpenTelemetry_IISPreInitStart" string
     // Create a string representing
     // "OpenTelemetry.ClrProfiler.Managed.Loader.Startup" Create OS-specific
     // implementations because on Windows, creating the string via
     // "OpenTelemetry.ClrProfiler.Managed.Loader.Startup"_W.c_str() does not
     // create the proper string for CreateInstance to successfully call
 #ifdef _WIN32
-    LPCWSTR pre_init_start_str = L"Datadog_IISPreInitStart";
+    LPCWSTR pre_init_start_str = L"OpenTelemetry_IISPreInitStart";
     auto pre_init_start_str_size = wcslen(pre_init_start_str);
 #else
-    char16_t pre_init_start_str[] = u"Datadog_IISPreInitStart";
+    char16_t pre_init_start_str[] = u"OpenTelemetry_IISPreInitStart";
     auto pre_init_start_str_size = std::char_traits<char16_t>::length(pre_init_start_str);
 #endif
 
@@ -2140,7 +2140,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
     // Call AppDomain.get_CurrentDomain
     rewriter_wrapper.CallMember(appdomain_get_current_domain_member_ref, false);
 
-    // ldstr "Datadog_IISPreInitStart"
+    // ldstr "OpenTelemetry_IISPreInitStart"
     pCurrentInstr = rewriter_wrapper.GetCurrentILInstr();
     pNewInstr = rewriter.NewILInstr();
     pNewInstr->m_opcode = CEE_LDSTR;
@@ -2170,7 +2170,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
     pInstr->m_opcode = CEE_CALL;
     pInstr->m_Arg32 = appdomain_get_current_domain_member_ref;
 
-    // ldstr "Datadog_IISPreInitStart"
+    // ldstr "OpenTelemetry_IISPreInitStart"
     pCurrentInstr = rewriter_wrapper.GetCurrentILInstr();
     pNewInstr = rewriter.NewILInstr();
     pNewInstr->m_opcode = CEE_LDSTR;


### PR DESCRIPTION
- Update DESIGN documentation to remove mentions of callsite
- Update DESIGN documentation for JITCompilation events, now that callsite instrumentation has been removed
- Rename "Datadog_IISPreInitStart" to "OpenTelemetry_IISPreInitStart"
- Update LICENSE-3rdparty.csv

Addresses concerns from https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/311#pullrequestreview-849056831