### PR TITLE
Add a simple VERSIONING.md to the repo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,13 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
+see the [versioning document](./VERSIONING.md) for more information.
 
 ## [Unreleased]
-
-## [0.0.1] - 2021-05-06
-
-Initial pre-alpha release.
-
-[Unreleased]: https://github.com/opentelemetry/opentelemetry-dotnet-instrumentation/compare/v0.0.1...HEAD
-[0.0.1]: https://github.com/opentelemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.0.1

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,15 +1,15 @@
 # Versioning and Stability
 
-As per OpenTelemetry specification this repository uses [Semantic Versioning 2.0.0](https://semver.org/).
-This means that all artifacts have a version of the format `MAJOR.MINOR.PATCH` or `MAJOR.MINOR.PATCH-<pre-release-id>`. For detailed information about version and stability for OpenTelemetry see
+As per the OpenTelemetry specification this repository uses [Semantic Versioning 2.0.0](https://semver.org/).
+This means that the version of all artifacts is in the format `MAJOR.MINOR.PATCH` or `MAJOR.MINOR.PATCH-<pre-release-id>`. For detailed information about version and stability for OpenTelemetry see
 [Versioning and stability for OpenTelemetry clients](https://github.com/open-telemetry/opentelemetry-specification/blob/bccdb63e3da14d7eb3a4f3090e270126373069ba/specification/versioning-and-stability.md#versioning-and-stability-for-opentelemetry-clients).
 
-In this repository `MAJOR` and `MINOR` version numbers are going to match the [OpenTelemetry .NET SDK](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#opentelemetry-net-sdk)
-currently shipped with the artifacts produced by CI.
+In this repository, `MAJOR` and `MINOR` version numbers match the version numbers of the
+[OpenTelemetry .NET SDK](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#opentelemetry-net-sdk) shipped with the artifacts produced by CI.
 
-As auto-instrumentation will inject assemblies during application runtime
-conflicts between assemblies are possible and may demand the workarounds
-listed at [Handling of assembly version conflicts](./troubleshooting.md/#handling-of-assembly-version-conflicts).
+As the auto-instrumentation injects assemblies at application runtime,
+conflicts between assemblies might happen and might require workarounds.
+See [Handling of assembly version conflicts](./troubleshooting.md/#handling-of-assembly-version-conflicts) for more information.
 
 <!-- 
 TODO:

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,24 @@
+# Versioning and Stability
+
+As per OpenTelemetry specification this repository uses [Semantic Versioning 2.0.0](https://semver.org/).
+This means that all artifacts have a version of the format `MAJOR.MINOR.PATCH` or `MAJOR.MINOR.PATCH-<pre-release-id>`. For detailed information about version and stability for OpenTelemetry see
+[Versioning and stability for OpenTelemetry clients](https://github.com/open-telemetry/opentelemetry-specification/blob/bccdb63e3da14d7eb3a4f3090e270126373069ba/specification/versioning-and-stability.md#versioning-and-stability-for-opentelemetry-clients).
+
+In this repository `MAJOR` and `MINOR` version numbers are going to match the [OpenTelemetry .NET SDK](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#opentelemetry-net-sdk)
+currently shipped with the artifacts produced by CI.
+
+As auto-instrumentation will inject assemblies during application runtime
+conflicts between assemblies are possible and may demand the workarounds
+listed at [Handling of assembly version conflicts](./troubleshooting.md/#handling-of-assembly-version-conflicts).
+
+<!-- 
+TODO:
+
+Automate the generation of the dependencies table to be linked here.
+It should include the package references from:
+
+src\OpenTelemetry.AutoInstrumentation\OpenTelemetry.AutoInstrumentation.csproj
+src\OpenTelemetry.AutoInstrumentation.AdditionalDeps\Directory.Build.props
+
+See https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/454
+-->


### PR DESCRIPTION
Per OTel spec we are required to have one VERSIONING file. I'm keeping it very short and for now not linking to top level docs (we will do that when we have a release).

The key table mentioned should be done via #454.