### PR TITLE
Fix starting container for aspnet tests

### DIFF
--- a/test/integration-tests/IntegrationTests.Helpers/PowershellHelper.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/PowershellHelper.cs
@@ -5,7 +5,7 @@ namespace IntegrationTests.Helpers
 {
     public static class PowershellHelper
     {
-        public static void RunCommand(string psCommand, ITestOutputHelper outputHelper)
+        public static (string StandardOutput, string ErrorOutput) RunCommand(string psCommand, ITestOutputHelper outputHelper)
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.FileName = @"powershell.exe";
@@ -22,6 +22,8 @@ namespace IntegrationTests.Helpers
 
             outputHelper.WriteLine($"PS> {psCommand}");
             outputHelper.WriteResult(helper);
+
+            return (helper.StandardOutput, helper.ErrorOutput);
         }
     }
 }

--- a/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using DotNet.Testcontainers.Containers.Builders;
 using DotNet.Testcontainers.Containers.Modules;
 using DotNet.Testcontainers.Containers.OutputConsumers;

--- a/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
@@ -5,6 +5,7 @@ using DotNet.Testcontainers.Containers.Builders;
 using DotNet.Testcontainers.Containers.Modules;
 using DotNet.Testcontainers.Containers.OutputConsumers;
 using DotNet.Testcontainers.Containers.WaitStrategies;
+using FluentAssertions;
 using IntegrationTests.Helpers.Models;
 using Xunit.Abstractions;
 
@@ -74,6 +75,8 @@ namespace IntegrationTests.Helpers
 
             var container = builder.Build();
             var wasStarted = container.StartAsync().Wait(TimeSpan.FromMinutes(5));
+
+            wasStarted.Should().BeTrue($"Container based on {sampleName} has to be operational for the test");
 
             Output.WriteLine($"Container was started successfully: {wasStarted}");
 

--- a/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
@@ -70,8 +70,7 @@ namespace IntegrationTests.Helpers
                   .WithPortBinding(webPort, 80)
                   .WithEnvironment("OTEL_EXPORTER_ZIPKIN_ENDPOINT", zipkinEndpoint)
                   .WithMount(logPath, "c:/inetpub/wwwroot/logs")
-                  .WithMount(EnvironmentHelper.GetNukeBuildOutput(), "c:/opentelemetry")
-                  .WithWaitStrategy(waitOS.UntilPortIsAvailable(80));
+                  .WithMount(EnvironmentHelper.GetNukeBuildOutput(), "c:/opentelemetry");
 
             var container = builder.Build();
             var wasStarted = container.StartAsync().Wait(TimeSpan.FromMinutes(5));

--- a/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
@@ -76,14 +76,15 @@ namespace IntegrationTests.Helpers
             var container = builder.Build();
             var wasStarted = container.StartAsync().Wait(TimeSpan.FromMinutes(5));
 
-            wasStarted.Should().BeTrue($"Container based on {sampleName} has to be operational for the test");
+            wasStarted.Should().BeTrue($"Container based on {sampleName} has to be operational for the test.");
 
-            Output.WriteLine($"Container was started successfully: {wasStarted}");
+            Output.WriteLine($"Container was started successfully.");
 
-            if (wasStarted)
-            {
-                PowershellHelper.RunCommand($"docker exec {container.Name} curl -v {healthCheckEndpoint}", Output);
-            }
+            PowershellHelper.RunCommand($"docker exec {container.Name} curl -v {healthCheckEndpoint}", Output);
+
+            var (standardOutput, _) = PowershellHelper.RunCommand($"Write-Host (Test-NetConnection -ComputerName 'localhost' -Port {webPort}).TcpTestSucceeded", Output);
+
+            standardOutput.Should().Contain("True", $"Test connection to the port number {webPort} failed. On this port container service should be available.");
 
             return new Container(container);
         }


### PR DESCRIPTION
Should fix #295

## Why
Try to stabilize flaky test.

## What
Change the way how we testing readiness of container.
It is hard to proof, but I think that the strategy `.WithWaitStrategy(waitOS.UntilPortIsAvailable(80)` is error prone. Internally it is trying to connect to the container and it is waiting for the given port.

It should be enough to verify it from the external process (powershell).

## Tests
CI.
When I removed the strategy the container started under 1m.
Probably it is not enough proof, on my fork it usually passed within 5 minutes, even with the strategy.

## Notes

I would like to give a chance for these changes. If the test still will be flaky we can revisit.
