### PR TITLE
Bump OTel .NET SDK to 1.2.0-rc4

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -131,7 +131,7 @@ public OpenTelemetry.Trace.TracerProviderBuilder ConfigureTracerProvider(OpenTel
 ```
 
 The plugin must use the same version of the `OpenTelemetry` as the
-OpenTelemetry .NET AutoInstrumentation. Current version is `1.2.0-rc3`.
+OpenTelemetry .NET AutoInstrumentation. Current version is `1.2.0-rc4`.
 
 ## .NET CLR Profiler
 

--- a/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
+++ b/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc10" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
+++ b/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
@@ -10,15 +10,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc10" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc10" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc10" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc10" Condition="'$(TargetFramework)' != 'net462'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc10" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.1" />
   </ItemGroup>
   
 </Project>

--- a/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
+++ b/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -5,17 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc10" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc10" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc10" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc3" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc10" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
@@ -41,10 +41,10 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-rc3\lib\net461\OpenTelemetry.Api.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-rc4\lib\net461\OpenTelemetry.Api.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc10\lib\net461\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc9.1\lib\net461\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
-  <package id="OpenTelemetry.Api" version="1.2.0-rc3" targetFramework="net462" />
-  <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc10" targetFramework="net462" />
+  <package id="OpenTelemetry.Api" version="1.2.0-rc4" targetFramework="net462" />
+  <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc9.1" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net462" />
   <package id="System.Memory" version="4.5.4" targetFramework="net462" />


### PR DESCRIPTION
Fixes #431 #432 #433 #434 #435

Changes proposed in this pull request:

Bump OTel .NET SDK to 1.2.0-rc4
and related packages to 1.0.0-rc9.1
1.0.0-rc10 was unlisted