### PR TITLE
Describe OTLP exporter usage

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -78,10 +78,10 @@ The exporter is used to output the telemetry.
 
 - On .NET 5 and later, using the `grpc` OTLP exporter protocol requires the application
   to reference [`Grpc.Net.Client`](https://www.nuget.org/packages/Grpc.Net.Client/).
-  E.g. by adding `<PackageReference Include="Grpc.Net.Client" Version="2.23.0" />` to the `.csproj` file.
+  E.g. by adding `<PackageReference Include="Grpc.Net.Client" Version="2.32.0" />` to the `.csproj` file.
 - On .NET Framework, using the `grpc` OTLP exporter protocol requires the application
   to reference [`Grpc`](https://www.nuget.org/packages/Grpc/).
-  E.g. by adding `<PackageReference Include="Grpc.Net.Grpc" Version="2.32.0" />` to the `.csproj` file.
+  E.g. by adding `<PackageReference Include="Grpc.Net.Grpc" Version="2.23.0" />` to the `.csproj` file.
   
 ### Batch Span Processor
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -79,9 +79,7 @@ The exporter is used to output the telemetry.
 - On .NET 5 and later, using the `grpc` OTLP exporter protocol requires the application
   to reference [`Grpc.Net.Client`](https://www.nuget.org/packages/Grpc.Net.Client/).
   E.g. by adding `<PackageReference Include="Grpc.Net.Client" Version="2.32.0" />` to the `.csproj` file.
-- On .NET Framework, using the `grpc` OTLP exporter protocol requires the application
-  to reference [`Grpc`](https://www.nuget.org/packages/Grpc/).
-  E.g. by adding `<PackageReference Include="Grpc.Net.Grpc" Version="2.23.0" />` to the `.csproj` file.
+- On .NET Framework, using the `grpc` OTLP exporter protocol is not supported.
   
 ### Batch Span Processor
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -71,9 +71,18 @@ The exporter is used to output the telemetry.
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Target endpoint for OTLP exporter. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | `http://localhost:4318` |
 | `OTEL_EXPORTER_OTLP_HEADERS` | Key-value pairs to be used as headers associated with gRPC or HTTP requests. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | |
 | `OTEL_EXPORTER_OTLP_TIMEOUT` | Maximum time the OTLP exporter will wait for each batch export. | `1000` (ms) |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | The transport protocol. Supported values: `grpc`, `http/protobuf`. | `grpc` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | The OTLP expoter transport protocol. Supported values: `grpc`, `http/protobuf`. [1] | `grpc` |
 | `OTEL_EXPORTER_ZIPKIN_ENDPOINT` | Zipkin URL. | `http://localhost:8126` |
 
+**[1]**: `OTEL_EXPORTER_OTLP_PROTOCOL` remarks:
+
+- On .NET 5 and later, using the `grpc` OTLP exporter protocol requires the application
+  to reference [`Grpc.Net.Client`](https://www.nuget.org/packages/Grpc.Net.Client/).
+  E.g. by adding `<PackageReference Include="Grpc.Net.Client" Version="2.23.0" />` to the `.csproj` file.
+- On .NET Framework, using the `grpc` OTLP exporter protocol requires the application
+  to reference [`Grpc`](https://www.nuget.org/packages/Grpc/).
+  E.g. by adding `<PackageReference Include="Grpc.Net.Grpc" Version="2.32.0" />` to the `.csproj` file.
+  
 ### Batch Span Processor
 
 The Batch Span Processor batches of finished spans before they are send by the exporter.


### PR DESCRIPTION
## Why

Currently, trying to use the OTLP exporter usually leads to problems.

Related issue https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/325

Related PR https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/343


## What

Describe the current state of the OTLP exporter support. Proper support of even deperecation of the gRPC protocol can be done later.

## Remarks

For .NET Framework, it is probably more complicated. When I added 

```xml
<PackageReference Include="Grpc.Net.Client" Version="2.32.0" />
```

to the sample app I got:

```csharp
Unhandled Exception: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory 
is corrupt.
   at Grpc.Core.Internal.CompletionQueueSafeHandle.ReleaseHandle()
   at System.Runtime.InteropServices.SafeHandle.InternalDispose()
   at System.Runtime.InteropServices.SafeHandle.Dispose(Boolean disposing)
   at System.Runtime.InteropServices.SafeHandle.Dispose()
   at Grpc.Core.Internal.AsyncCall`2.UnaryCall(TRequest msg)
   at Grpc.Core.DefaultCallInvoker.BlockingUnaryCall[TRequest,TResponse](Method`2 method, String host, CallOptions options, TRequest request)    
   at Grpc.Core.Interceptors.InterceptingCallInvoker.<BlockingUnaryCall>b__3_0[TRequest,TResponse](TRequest req, ClientInterceptorContext`2 ctx) 
   at Grpc.Core.ClientBase.ClientBaseConfiguration.ClientBaseConfigurationInterceptor.BlockingUnaryCall[TRequest,TResponse](TRequest request, ClientInterceptorContext`2 context, BlockingUnaryCallContinuation`2 continuation)
   at Grpc.Core.Interceptors.InterceptingCallInvoker.BlockingUnaryCall[TRequest,TResponse](Method`2 method, String host, CallOptions options, TRequest request)
   at Opentelemetry.Proto.Collector.Trace.V1.TraceService.TraceServiceClient.Export(ExportTraceServiceRequest request, CallOptions options)      
   at Opentelemetry.Proto.Collector.Trace.V1.TraceService.TraceServiceClient.Export(ExportTraceServiceRequest request, Metadata headers, Nullable`1 deadline, CancellationToken cancellationToken)
   at OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient.OtlpGrpcTraceExportClient.SendExportRequest(ExportTraceServiceRequest request, CancellationToken cancellationToken)
   at OpenTelemetry.Exporter.OtlpTraceExporter.Export(Batch`1& activityBatch)
   at OpenTelemetry.BatchExportProcessor`1.ExporterProc()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)  
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
Segmentation fault
```