### PR TITLE
Add windowscontainer_version parameter

### DIFF
--- a/build/nuke/Build.Steps.Windows.cs
+++ b/build/nuke/Build.Steps.Windows.cs
@@ -136,7 +136,7 @@ partial class Build
             {
                 DockerBuild(x => x
                     .SetPath(".")
-                    .SetBuildArg($"configuration={BuildConfiguration}")
+                    .SetBuildArg($"configuration={BuildConfiguration}", $"windowscontainer_version={WindowsContainerVersion}")
                     .SetRm(true)
                     .SetTag(Path.GetFileNameWithoutExtension(proj).Replace(".", "-").ToLowerInvariant())
                     .SetProcessWorkingDirectory(proj.Parent)

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -17,6 +17,9 @@ partial class Build : NukeBuild
     [Parameter("Platform to build - x86 or x64. Default is x64")]
     readonly MSBuildTargetPlatform Platform = MSBuildTargetPlatform.x64;
 
+    [Parameter("Windows Server Core container version. Use it if your Windows does not support the default value. Default is 'ltsc2022'")]
+    readonly string WindowsContainerVersion = "ltsc2022";
+
     [Parameter("The location to create the tracer home directory. Default is ./bin/tracer-home ")]
     readonly AbsolutePath TracerHome;
     [Parameter("The location to place NuGet packages and other packages. Default is ./bin/artifacts ")]

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/Dockerfile
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/Dockerfile
@@ -1,18 +1,21 @@
-FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022
-ARG configuration=debug
+# escape=`
+
+ARG windowscontainer_version=ltsc2022
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-${windowscontainer_version}
+ARG configuration=Debug
 ARG platform=x64
-ENV COR_ENABLE_PROFILING=1 \
-    COR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318} \
-    COR_PROFILER_PATH=C:\\opentelemetry\\win-${platform}\\OpenTelemetry.AutoInstrumentation.Native.dll \
-    OTEL_DOTNET_AUTO_HOME=C:\\opentelemetry\\ \
-    OTEL_DOTNET_AUTO_INTEGRATIONS_FILE=C:\\opentelemetry\\integrations.json \
-    OTEL_TRACES_EXPORTER=zipkin \
-    OTEL_DOTNET_AUTO_ADDITIONAL_SOURCES=Samples.* \
-    OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS=HttpClient,AspNet \
-    OTEL_SERVICE_NAME=Samples.AspNet \
-    OTEL_DOTNET_AUTO_DOMAIN_NEUTRAL_INSTRUMENTATION=1 \
-    OTEL_DOTNET_AUTO_DEBUG=1 \
-    OTEL_DOTNET_AUTO_LOG_DIRECTORY=C:\\inetpub\\wwwroot\\logs \
+ENV COR_ENABLE_PROFILING=1 `
+    COR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318} `
+    COR_PROFILER_PATH=C:\opentelemetry\win-${platform}\OpenTelemetry.AutoInstrumentation.Native.dll `
+    OTEL_DOTNET_AUTO_HOME=C:\opentelemetry\ `
+    OTEL_DOTNET_AUTO_INTEGRATIONS_FILE=C:\opentelemetry\integrations.json `
+    OTEL_TRACES_EXPORTER=zipkin `
+    OTEL_DOTNET_AUTO_ADDITIONAL_SOURCES=Samples.* `
+    OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS=HttpClient,AspNet `
+    OTEL_SERVICE_NAME=Samples.AspNet `
+    OTEL_DOTNET_AUTO_DOMAIN_NEUTRAL_INSTRUMENTATION=1 `
+    OTEL_DOTNET_AUTO_DEBUG=1 `
+    OTEL_DOTNET_AUTO_LOG_DIRECTORY=C:\inetpub\wwwroot\logs `
     OTEL_DOTNET_AUTO_INCLUDE_PROCESSES=w3wp.exe
-WORKDIR C:\\inetpub\\wwwroot
+WORKDIR C:\inetpub\wwwroot
 COPY bin/${configuration}/app.publish .


### PR DESCRIPTION
As a developer, I want to be able to run the tests using Windows containers even if my OS is not the newest one.

## Testing

```
nuke
nuke ManagedTests --windows-server-core-version ltsc2019
```

build passed

