### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,100 @@ updates:
       day: sunday
       interval: weekly
 
+ 
   - package-ecosystem: nuget
     directory: /build/nuke
     schedule:
       day: sunday
       interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/AspNetCoreMvc
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/BindingRedirect
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/ConsoleApp
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/ConsoleApp.SelfBootstrap
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/CoreAppOldReference
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/OldReference
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/OpenTracingLibrary
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /examples/Vendor.Distro
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
 
   - package-ecosystem: nuget
     directory: /src/OpenTelemetry.AutoInstrumentation
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /src/OpenTelemetry.AutoInstrumentation.AdditionalDeps
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /src/OpenTelemetry.AutoInstrumentation.Core
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /src/OpenTelemetry.AutoInstrumentation.Loader
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /src/OpenTelemetry.AutoInstrumentation.StartupHook
     schedule:
       day: sunday
       interval: weekly
@@ -28,7 +114,98 @@ updates:
     open-pull-requests-limit: 20
 
   - package-ecosystem: nuget
+    directory: /test/integration-tests/IntegrationTests.GraphQL
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
     directory: /test/integration-tests/IntegrationTests.Helpers
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/integration-tests/IntegrationTests.MongoDB
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/integration-tests/IntegrationTests.StartupHook
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/OpenTelemetry.AutoInstrumentation.Loader.Tests
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/OpenTelemetry.AutoInstrumentation.Tests
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/test-applications/integrations/aspnet/Samples.AspNet
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/test-applications/integrations/dependency-libs/Samples.ExampleLibrary
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/test-applications/integrations/dependency-libs/Samples.ExampleLibraryTracer
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/test-applications/integrations/Samples.GraphQL
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/test-applications/integrations/Samples.MongoDB
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/test-applications/integrations/Samples.StartupHook
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/test-applications/mocks/OpenTelemetry.AutoInstrumentation.Mock
     schedule:
       day: sunday
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,45 +3,33 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
-    labels:
-      - dependencies
-      - actions
     schedule:
       day: sunday
       interval: weekly
 
   - package-ecosystem: nuget
     directory: /build/nuke
-    labels:
-      - dependencies
     schedule:
       day: sunday
       interval: weekly
 
   - package-ecosystem: nuget
     directory: /src/OpenTelemetry.AutoInstrumentation
-    labels:
-      - dependencies
-    ignore:
-      # these libraries are kept at the lowest supported version for compatibility on netstandard2.0
-      - dependency-name: "System.Reflection.Emit"
-      - dependency-name: "System.Reflection.Emit.Lightweight"
     schedule:
       day: sunday
       interval: weekly
-  
-  - package-ecosystem: nuget
-    directory: /src
-    labels:
-      - dependencies
-    schedule:
-      day: sunday
-      interval: weekly
+    open-pull-requests-limit: 20
 
   - package-ecosystem: nuget
-    directory: /test
-    labels:
-      - dependencies
+    directory: /test/integration-tests/aspnet/IntegrationTests.AspNet
     schedule:
       day: sunday
       interval: weekly
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
+    directory: /test/integration-tests/IntegrationTests.Helpers
+    schedule:
+      day: sunday
+      interval: weekly
+    open-pull-requests-limit: 20


### PR DESCRIPTION
## Why

Per https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/356#issuecomment-1087280213

## What

Fixes following issues

<img width="825" alt="image" src="https://user-images.githubusercontent.com/5067549/161517065-07e23abb-d1be-4db2-bce1-7df6ff4191eb.png">

<img width="767" alt="image" src="https://user-images.githubusercontent.com/5067549/161517104-9b261e76-a723-4ea3-9331-f5d2ed9d55ea.png">

<img width="754" alt="image" src="https://user-images.githubusercontent.com/5067549/161517159-5e6cd0c1-1412-465a-a810-da458a409571.png">

Changes proposed in this pull request:

- Remove the `nuget` for directories that only contain the `Directory.Build.props` file
- Increase the "open PR limit"
- Do not set `label` manually (dependabot set it by its own if it is seft unset)
- Add all directories containing *.csproj 


Probably we should use the generated PRs only for sake of "tracking". Thanks to it we are notified about new versions. After we create PRs like https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/436 we can then check if the PRs are automatically closed.

Some of them we can close manually if we do not want to bump the dependency.

A similar approach is used in https://github.com/open-telemetry/opentelemetry-go and https://github.com/open-telemetry/opentelemetry-go-contrib. The only issue is that it generates a lot of spam GitHub notifications...

## Testing

Check https://github.com/pellared/opentelemetry-dotnet-instrumentation-dependabot/pulls

## Generating dependabot

I executed `find . -type f -name '*.csproj' | sed -r 's|/[^/]+$||' | sort | uniq` to all directories containing `*.csproj`.

Then I have written a little Go program to generate the yml file

```golang
package main

import (
	"log"
	"os"
	"text/template"
)

func main() {
	const tplt = `
version: 2
updates:

  - package-ecosystem: github-actions
    directory: /
    schedule:
      day: sunday
      interval: weekly

{{range .}} 
  - package-ecosystem: nuget
    directory: {{.}}
    schedule:
      day: sunday
      interval: weekly
    open-pull-requests-limit: 20
{{end}}
`

	folders := []string{
		"/build/nuke",
		"/examples/AspNetCoreMvc",
		"/examples/BindingRedirect",
		"/examples/ConsoleApp",
		"/examples/ConsoleApp.SelfBootstrap",
		"/examples/CoreAppOldReference",
		"/examples/OldReference",
		"/examples/OpenTracingLibrary",
		"/examples/Vendor.Distro",
		"/src/OpenTelemetry.AutoInstrumentation",
		"/src/OpenTelemetry.AutoInstrumentation.AdditionalDeps",
		"/src/OpenTelemetry.AutoInstrumentation.Core",
		"/src/OpenTelemetry.AutoInstrumentation.Loader",
		"/src/OpenTelemetry.AutoInstrumentation.StartupHook",
		"/test/integration-tests/aspnet/IntegrationTests.AspNet",
		"/test/integration-tests/IntegrationTests.GraphQL",
		"/test/integration-tests/IntegrationTests.Helpers",
		"/test/integration-tests/IntegrationTests.MongoDB",
		"/test/integration-tests/IntegrationTests.StartupHook",
		"/test/OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests",
		"/test/OpenTelemetry.AutoInstrumentation.Loader.Tests",
		"/test/OpenTelemetry.AutoInstrumentation.Tests",
		"/test/test-applications/integrations/aspnet/Samples.AspNet",
		"/test/test-applications/integrations/dependency-libs/Samples.ExampleLibrary",
		"/test/test-applications/integrations/dependency-libs/Samples.ExampleLibraryTracer",
		"/test/test-applications/integrations/Samples.GraphQL",
		"/test/test-applications/integrations/Samples.MongoDB",
		"/test/test-applications/integrations/Samples.StartupHook",
		"/test/test-applications/mocks/OpenTelemetry.AutoInstrumentation.Mock",
	}

	t := template.Must(template.New("letter").Parse(tplt))
	if err := t.Execute(os.Stdout, folders); err != nil {
		log.Fatalln("executing template:", err)
	}
}
```

Probably we could make a Nuke target that does it instead.