### PR TITLE
Format datetime consistently in logs

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Loader/StartupLogger.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/StartupLogger.cs
@@ -38,7 +38,7 @@ internal static class StartupLogger
                 {
                     using (var fileSink = new FileSink(StartupLogFilePath))
                     {
-                        fileSink.Info($"[{DateTime.UtcNow}] {message}{Environment.NewLine}", args);
+                        fileSink.Info($"[{DateTime.UtcNow:O}] {message}{Environment.NewLine}", args);
                     }
 
                     return;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/logger.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/logger.h
@@ -18,7 +18,7 @@ struct TracerLoggerPolicy
     // the same product folder name
     inline static const WSTRING folder_path = WStr(R"(OpenTelemetry .NET AutoInstrumentation\logs)");
 #endif
-    inline static const std::string pattern = "%D %I:%M:%S.%e %p [%P|%t] [%l] %v";
+    inline static const std::string pattern = "[%Y-%m-%dT%X.%FZ] [%P|%t] [%l] %v";
     struct logging_environment
     {
         // cannot reuse environment::log_path variable. On alpine, test fails

--- a/src/OpenTelemetry.AutoInstrumentation.Native/logger_impl.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/logger_impl.h
@@ -144,7 +144,7 @@ LoggerImpl<TLoggerPolicy>::LoggerImpl()
 
     m_fileout->set_level(spdlog::level::debug);
 
-    m_fileout->set_pattern(TLoggerPolicy::pattern);
+    m_fileout->set_pattern(TLoggerPolicy::pattern, spdlog::pattern_time_type::utc);
 
     m_fileout->flush_on(spdlog::level::info);
 };

--- a/src/OpenTelemetry.AutoInstrumentation/Logging/Logger.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Logging/Logger.cs
@@ -22,6 +22,7 @@ namespace OpenTelemetry.AutoInstrumentation.Logging;
 internal class Logger : ILogger
 {
     private static readonly object[] NoPropertyValues = Array.Empty<object>();
+
     private readonly ISink _sink;
 
     internal Logger(ISink sink)
@@ -196,7 +197,7 @@ internal class Logger : ILogger
         try
         {
             var message =
-                $"[{DateTime.UtcNow}] [{level}] {string.Format(messageTemplate, args)} {Environment.NewLine}";
+                $"[{DateTime.UtcNow:O}] [{level}] {string.Format(messageTemplate, args)} {Environment.NewLine}";
             _sink.Write(message);
 
             if (exception != null)


### PR DESCRIPTION
Fixes #481 
## What
Use consistent, standard datetime format in native and managed logs.

### Native logs
**before:**
`04/12/22 01:03:38.321 PM [19452|9268] [info] OpenTelemetry CLR Profiler 0.0.1 on Windows (amd64)`
**after:**
`[2022-04-12T11:05:43.596479500Z] [24400|25268] [info] OpenTelemetry CLR Profiler 0.0.1 on Windows (amd64)`

### Managed logs
**before:**
`[4/12/2022 11:03:38 AM] [Information] OpenTelemetry tracer initialized. `
**after:**
`[2022-04-12T11:05:44.0764465Z] [Information] OpenTelemetry tracer initialized. `

## TODO (other PR)
Consistent logging of log levels, inclusion/exclusion of additional info such as thread/process id, truncation of trailing 2 digits of nanoseconds part in native logs.