### PR TITLE
Configure dependabot to update Directory.Build.props

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,19 @@ updates:
     schedule:
       day: sunday
       interval: weekly
+  
+  - package-ecosystem: nuget
+    directory: /src
+    labels:
+      - dependencies
+    schedule:
+      day: sunday
+      interval: weekly
+
+  - package-ecosystem: nuget
+    directory: /test
+    labels:
+      - dependencies
+    schedule:
+      day: sunday
+      interval: weekly


### PR DESCRIPTION
**What**:

Update dependencies from `Directory.Build.props` from `/src` and `/test` directories.

Fixes #356 

