### PR TITLE
.NET 6.0 follow-up

### DIFF
--- a/docs/POC_README.md
+++ b/docs/POC_README.md
@@ -91,7 +91,7 @@ aspNetAppTargetFramework=net5.0 sampleAppTargetFramework=net5.0 ./poc.sh
 For .NET Framework run:
 
 ```sh
-sampleAppTargetFramework=net46 ./poc.sh
+sampleAppTargetFramework=net462 ./poc.sh
 ```
 
 To instrument the .NET BindingRedirect sample application run:

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -10,14 +10,13 @@ On all platforms, the minimum requirements are:
 
 ### Windows
 
-- [Visual Studio 2022 (17.0)](https://visualstudio.microsoft.com/downloads/) or newer
-  - Workloads
-    - Desktop development with C++
+- [Visual Studio 2022 (17.1)](https://visualstudio.microsoft.com/downloads/) or newer
+  - Workloads (with recommeded components):
+    - ASP.NET and web development
     - .NET desktop development
-    - .NET Core cross-platform development
-    - Optional: ASP.NET and web development (to build samples)
-  - Individual components
-    - .NET Framework 4.7 targeting pack
+    - Desktop development with C++
+  - Individual components:
+    - MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.29)
 - [Docker for Windows](https://docs.docker.com/docker-for-windows/)
 
 Microsoft provides

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -134,8 +134,8 @@ export OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS=HttpClient
 
   ```bash
   PATH="$PATH:$PWD/artifacts/bin/coreclr/Linux.x64.Debug/corerun"
-  export CORE_LIBRARIES="$PWD/artifacts/bin/runtime/net5.0-Linux-Debug-x64"
-  corerun ~/repos/opentelemetry-dotnet-instrumentation/samples/ConsoleApp/bin/Debug/net5.0/ConsoleApp.dll
+  export CORE_LIBRARIES="$PWD/artifacts/bin/runtime/net6.0-Linux-Debug-x64"
+  corerun ~/repos/opentelemetry-dotnet-instrumentation/samples/ConsoleApp/bin/Debug/net6.0/ConsoleApp.dll
   ```
 
 - [Debugging](https://github.com/dotnet/runtime/blob/main/docs/workflow/debugging/coreclr/debugging.md)
@@ -145,10 +145,10 @@ export OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS=HttpClient
   ```bash
   ~/repos/opentelemetry-dotnet-instrumentation$ source dev/envvars.sh 
   ~/repos/opentelemetry-dotnet-instrumentation$ cd ../runtime/
-  ~/repos/runtime$ lldb -- ./artifacts/bin/coreclr/Linux.x64.Debug/corerun ~/repos/opentelemetry-dotnet-instrumentation/samples/ConsoleApp/bin/Debug/net5.0/ConsoleApp.dll
+  ~/repos/runtime$ lldb -- ./artifacts/bin/coreclr/Linux.x64.Debug/corerun ~/repos/opentelemetry-dotnet-instrumentation/samples/ConsoleApp/bin/Debug/net6.0/ConsoleApp.dll
   (lldb) target create "./artifacts/bin/coreclr/Linux.x64.Debug/corerun"
   Current executable set to '/home/user/repos/runtime/artifacts/bin/coreclr/Linux.x64.Debug/corerun' (x86_64).
-  (lldb) settings set -- target.run-args  "/home/user/repos/opentelemetry-dotnet-instrumentation/samples/ConsoleApp/bin/Debug/net5.0/ConsoleApp.dll"
+  (lldb) settings set -- target.run-args  "/home/user/repos/opentelemetry-dotnet-instrumentation/samples/ConsoleApp/bin/Debug/net6.0/ConsoleApp.dll"
   (lldb) process launch -s
   Process 1905 launched: '/home/user/repos/runtime/artifacts/bin/coreclr/Linux.x64.Debug/corerun' (x86_64)
   (lldb) process handle -s false SIGUSR1 SIGUSR2

--- a/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
+++ b/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/samples/CoreAppOldReference/CoreAppOldReference.csproj
+++ b/samples/CoreAppOldReference/CoreAppOldReference.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>Samples.AspNetCoreMvc</RootNamespace>
   </PropertyGroup>
 

--- a/samples/Vendor.Distro/Vendor.Distro.csproj
+++ b/samples/Vendor.Distro/Vendor.Distro.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Version>0.0.1</Version>
   </PropertyGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,8 +3,8 @@
 
   <PropertyGroup>
     <!-- only run .NET Framework tests on Windows -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/test/integration-tests/IntegrationTests.GraphQL/GraphQLTests.cs
+++ b/test/integration-tests/IntegrationTests.GraphQL/GraphQLTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using IntegrationTests.Helpers;
 using IntegrationTests.Helpers.Models;
@@ -219,7 +220,10 @@ public class GraphQLTests : TestHelper
     {
         try
         {
+            #pragma warning disable SYSLIB0014 // suppress error SYSLIB0014: 'WebRequest.Create(string)' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead
             var request = WebRequest.Create($"http://localhost:{aspNetCorePort}{requestInfo.Url}");
+            #pragma warning restore SYSLIB0014
+
             request.Method = requestInfo.HttpMethod;
 
             if (requestInfo.RequestBody != null)

--- a/test/integration-tests/IntegrationTests.StartupHook/IntegrationTests.StartupHook.csproj
+++ b/test/integration-tests/IntegrationTests.StartupHook/IntegrationTests.StartupHook.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.StartupHook/Directory.Build.props
+++ b/test/test-applications/integrations/Samples.StartupHook/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
 


### PR DESCRIPTION
Fixes #379

Changes proposed in this pull request:
- Add `net6.0` target framework everywhere
- Update runtime debugging documentation
- Update Visual Studio requirements
- [suppress error SYSLIB0014](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/383/commits/eb06e3654b37b6b1e5fe2e87f10d1675a497b2d6) - I think it would be an overkill to rewrite the test to use `HttpClient` instead