### PR TITLE
Option to enable the System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -82,6 +82,7 @@ The exporter is used to output the telemetry.
 | `OTEL_EXPORTER_OTLP_TIMEOUT` | Maximum time the OTLP exporter will wait for each batch export. | `1000` (ms) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | The OTLP expoter transport protocol. Supported values: `grpc`, `http/protobuf`. [1] | `http/protobuf` |
 | `OTEL_EXPORTER_ZIPKIN_ENDPOINT` | Zipkin URL. | `http://localhost:8126` |
+| `OTEL_DOTNET_AUTO_HTTP2UNENCRYPTEDSUPPORT_ENABLED` | Allows to enable `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport`. It is required by OTLP over `grpc` exporter execute on .NET Core 3.x. For details plesae check [this documentation](https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client) | `false` |
 
 **[1]**: `OTEL_EXPORTER_OTLP_PROTOCOL` remarks:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -82,7 +82,7 @@ The exporter is used to output the telemetry.
 | `OTEL_EXPORTER_OTLP_TIMEOUT` | Maximum time the OTLP exporter will wait for each batch export. | `1000` (ms) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | The OTLP expoter transport protocol. Supported values: `grpc`, `http/protobuf`. [1] | `http/protobuf` |
 | `OTEL_EXPORTER_ZIPKIN_ENDPOINT` | Zipkin URL. | `http://localhost:8126` |
-| `OTEL_DOTNET_AUTO_HTTP2UNENCRYPTEDSUPPORT_ENABLED` | Allows to enable `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport`. It is required by OTLP over `grpc` exporter execute on .NET Core 3.x. For details plesae check [this documentation](https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client) | `false` |
+| `OTEL_DOTNET_AUTO_HTTP2UNENCRYPTEDSUPPORT_ENABLED` | Enables `[System.Net](http://system.net/).Http.SocketsHttpHandler.Http2UnencryptedSupport`. Required by OTLP over gRPC when instrumenting NET Core 3.x applications. See [the official Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-6.0#call-insecure-grpc-services-with-net-core-client) for more details. | `false` |
 
 **[1]**: `OTEL_EXPORTER_OTLP_PROTOCOL` remarks:
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -63,7 +63,7 @@ public class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for enabling `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport`.
-    /// It is required by OTLP Grpc exporter.
+    /// It is required by OTLP gRPC exporter on .NET Core 3.x.
     /// Default is <c>false</c>.
     /// </summary>
     public const string Http2UnencryptedSupportEnabled = "OTEL_DOTNET_AUTO_HTTP2UNENCRYPTEDSUPPORT_ENABLED";

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -62,6 +62,13 @@ public class ConfigurationKeys
     public const string LegacySources = "OTEL_DOTNET_AUTO_LEGACY_SOURCES";
 
     /// <summary>
+    /// Configuration key for enabling `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport`.
+    /// It is required by OTLP Grpc exporter.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public const string Http2UnencryptedSupportEnabled = "OTEL_DOTNET_AUTO_HTTP2UNENCRYPTEDSUPPORT_ENABLED";
+
+    /// <summary>
     /// String format patterns used to match integration-specific configuration keys.
     /// </summary>
     internal static class Integrations

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationHelper.cs
@@ -71,7 +71,7 @@ internal static class EnvironmentConfigurationHelper
                 break;
             case TracesExporter.Otlp:
 #if NETCOREAPP3_1
-                if (!settings.OtlpExportProtocol.HasValue || settings.OtlpExportProtocol != OtlpExportProtocol.HttpProtobuf)
+                if (settings.Http2UnencryptedSupportEnabled)
                 {
                     // Adding the OtlpExporter creates a GrpcChannel.
                     // This switch must be set before creating a GrpcChannel/HttpClient when calling an insecure gRPC service.

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -147,7 +147,7 @@ public class Settings
     /// <summary>
     /// Gets a value indicating whether the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport`
     /// should be enabled.
-    /// It is required by OTLP Grpc exporter.
+    /// It is required by OTLP gRPC exporter on .NET Core 3.x.
     /// Default is <c>false</c>.
     /// </summary>
     public bool Http2UnencryptedSupportEnabled { get; }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -88,6 +88,8 @@ public class Settings
         LoadTracerAtStartup = source.GetBool(ConfigurationKeys.LoadTracerAtStartup) ?? true;
 
         Integrations = new IntegrationSettingsCollection(source);
+
+        Http2UnencryptedSupportEnabled = source.GetBool(ConfigurationKeys.Http2UnencryptedSupportEnabled) ?? false;
     }
 
     /// <summary>
@@ -141,6 +143,14 @@ public class Settings
     /// Gets a collection of <see cref="Integrations"/> keyed by integration name.
     /// </summary>
     public IntegrationSettingsCollection Integrations { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport`
+    /// should be enabled.
+    /// It is required by OTLP Grpc exporter.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool Http2UnencryptedSupportEnabled { get; }
 
     internal static Settings FromDefaultSources()
     {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -172,10 +172,9 @@ public class Settings
         // the default in SDK is grpc. http/protobuf should be default for our purposes
         var exporterOtlpProtocol = source.GetString(ConfigurationKeys.ExporterOtlpProtocol);
 
-        if (string.IsNullOrEmpty(exporterOtlpProtocol) || exporterOtlpProtocol == "http/protobuf")
+        if (string.IsNullOrEmpty(exporterOtlpProtocol))
         {
             // override settings only for http/protobuf
-            // the second part of the condition is needed to override default endpoint as long as we verify if enable System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport in EnvironmentConfigurationHelper
             return OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
         }
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -70,7 +70,7 @@ public class SettingsTests : IDisposable
     [Theory]
     [InlineData("", OtlpExportProtocol.HttpProtobuf)]
     [InlineData(null, OtlpExportProtocol.HttpProtobuf)]
-    [InlineData("http/protobuf", OtlpExportProtocol.HttpProtobuf)]
+    [InlineData("http/protobuf", null)]
     [InlineData("grpc", null)]
     [InlineData("nonExistingProtocol", null)]
     public void OtlpExportProtocol_DependsOnCorrespondingEnvVariable(string otlpProtocol, OtlpExportProtocol? expectedOtlpExportProtocol)

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -37,6 +37,7 @@ public class SettingsTests : IDisposable
             settings.ActivitySources.Should().BeEquivalentTo(new List<string> { "OpenTelemetry.AutoInstrumentation.*" });
             settings.LegacySources.Should().BeEmpty();
             settings.Integrations.Should().NotBeNull();
+            settings.Http2UnencryptedSupportEnabled.Should().BeFalse();
         }
     }
 
@@ -82,9 +83,23 @@ public class SettingsTests : IDisposable
         settings.OtlpExportProtocol.Should().Be(expectedOtlpExportProtocol);
     }
 
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData(null, false)]
+    public void Http2UnencryptedSupportEnabled_DependsOnCorrespondingEnvVariable(string http2UnencryptedSupportEnabled, bool expectedValue)
+    {
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Http2UnencryptedSupportEnabled, http2UnencryptedSupportEnabled);
+
+        var settings = Settings.FromDefaultSources();
+
+        settings.Http2UnencryptedSupportEnabled.Should().Be(expectedValue);
+    }
+
     private static void ClearEnvVars()
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.TracesExporter, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, null);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Http2UnencryptedSupportEnabled, null);
     }
 }


### PR DESCRIPTION
Fixes #217

Changes proposed in this pull request:
`System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` is by default disabled.
As it could be a security issue it can be manually enabled by `OTEL_DOTNET_AUTO_HTTP2UNENCRYPTEDSUPPORT_ENABLED`.
It is needed only for .NET Core 3.x. Newer versions of .NET are not affected.
