### PR TITLE
Remove unnecessary env vars

### DIFF
--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
@@ -65,16 +65,6 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
             /// Configuration key pattern for enabling or disabling an integration.
             /// </summary>
             public const string Enabled = "OTEL_TRACE_{0}_ENABLED";
-
-            /// <summary>
-            /// Configuration key pattern for enabling or disabling Analytics in an integration.
-            /// </summary>
-            public const string AnalyticsEnabled = "OTEL_TRACE_{0}_ANALYTICS_ENABLED";
-
-            /// <summary>
-            /// Configuration key pattern for setting Analytics sampling rate in an integration.
-            /// </summary>
-            public const string AnalyticsSampleRate = "OTEL_TRACE_{0}_ANALYTICS_SAMPLE_RATE";
         }
     }
 }

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/IntegrationSettings.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/IntegrationSettings.cs
@@ -23,14 +23,6 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
 
             Enabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.Enabled, integrationName)) ??
                       source.GetBool(string.Format("OTEL_{0}_ENABLED", integrationName));
-
-            AnalyticsEnabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName)) ??
-                               source.GetBool(string.Format("OTEL_{0}_ANALYTICS_ENABLED", integrationName));
-
-            AnalyticsSampleRate = source.GetDouble(string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName)) ??
-                                  source.GetDouble(string.Format("OTEL_{0}_ANALYTICS_SAMPLE_RATE", integrationName)) ??
-                                  // default value
-                                  1.0;
         }
 
         /// <summary>
@@ -43,17 +35,5 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
         /// this integration is enabled.
         /// </summary>
         public bool? Enabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether
-        /// Analytics are enabled for this integration.
-        /// </summary>
-        public bool? AnalyticsEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value between 0 and 1 (inclusive)
-        /// that determines the sampling rate for this integration.
-        /// </summary>
-        public double AnalyticsSampleRate { get; set; }
     }
 }

--- a/src/OpenTelemetry.ClrProfiler.Managed/Util/SettingsExtensions.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Util/SettingsExtensions.cs
@@ -13,16 +13,5 @@ namespace OpenTelemetry.ClrProfiler.Managed.Util
 
             return false;
         }
-
-        internal static bool IsIntegrationEnabled(this Settings settings, string integrationName)
-        {
-            if (settings.TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
-            {
-                bool? enabled = settings.Integrations[integrationName].Enabled;
-                return enabled != false;
-            }
-
-            return false;
-        }
     }
 }


### PR DESCRIPTION
Fixes #319 

Changes proposed in this pull request:
Remove support for
`OTEL_TRACE_{0}_ANALYTICS_ENABLED`
`OTEL_TRACE_{0}_ANALYTICS_SAMPLE_RATE`
`OTEL_{0}_ANALYTICS_ENABLED`
`OTEL_{0}_ANALYTICS_SAMPLE_RATE`

`OTEL_{0}_ENABLED` is used in GraphQL and MongoDB integrations to determine if it should be executed.