### PR TITLE
Bump OTel .NET SDK to 1.2.0-rc3

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -120,7 +120,7 @@ public OpenTelemetry.Trace.TracerProviderBuilder ConfigureTracerProvider(OpenTel
 ```
 
 The plugin must use the same version of the `OpenTelemetry` as the
-OpenTelemetry .NET AutoInstrumentation. Current version is `1.2.0-rc2`.
+OpenTelemetry .NET AutoInstrumentation. Current version is `1.2.0-rc3`.
 
 ## .NET CLR Profiler
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -63,10 +63,10 @@ The exporter is used to output the telemetry.
 | Environment variable | Description | Default |
 |-|-|-|
 | `OTEL_TRACES_EXPORTER` | The traces exporter to be used. Available values are: `zipkin`, `jeager`, `otlp`, `none`. | `otlp` |
-| `OTEL_EXPORTER_JAEGER_AGENT_HOST` | Hostname for the Jaeger agent. Used for `UdpCompactThrift` protocol.| `localhost` |
-| `OTEL_EXPORTER_JAEGER_AGENT_PORT` | Port for the Jaeger agent. Used for `UdpCompactThrift` protocol. | `6831` |
-| `OTEL_EXPORTER_JAEGER_ENDPOINT` | The Jaeger Collector HTTP endpoint. Used for `HttpBinaryThrift` protocol. | `http://localhost:14268` |
-| `OTEL_EXPORTER_JAEGER_PROTOCOL` | The protocol to use for Jager exporter. Supported values: `UdpCompactThrift`, `HttpBinaryThrift` | `UdpCompactThrift` |
+| `OTEL_EXPORTER_JAEGER_AGENT_HOST` | Hostname for the Jaeger agent. Used for `udp/thrift.compact` protocol.| `localhost` |
+| `OTEL_EXPORTER_JAEGER_AGENT_PORT` | Port for the Jaeger agent. Used for `udp/thrift.compact` protocol. | `6831` |
+| `OTEL_EXPORTER_JAEGER_ENDPOINT` | The Jaeger Collector HTTP endpoint. Used for `http/thrift.binary` protocol. | `http://localhost:14268` |
+| `OTEL_EXPORTER_JAEGER_PROTOCOL` | The protocol to use for Jager exporter. Supported values: `udp/thrift.compact`, `http/thrift.binary` | `udp/thrift.compact` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Target endpoint for OTLP exporter. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | `http://localhost:4318` for `http/protobuf` protocol, `http://localhost:4317` for `grpc` protocol |
 | `OTEL_EXPORTER_OTLP_HEADERS` | Key-value pairs to be used as headers associated with gRPC or HTTP requests. More details [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md). | |
 | `OTEL_EXPORTER_OTLP_TIMEOUT` | Maximum time the OTLP exporter will wait for each batch export. | `1000` (ms) |

--- a/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
+++ b/samples/ConsoleApp.SelfBootstrap/ConsoleApp.SelfBootstrap.csproj
@@ -10,15 +10,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" Condition="'$(TargetFramework)' != 'net462'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc10" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc10" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc10" />
   </ItemGroup>
   
 </Project>

--- a/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc10" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/samples/Vendor.Distro/Vendor.Distro.csproj
+++ b/samples/Vendor.Distro/Vendor.Distro.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc2" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -32,11 +32,6 @@ public class ConfigurationKeys
     public const string ExporterOtlpProtocol = "OTEL_EXPORTER_OTLP_PROTOCOL";
 
     /// <summary>
-    /// Configuration key for the OTLP exporter endpoint to be used.
-    /// </summary>
-    public const string ExporterOtlpEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT";
-
-    /// <summary>
     /// Configuration key for whether the console exporter is enabled.
     /// </summary>
     public const string ConsoleExporterEnabled = "OTEL_DOTNET_AUTO_CONSOLE_EXPORTER_ENABLED";

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationHelper.cs
@@ -85,11 +85,6 @@ internal static class EnvironmentConfigurationHelper
                     {
                         options.Protocol = settings.OtlpExportProtocol.Value;
                     }
-
-                    if (settings.OtlpExportEndpoint != null)
-                    {
-                        options.Endpoint = settings.OtlpExportEndpoint;
-                    }
                 });
                 break;
             case TracesExporter.None:

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -167,7 +167,7 @@ public class Settings
 
     private static OtlpExportProtocol? GetExporterOtlpProtocol(IConfigurationSource source)
     {
-        // the defualt in SDK is grpc. http/protobuf should be default for our purposes
+        // the default in SDK is grpc. http/protobuf should be default for our purposes
         var exporterOtlpProtocol = source.GetString(ConfigurationKeys.ExporterOtlpProtocol);
 
         if (string.IsNullOrEmpty(exporterOtlpProtocol) || exporterOtlpProtocol == "http/protobuf")

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -25,7 +25,6 @@ public class Settings
 
         TracesExporter = ParseTracesExporter(source);
         OtlpExportProtocol = GetExporterOtlpProtocol(source);
-        OtlpExportEndpoint = GetExporterOtlpEndpoint(source, OtlpExportProtocol);
 
         LoadTracerAtStartup = source.GetBool(ConfigurationKeys.LoadTracerAtStartup) ?? true;
         ConsoleExporterEnabled = source.GetBool(ConfigurationKeys.ConsoleExporterEnabled) ?? true;
@@ -114,13 +113,6 @@ public class Settings
     public OtlpExportProtocol? OtlpExportProtocol { get; }
 
     /// <summary>
-    /// Gets the the OTLP exporter endpoint.
-    /// Will be removed when https://github.com/open-telemetry/opentelemetry-dotnet/pull/2868 is released.
-    /// </summary>
-    // TODO: To be removed when https://github.com/open-telemetry/opentelemetry-dotnet/pull/2868 is released.
-    public Uri OtlpExportEndpoint { get; }
-
-    /// <summary>
     /// Gets a value indicating whether the console exporter is enabled.
     /// </summary>
     public bool ConsoleExporterEnabled { get; }
@@ -173,7 +165,7 @@ public class Settings
         if (string.IsNullOrEmpty(exporterOtlpProtocol) || exporterOtlpProtocol == "http/protobuf")
         {
             // override settings only for http/protobuf
-            // the second part of the condition is needed to override default endpoint as long as https://github.com/open-telemetry/opentelemetry-dotnet/pull/2868 is not fixed
+            // the second part of the condition is needed to override default endpoint as long as we verify if enable System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport in EnvironmentConfigurationHelper
             return OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
         }
 
@@ -199,19 +191,5 @@ public class Settings
             default:
                 throw new FormatException($"Traces exporter '{tracesExporterEnvVar}' is not supported");
         }
-    }
-
-    private static Uri GetExporterOtlpEndpoint(IConfigurationSource source, OtlpExportProtocol? otlpExportProtocol)
-    {
-        var exporterOtlpEndpoint = source.GetString(ConfigurationKeys.ExporterOtlpEndpoint);
-
-        if (otlpExportProtocol == OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf && string.IsNullOrWhiteSpace(exporterOtlpEndpoint))
-        {
-            // override endpoint only for otlp over http/protobuf
-            return new Uri("http://localhost:4318/v1/traces");
-        }
-
-        // null value here means that it will be handled by OTEL .NET SDK
-        return null;
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -5,17 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc2" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc10" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc10" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -31,7 +31,6 @@ public class SettingsTests : IDisposable
             settings.LoadTracerAtStartup.Should().BeTrue();
             settings.TracesExporter.Should().Be(TracesExporter.Otlp);
             settings.OtlpExportProtocol.Should().Be(OtlpExportProtocol.HttpProtobuf);
-            settings.OtlpExportEndpoint.Should().Be(new Uri("http://localhost:4318/v1/traces"));
             settings.ConsoleExporterEnabled.Should().BeTrue();
             settings.EnabledInstrumentations.Should().BeEmpty();
             settings.TracerPlugins.Should().BeEmpty();
@@ -68,45 +67,24 @@ public class SettingsTests : IDisposable
     }
 
     [Theory]
-    [InlineData("", OtlpExportProtocol.HttpProtobuf, "http://localhost:4318/v1/traces")]
-    [InlineData(null, OtlpExportProtocol.HttpProtobuf, "http://localhost:4318/v1/traces")]
-    [InlineData("http/protobuf", OtlpExportProtocol.HttpProtobuf, "http://localhost:4318/v1/traces")]
-    [InlineData("grpc", null, null)]
-    [InlineData("nonExistingProtocol", null, null)]
-    public void OtlpExporterProperties_DependsOnCorrespondingEnvVariables(string otlpProtocol, OtlpExportProtocol? expectedOtlpExportProtocol, string expectedOtlpExportEndpoint)
+    [InlineData("", OtlpExportProtocol.HttpProtobuf)]
+    [InlineData(null, OtlpExportProtocol.HttpProtobuf)]
+    [InlineData("http/protobuf", OtlpExportProtocol.HttpProtobuf)]
+    [InlineData("grpc", null)]
+    [InlineData("nonExistingProtocol", null)]
+    public void OtlpExportProtocol_DependsOnCorrespondingEnvVariable(string otlpProtocol, OtlpExportProtocol? expectedOtlpExportProtocol)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, otlpProtocol);
 
         var settings = Settings.FromDefaultSources();
 
-        using (new AssertionScope())
-        {
-            // null values for expected data will be handled by OTel .NET SDK
-            settings.OtlpExportProtocol.Should().Be(expectedOtlpExportProtocol);
-            settings.OtlpExportEndpoint.Should().Be(expectedOtlpExportEndpoint != null ? new Uri(expectedOtlpExportEndpoint) : null);
-        }
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("http/protobuf")]
-    [InlineData("grpc")]
-    [InlineData("nonExistingProtocol")]
-    public void OtlpExportEndpoint_IsNullWhenCorrespondingEnvVarIsSet(string otlpProtocol)
-    {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, otlpProtocol);
-        Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpEndpoint, "http://customurl:1234");
-
-        var settings = Settings.FromDefaultSources();
-
-        settings.OtlpExportEndpoint.Should().BeNull("leaving as null as SDK will handle it");
+        // null values for expected data will be handled by OTel .NET SDK
+        settings.OtlpExportProtocol.Should().Be(expectedOtlpExportProtocol);
     }
 
     private static void ClearEnvVars()
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.TracesExporter, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, null);
-        Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpEndpoint, null);
     }
 }

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
@@ -41,10 +41,10 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-rc2\lib\net462\OpenTelemetry.Api.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-rc3\lib\net462\OpenTelemetry.Api.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc9\lib\net462\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc10\lib\net462\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
-  <package id="OpenTelemetry.Api" version="1.2.0-rc2" targetFramework="net462" />
-  <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc9" targetFramework="net462" />
+  <package id="OpenTelemetry.Api" version="1.2.0-rc3" targetFramework="net462" />
+  <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc10" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net462" />
   <package id="System.Memory" version="4.5.4" targetFramework="net462" />


### PR DESCRIPTION
Fixes #352

Changes proposed in this pull request:
Update OTel .NET SDK to 1.2.0-rc3 and other components to 1.0.0-rc10
Remove custom handling for OTLP Exporter Endpoint.
Update config.md based on readmes from https://github.com/open-telemetry/opentelemetry-dotnet/compare/core-1.2.0-rc2...core-1.2.0-rc3

