### PR TITLE
Make OTEL_INTEGRATIONS optional

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -9,9 +9,11 @@ services:
       - "14250:14250"
 
   otel-collector:
-    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector-contrib:0.40.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
+    environment:
+      - JAEGER_ENDPOINT=jaeger:14250
     ports:
       - "1777:1777"  # pprof extension
       - "8888:8888"  # Prometheus metrics exposed by the collector

--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -58,7 +58,7 @@ fi
 export OTEL_DOTNET_TRACER_HOME="${CURDIR}/bin/tracer-home"
 export OTEL_INTEGRATIONS="${CURDIR}/bin/tracer-home/integrations.json"
 export OTEL_TRACE_DEBUG="1"
-export OTEL_EXPORTER="jaeger"
+export OTEL_EXPORTER="zipkin"
 export OTEL_DUMP_ILREWRITE_ENABLED="0"
 export OTEL_CLR_ENABLE_INLINING="1"
 export OTEL_PROFILER_EXCLUDE_PROCESSES="dotnet.exe,dotnet"

--- a/dev/otel-config.yaml
+++ b/dev/otel-config.yaml
@@ -26,8 +26,9 @@ exporters:
   logging:
     logLevel: debug
   jaeger:
-    endpoint: jaeger:14250
-    insecure: true
+    endpoint: "${JAEGER_ENDPOINT}"
+    tls:
+      insecure: true
   prometheus:
     endpoint: "0.0.0.0:8889"
     namespace: promexample
@@ -45,5 +46,4 @@ service:
       processors: [batch]
       exporters: [prometheus]
       #exporters: [logging]
-
   extensions: [health_check, pprof, zpages]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -59,7 +59,7 @@ injected into the application.
 contains the code setting up the OpenTelemtry .NET SDK and configured instrumentations.
 Plus, support code to run and implement bytecode instrumentations. Optionally, the code
 setting-up the OpenTelemetry .NET SDK can be left to the application by setting the
-environment variable `OTEL_DOTNET_TRACER_FORCE` to `false`.
+environment variable `OTEL_DOTNET_TRACER_LOAD_AT_STARTUP` to `false`.
 
 - **Source Instrumentations**: instrumentations created on top of API hooks/callbacks provided
 directly by the library/framework being instrumented. This type of instrumentation depends on the

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -113,8 +113,8 @@ Example usage:
  source ./dev/envvars.sh
  ./samples/ConsoleApp/bin/Debug/netcoreapp3.1/ConsoleApp
  ```
- 
- ## Debug .NET Runtime on Linux
+
+## Debug .NET Runtime on Linux
 
 - [Requirements](https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/linux-requirements.md)
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,7 +9,6 @@
 | Environment variable | Description | Default |
 |-|-|-|
 | `OTEL_TRACE_ENABLED` | Enable to activate the tracer. | `true` |
-| `OTEL_DOTNET_TRACER_FORCE` | Enable the tracer even if no integrations is set using `OTEL_INTEGRATIONS`. | `true` |
 | `OTEL_PROFILER_PROCESSES` | Sets the filename of executables the profiler can attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 | `OTEL_PROFILER_EXCLUDE_PROCESSES` | Sets the filename of executables the profiler cannot attach to. If not defined (default), the profiler will attach to any process. Supports multiple values separated with comma, for example: `MyApp.exe,dotnet.exe` |  |
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -27,7 +27,7 @@ for more details.
 
 | Environment variable | Description | Default |
 |-|-|-|
-| `OTEL_INTEGRATIONS` | The file path of bytecode instrumentations JSON configuration file. | `%ProfilerDirectory%/integrations.json` |
+| `OTEL_INTEGRATIONS` | The file path of bytecode instrumentations JSON configuration file. Usually it should be set to `%ProfilerDirectory%/integrations.json` | |
 | `OTEL_DOTNET_TRACER_INSTRUMENTATIONS` | The instrumentations you want to enable, separated by a comma. Supported values: `AspNet`, `HttpClient`, `SqlClient`, `MongoDb`. |  |
 | `OTEL_DOTNET_TRACER_DISABLED_INSTRUMENTATIONS` | The instrumentations set via `OTEL_DOTNET_TRACER_INSTRUMENTATIONS` value and `OTEL_INTEGRATIONS` configuration file you want to disable, separated by a comma. | |
 | `OTEL_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` |  Sets whether to intercept method calls when the caller method is inside a domain-neutral assembly. This is recommended when instrumenting IIS applications. | `false` |

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -11,8 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
+
+    <!-- Hack to fix SDK dependencies -->
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
@@ -482,12 +482,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
         return S_OK;
     }
 
-    if (integration_methods_.empty())
-    {
-        Logger::Debug("ModuleLoadFinished skipping module (no integrations): ", module_id);
-        return S_OK;
-    }
-
     // keep this lock until we are done using the module,
     // to prevent it from unloading while in use
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);

--- a/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
@@ -160,16 +160,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         }
     }
 
-    // get path to integration definition JSON files
-    const WSTRING integrations_paths = GetEnvironmentValue(environment::integrations_path);
-
-    if (integrations_paths.empty())
-    {
-        Logger::Warn("OpenTelemetry TRACER DIAGNOSTICS - Profiler disabled: ", environment::integrations_path,
-                     " environment variable not set.");
-        return E_FAIL;
-    }
-
     // Initialize ReJIT handler and define the Rewriter Callback
     auto callback = [this](RejitHandlerModule* mod, RejitHandlerModuleMethod* method) {
         return this->CallTarget_RewriterCallback(mod, method);

--- a/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.ClrProfiler.Native/cor_profiler.cpp
@@ -182,16 +182,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // load all integrations from JSON files
     LoadIntegrationsFromEnvironment(integration_methods_, GetEnvironmentValues(environment::disabled_integrations));
 
-    // check if there are any enabled integrations left
-    if (integration_methods_.empty())
-    {
-        Logger::Warn("OpenTelemetry TRACER DIAGNOSTICS - Profiler disabled: no enabled integrations found.");
-        return E_FAIL;
-    }
-    else
-    {
-        Logger::Debug("Number of Integrations loaded: ", integration_methods_.size());
-    }
+    Logger::Debug("Number of Integrations loaded: ", integration_methods_.size());
 
     DWORD event_mask = COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST |
                        COR_PRF_MONITOR_MODULE_LOADS | COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS;

--- a/src/OpenTelemetry.ClrProfiler.Native/environment_variables.h
+++ b/src/OpenTelemetry.ClrProfiler.Native/environment_variables.h
@@ -13,11 +13,6 @@ const WSTRING tracing_enabled = WStr("OTEL_TRACE_ENABLED");
 // Sets whether debug mode is enabled. Default is false.
 const WSTRING debug_enabled = WStr("OTEL_TRACE_DEBUG");
 
-// Sets whether we force the instrumentation
-// even if nothing is supposed to be instrumented according to integration
-// definition JSON files. Default is true.
-const WSTRING tracing_force = WStr("OTEL_DOTNET_TRACER_FORCE");
-
 // Sets the paths to integration definition JSON files.
 // Supports multiple values separated with comma, for example:
 // "C:\Program Files\OpenTelemetry .NET AutoInstrumentation\integrations.json,D:\temp\test_integrations.json"


### PR DESCRIPTION
## Why

When I started updating `USAGE.md` I noticed that the functionality introduced in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/180 was accidentally removed by https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/218

## What

1. Simplify the code and configuration by simply not requiring `integrations.json`  nor `OTEL_INTEGRATIONS`
2. Remove the description and field for the unused env var
3. Fix the default value of `OTEL_INTEGRATIONS` in documentation
3. Fix DESIGN.md documentation

## Testing

The spans are exported for all use cases. Below is the native logs content:

1. regular `integrations.json` 

```
01/14/22 01:25:42.271 PM [23652|7120] [debug] Loading integrations from file: C:/Users/rpajak/repos/opentelemetry-dotnet-instrumentation/bin/tracer-home/integrations.json
01/14/22 01:25:42.271 PM [23652|23932] [info] Initializing ReJIT request thread.
01/14/22 01:25:42.272 PM [23652|7120] [debug] Number of Integrations loaded: 17
```

2. `integrations.json` with following content: `[]`

```
01/14/22 01:25:42.271 PM [23652|7120] [debug] Loading integrations from file: C:/Users/rpajak/repos/opentelemetry-dotnet-instrumentation/bin/tracer-home/integrations.json
01/14/22 01:25:42.271 PM [23652|23932] [info] Initializing ReJIT request thread.
01/14/22 01:25:42.272 PM [23652|7120] [debug] Number of Integrations loaded: 0
```

3. Empty `integrations.json`

```
01/14/22 01:14:42.354 PM [22684|25296] [debug] Loading integrations from file: C:/Users/rpajak/repos/opentelemetry-dotnet-instrumentation/bin/tracer-home/integrations.json
01/14/22 01:14:42.354 PM [22684|23572] [info] Initializing ReJIT request thread.
01/14/22 01:14:42.354 PM [22684|25296] [warning] Invalid integrations:[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
01/14/22 01:14:42.354 PM [22684|25296] [debug] Number of Integrations loaded: 0
```

4. Missing file `integrations.json`

```
01/14/22 01:15:18.736 PM [10256|25416] [debug] Loading integrations from file: C:/Users/rpajak/repos/opentelemetry-dotnet-instrumentation/bin/tracer-home/integrations.json
01/14/22 01:15:18.736 PM [10256|22536] [info] Initializing ReJIT request thread.
01/14/22 01:15:18.736 PM [10256|25416] [warning] Failed to load integrations from file C:/Users/rpajak/repos/opentelemetry-dotnet-instrumentation/bin/tracer-home/integrations.json
01/14/22 01:15:18.736 PM [10256|25416] [debug] Number of Integrations loaded: 0
```

5. `OTEL_INTEGRATIONS=""`

```
01/14/22 01:21:59.365 PM [11044|22536] [debug] Number of Integrations loaded: 0
```