### PR TITLE
Add target framework for managed library test project reference

### DIFF
--- a/test/OpenTelemetry.ClrProfiler.Native.Tests/OpenTelemetry.ClrProfiler.Native.Tests.vcxproj
+++ b/test/OpenTelemetry.ClrProfiler.Native.Tests/OpenTelemetry.ClrProfiler.Native.Tests.vcxproj
@@ -88,9 +88,11 @@
   <ItemGroup>
     <ProjectReference Include="..\test-applications\integrations\dependency-libs\Samples.ExampleLibraryTracer\Samples.ExampleLibraryTracer.csproj">
       <Project>{4b243cf1-4269-45c6-a238-1a9bfa58b8cc}</Project>
+      <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\test-applications\integrations\dependency-libs\Samples.ExampleLibrary\Samples.ExampleLibrary.csproj">
       <Project>{fdb5c8d0-018d-4ff9-9680-c6a5078f819b}</Project>
+      <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\src\OpenTelemetry.ClrProfiler.Native\OpenTelemetry.ClrProfiler.Native.vcxproj">
       <Project>{91b6272f-5780-4c94-8071-dbba7b4f67f3}</Project>


### PR DESCRIPTION
Fixes issue with inconsistent test behavior between the CI and local test runners for the native tests. It also allows us to run the native tests from within Visual Studio

The problem was caused by the native tests containing project references to multi-targeted managed projects. The different test runners handle the selection of the managed target framework differently. This PR forces the consistent usage of the net461 target framework, because the native tests are already assuming that the managed libraries are targeting .net framework. If we want to run these native tests against multiple library target frameworks we need to also update the tests so that they are not assuming the presence of mscorlib or other .net framework specifics.
