### PR TITLE
OTLP Exported as default for .NET (Core)

### DIFF
--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -58,7 +58,6 @@ fi
 export OTEL_DOTNET_TRACER_HOME="${CURDIR}/bin/tracer-home"
 export OTEL_INTEGRATIONS="${CURDIR}/bin/tracer-home/integrations.json"
 export OTEL_TRACE_DEBUG="1"
-export OTEL_EXPORTER="zipkin"
 export OTEL_DUMP_ILREWRITE_ENABLED="0"
 export OTEL_CLR_ENABLE_INLINING="1"
 export OTEL_PROFILER_EXCLUDE_PROCESSES="dotnet.exe,dotnet"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -65,7 +65,7 @@ The exporter is used to output the telemetry.
 
 | Environment variable | Description | Default |
 |-|-|-|
-| `OTEL_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `zipkin`, `jeager`, `otlp`. | |
+| `OTEL_EXPORTER` | The exporter to be used. The Tracer uses it to encode and dispatch traces. Available values are: `zipkin`, `jeager`, `otlp`. | `otlp` for .NET (Core), `zipkin` for .NET Framework |
 | `OTEL_EXPORTER_JAEGER_AGENT_HOST` | Hostname for the Jaeger agent. | `localhost` |
 | `OTEL_EXPORTER_JAEGER_AGENT_PORT` | Port for the Jaeger agent. | `6831` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Target endpoint for OTLP exporter. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | `http://localhost:4318` |

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,7 +15,8 @@
 
     <!-- Hack to fix SDK dependencies -->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.3" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,6 +17,8 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.3" />
 
+    <!-- Hack to make the otel exportert working for .NET 5.0 -->
+    <PackageReference Include="Grpc.Net.Client" Version="2.32.0" Condition="'$(TargetFramework)' == 'net5.0'"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
         public const string DisabledInstrumentations = "OTEL_DOTNET_TRACER_DISABLED_INSTRUMENTATIONS";
 
         /// <summary>
-        /// Configuration key for colon (:) separated list of plugins repesented by <see cref="System.Type.AssemblyQualifiedName"/>.
+        /// Configuration key for colon (:) separated list of plugins represented by <see cref="System.Type.AssemblyQualifiedName"/>.
         /// </summary>
         public const string ProviderPlugins = "OTEL_DOTNET_TRACER_INSTRUMENTATION_PLUGINS";
 

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/ConfigurationKeys.cs
@@ -22,7 +22,8 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
         /// <summary>
         /// Configuration key for the exporter to be used. The Tracer uses it to encode and
         /// dispatch traces.
-        /// Default is <c>"Zipkin"</c>.
+        /// Default is <c>"otlp"</c> for .NET (Core).
+        /// Default is <c>"Zipkin"</c> for .NET Framework.
         /// </summary>
         public const string Exporter = "OTEL_EXPORTER";
 

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -84,7 +84,7 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
                 case null:
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("The exporter name is not recognised");
+                    throw new ArgumentOutOfRangeException("The exporter name is not recognized");
             }
 
             return builder;

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -75,10 +75,7 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
                     // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
                     AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 #endif
-                    builder.AddOtlpExporter(options =>
-                    {
-                        options.ExportProcessorType = ExportProcessorType.Simple; // workaround for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/290
-                    });
+                    builder.AddOtlpExporter();
                     break;
                 case "":
                 case null:

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/EnvironmentConfigurationHelper.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 

--- a/src/OpenTelemetry.ClrProfiler.Managed/Configuration/Settings.cs
+++ b/src/OpenTelemetry.ClrProfiler.Managed/Configuration/Settings.cs
@@ -23,7 +23,13 @@ namespace OpenTelemetry.ClrProfiler.Managed.Configuration
                 throw new ArgumentNullException(nameof(source));
             }
 
-            Exporter = source.GetString(ConfigurationKeys.Exporter);
+            Exporter = source.GetString(ConfigurationKeys.Exporter) ??
+#if NETFRAMEWORK
+                       "zipkin";
+#else
+                       "otlp";
+#endif
+
             LoadTracerAtStartup = source.GetBool(ConfigurationKeys.LoadTracerAtStartup) ?? true;
             ConsoleExporterEnabled = source.GetBool(ConfigurationKeys.ConsoleExporterEnabled) ?? true;
 


### PR DESCRIPTION
Partially Fixes #325 
Relates to #324

Changes proposed in this pull request:
Use the OTLP exporter as default for the .NET (Core) and Zipkin for .NET Framework

## Tests

CI
Local tests for ConsoleApp, works fine for
* .NET 4.6.1 (Zipkin exporter)
* .NET Core App 4.1 (otlp)

Works with workaround for
* .NET 5.0 (otlp) 

## Issue to be discussed 

https://www.nuget.org/packages/Grpc.Net.Client/2.32.0 used by https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol/1.2.0-rc1 is released for
* .NET Standard 2.1
* .NET 5.0

Otel-dotnet-inturmenation, for now, is released as .NET 4.6.1 and .NET Core App 3.1.

.NET Core App 3.1 is using .NET Standard 2.1 (deploys Grpc.Net.Client to the tracer-home).

.NET Standard 2.1 of Grpc.Net.Client is not working correctly with .NET 5.0. It leads to following error

```logs
info    zapgrpc/zapgrpc.go:174  [transport] transport: loopyWriter.run returning. connection error: desc = "transport is closing"       {"grpc_log": true}
```

As a workaround, there is a possibility to force load Grpc.Net.Client for .NET 5.0 from the instrumented application. I think that it is not the long-term sollution.

I think that we should consider separate version of otel-intrumentation for .NET 5.0+.


## Alternative solution - defaulting to Otel over http/protobuf

Is it possible, and it is working correctly both for .NET Framework 4.6.1, NET Core App 3.1 and .NET 5.0 without any hacks for the end user, but we should consider following things:
* defaults are different than prepared by the OTEL .NET SDK,
* defaults protocol for otlp exporter should be http/protobuf. The grpc is allowed only when SDK was already released https://github.com/open-telemetry/opentelemetry-specification/blob/ce50e4634efcba8da445cc23523243cb893905cb/specification/protocol/exporter.md?plain=1#L111-L114
* most of the code to manage default values is internal API, we should copy (and maintatin!) it to our code call it by reflections https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs#L61
* in the future we should expect more env-variables to manage on our side, see OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, etc.

To reduce the complication on our side we can consider fixing https://github.com/open-telemetry/opentelemetry-dotnet/issues/2857 and waiting for the next RC candidate. If it will cover updates by the Protocol setter it will reduce complication of the code on our side.

## Discusion about changing default exporter to HTTP
https://github.com/open-telemetry/opentelemetry-dotnet/discussions/2855

