### PR TITLE
Fix mismatch between attribute and log message for startup hook logging.

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHookEventSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHookEventSource.cs
@@ -14,7 +14,7 @@ namespace OpenTelemetry.AutoInstrumentation.StartupHook
 
         /// <summary>Logs as Trace level message.</summary>
         /// <param name="message">Message to log.</param>
-        [Event(2, Message = "{0}", Level = EventLevel.Informational)]
+        [Event(1, Message = "{0}", Level = EventLevel.Informational)]
         public void Trace(string message)
         {
             this.WriteEvent(1, message);


### PR DESCRIPTION
When diagnosing another problem in a test application I noticed that the troubleshooting logs that the OTel SDK can generate reported an error with attempting to log a message from the startup hook. The error was caused by the event id value in the attribute was different than the event id passed in the call to log the message. This change fixes that error, and allows us to the desired log message when the appropriate troubleshooting log levels are enabled.

