### PR TITLE
use otel/opentelemetry-collector-contrib:0.42.0

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -9,9 +9,10 @@ services:
       - "14250:14250"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.40.0
+    image: otel/opentelemetry-collector-contrib:0.42.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
+    command: --config /etc/otel/config.yaml
     environment:
       - JAEGER_ENDPOINT=jaeger:14250
     ports:


### PR DESCRIPTION
In this version there were changes for the default location for config files.
Adding the command statement allow us to use older version of otel/opentelemetry-collector or otel/opentelemetry-collector-contrib

As a reference please check
https://github.com/signalfx/signalfx-dotnet-tracing/pull/321
https://github.com/open-telemetry/opentelemetry-collector-releases/issues/59