### PR TITLE
[WIP] Use OTLP exporter by default

### DIFF
--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -58,7 +58,6 @@ fi
 export OTEL_DOTNET_TRACER_HOME="${CURDIR}/bin/tracer-home"
 export OTEL_INTEGRATIONS="${CURDIR}/bin/tracer-home/integrations.json"
 export OTEL_TRACE_DEBUG="1"
-export OTEL_EXPORTER="jaeger"
 export OTEL_DUMP_ILREWRITE_ENABLED="0"
 export OTEL_CLR_ENABLE_INLINING="1"
 export OTEL_PROFILER_EXCLUDE_PROCESSES="dotnet.exe,dotnet"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -60,7 +60,7 @@ The exporter is used to output the telemetry.
 
 | Environment variable | Description | Default |
 |-|-|-|
-| `OTEL_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `zipkin`, `jeager`, `otlp`. | |
+| `OTEL_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `zipkin`, `jeager`, `otlp`. | `otlp` |
 | `OTEL_EXPORTER_JAEGER_AGENT_HOST` | Hostname for the Jaeger agent. | `localhost` |
 | `OTEL_EXPORTER_JAEGER_AGENT_PORT` | Port for the Jaeger agent. | `6831` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Target endpoint for OTLP exporter. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | `http://localhost:4318` |

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.3" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -34,8 +34,8 @@ namespace ConsoleApp
                 activity?.SetTag("foo", "bar");
 
                 await HttpGet("https://www.example.com/default-handler");
-                await HttpGet("http://127.0.0.1:8080/api/mongo");
-                await HttpGet("http://127.0.0.1:8080/api/redis");
+                // await HttpGet("http://127.0.0.1:8080/api/mongo");
+                // await HttpGet("http://127.0.0.1:8080/api/redis");
             }
             
             var request = new HttpRequestMessage

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
         /// <summary>
         /// Configuration key for the exporter to be used. The Tracer uses it to encode and
         /// dispatch traces.
-        /// Default is <c>"Zipkin"</c>.
+        /// Default is <c>"otlp"</c>.
         /// </summary>
         public const string Exporter = "OTEL_EXPORTER";
 

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -75,10 +75,7 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
                     // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
                     AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 #endif
-                    builder.AddOtlpExporter(options =>
-                    {
-                        options.ExportProcessorType = ExportProcessorType.Simple; // workaround for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/290
-                    });
+                    builder.AddOtlpExporter();
                     break;
                 case "":
                 case null:

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/Settings.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/Settings.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
                 throw new ArgumentNullException(nameof(source));
             }
 
-            Exporter = source.GetString(ConfigurationKeys.Exporter);
+            Exporter = source.GetString(ConfigurationKeys.Exporter) ?? "otlp";
             LoadTracerAtStartup = source.GetBool(ConfigurationKeys.LoadTracerAtStartup) ?? true;
             ConsoleExporterEnabled = source.GetBool(ConfigurationKeys.ConsoleExporterEnabled) ?? true;
 


### PR DESCRIPTION
Fixes #325

Changes proposed in this pull request:

- Use OTLP exporter by default.

### Issues

1. On .NET Core for some reason the spans from the OTLP exporter do not reach the Collector. Possibly caused by bad configuration.

2. OTLP Exporter vs .NET Framework:

```
Unhandled Exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.TypeInitializationException: The type initializer for 'OpenTelemetry.ClrProfiler.Managed.Loader.Startup' threw an exception. ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.IO.FileNotFoundException: Error loading native library. Not found in any of the possible locations: C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\bin\tracer-home\net461\grpc_csharp_ext.x86.dll,C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\bin\tracer-home\net461\runtimes/win/native\grpc_csharp_ext.x86.dll,C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\bin\tracer-home\net461\../..\runtimes/win/native\grpc_csharp_ext.x86.dll
   at Grpc.Core.Internal.UnmanagedLibrary.FirstValidLibraryPath(String[] libraryPathAlternatives)
   at Grpc.Core.Internal.UnmanagedLibrary..ctor(String[] libraryPathAlternatives)
   at Grpc.Core.Internal.NativeExtension.LoadUnmanagedLibrary()
   at Grpc.Core.Internal.NativeExtension.LoadNativeMethods()
   at Grpc.Core.Internal.NativeExtension..ctor()
   at Grpc.Core.Internal.NativeExtension.Get()
   at Grpc.Core.GrpcEnvironment.GrpcNativeInit()
   at Grpc.Core.GrpcEnvironment..ctor()
   at Grpc.Core.GrpcEnvironment.AddRef()
   at Grpc.Core.Channel..ctor(String target, ChannelCredentials credentials, IEnumerable`1 options)
   at OpenTelemetry.Exporter.OtlpExporterOptionsExtensions.CreateChannel(OtlpExporterOptions options)
   at OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient.OtlpGrpcTraceExportClient..ctor(OtlpExporterOptions options, ITraceServiceClient traceServiceClient)
   at OpenTelemetry.Exporter.OtlpExporterOptionsExtensions.GetTraceExportClient(OtlpExporterOptions options)
   at OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(TracerProviderBuilder builder, OtlpExporterOptions exporterOptions, Action`1 configure, IServiceProvider serviceProvider)
   at OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(TracerProviderBuilder builder, Action`1 configure)
   at OpenTelemetry.ClrProfiler.Managed.Configuration.EnvironmentConfigurationHelper.SetExporter(TracerProviderBuilder builder, Settings settings) in C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.ClrProfiler.Managed\Configuration\EnvironmentConfigurationHelper.cs:line 87
   at OpenTelemetry.ClrProfiler.Managed.Configuration.EnvironmentConfigurationHelper.UseEnvironmentVariables(TracerProviderBuilder builder, Settings settings) in C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.ClrProfiler.Managed\Configuration\EnvironmentConfigurationHelper.cs:line 22
   at OpenTelemetry.ClrProfiler.Managed.Instrumentation.Initialize() in C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.ClrProfiler.Managed\Instrumentation.cs:line 78
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)      
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)       
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, 
CultureInfo culture)
   at OpenTelemetry.ClrProfiler.Managed.Loader.Startup.TryLoadManagedAssembly() in C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.ClrProfiler.Managed.Loader\Startup.cs:line 63
   at OpenTelemetry.ClrProfiler.Managed.Loader.Startup..cctor() in C:\Users\rpajak\repos\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.ClrProfiler.Managed.Loader\Startup.cs:line 29
   --- End of inner exception stack trace ---
   at OpenTelemetry.ClrProfiler.Managed.Loader.Startup..ctor()
   --- End of inner exception stack trace ---
   at System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean noCheck, Boolean& canBeCached, RuntimeMethodHandleInternal& ctor, Boolean& bNeedSecurityCheck)
   at System.RuntimeType.CreateInstanceSlow(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache, StackCrawlMark& 
stackMark)
   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache, StackCrawlMark& stackMark)
   at System.Activator.CreateInstance(Type type, Boolean nonPublic)
   at System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes, StackCrawlMark& stackMark)
   at System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes)
   at System.Reflection.Assembly.CreateInstance(String typeName, Boolean ignoreCase, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes)
   at __DDVoidMethodType__.__DDVoidMethodCall__()
   at GitCredentialManager.Program.Main(String[] args)
```


