### PR TITLE
Bump otel sdk 1.2.0 rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 The is an initial, official beta release,
 built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
-- Core components: [`1.2.0-rc4`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0-rc4)
-- Non-core components: [`1.0.0-rc9.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.1)
+- Core components: [`1.2.0-rc5`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0-rc5)
+- Non-core components: [`1.0.0-rc9.2`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.2)
 - `System.Diagnostics.DiagnosticSource`: [`6.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/6.0.0)
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@ to .NET applications without having to modify their source code.
 
 OpenTelemetry .NET Auto-Instrumentation is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
-- core components: [`1.2.0-rc4`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0-rc4)
-- non-core components: [`1.0.0-rc9.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.1)
+- core components: [`1.2.0-rc5`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0-rc5)
+- non-core components: [`1.0.0-rc9.2`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.2)
 - `System.Diagnostics.DiagnosticSource`: [`6.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/6.0.0)
 
 To auto-instrument applications, the OpenTelemetry .NET Auto-Instrumentation does the following:

--- a/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
+++ b/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.2" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/examples/AspNetCoreMvc/Properties/launchSettings.json
+++ b/examples/AspNetCoreMvc/Properties/launchSettings.json
@@ -19,7 +19,6 @@
         "OTEL_DOTNET_AUTO_CONSOLE_EXPORTER_ENABLED": "true",
         "OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS": "AspNet,HttpClient,SqlClient",
         "OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS": "Examples.AspNetCoreMvc.OtelSdkPlugin, Examples.AspNetCoreMvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
         "OTEL_SERVICE_NAME": "StartupHook.IISExpress",
         "OTEL_TRACES_EXPORTER": "otlp"
       },
@@ -41,7 +40,6 @@
         "OTEL_DOTNET_AUTO_HOME": "$(SolutionDir)bin\\tracer-home",
         "OTEL_DOTNET_AUTO_INTEGRATIONS_FILE": "$(SolutionDir)bin\\tracer-home\\integrations.json",
         "OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS": "Examples.AspNetCoreMvc.OtelSdkPlugin, Examples.AspNetCoreMvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
         "OTEL_SERVICE_NAME": "CLRProfiler.IISExpress",
         "OTEL_TRACES_EXPORTER": "otlp"
       },
@@ -59,7 +57,6 @@
         "OTEL_DOTNET_AUTO_CONSOLE_EXPORTER_ENABLED": "true",
         "OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS": "AspNet,HttpClient,SqlClient",
         "OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS": "Examples.AspNetCoreMvc.OtelSdkPlugin, Examples.AspNetCoreMvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
         "OTEL_SERVICE_NAME": "StartupHook.Self-hosted",
         "OTEL_TRACES_EXPORTER": "otlp"
       },
@@ -82,7 +79,6 @@
         "OTEL_DOTNET_AUTO_HOME": "$(SolutionDir)bin\\tracer-home",
         "OTEL_DOTNET_AUTO_INTEGRATIONS_FILE": "$(SolutionDir)bin\\tracer-home\\integrations.json",
         "OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS": "Examples.AspNetCoreMvc.OtelSdkPlugin, Examples.AspNetCoreMvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
         "OTEL_SERVICE_NAME": "CLRProfiler.Self-hosted",
         "OTEL_TRACES_EXPORTER": "otlp"
       },

--- a/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
+++ b/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
@@ -10,15 +10,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' != 'net462'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.2" />
   </ItemGroup>
   
 </Project>

--- a/examples/ManualInstrumentations/Properties/launchSettings.json
+++ b/examples/ManualInstrumentations/Properties/launchSettings.json
@@ -13,7 +13,6 @@
 
         "OTEL_DOTNET_AUTO_HOME": "$(SolutionDir)bin\\tracer-home\\",
         "OTEL_DOTNET_AUTO_INTEGRATIONS_FILE": "$(SolutionDir)bin\\tracer-home\\integrations.json",
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
         "OTEL_DOTNET_AUTO_DEBUG": "1",
 
         "DOTNET_ADDITIONAL_DEPS": "$(SolutionDir)bin\\tracer-home\\AdditionalDeps",

--- a/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
+++ b/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc5" />
   </ItemGroup>
 </Project>

--- a/run-example.sh
+++ b/run-example.sh
@@ -52,12 +52,12 @@ docker-compose -f ./dev/docker-compose.yaml -f ./examples/docker-compose.yaml up
 
 # instrument and run HTTP server app in background
 export OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS="Examples.AspNetCoreMvc.OtelSdkPlugin, Examples.AspNetCoreMvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null:Examples.Vendor.Distro.Plugin, Examples.Vendor.Distro, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null"
-ENABLE_PROFILING=${enableProfiling} OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS="AspNet,SqlClient" OTEL_SERVICE_NAME="aspnet-server" OTEL_TRACES_EXPORTER=${exporter} ./dev/instrument.sh ASPNETCORE_URLS="http://127.0.0.1:8080/" dotnet ./examples/AspNetCoreMvc/bin/${configuration}/${aspNetAppTargetFramework}/Examples.AspNetCoreMvc.dll &
+ENABLE_PROFILING=${enableProfiling} OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS="AspNet,SqlClient" OTEL_SERVICE_NAME="aspnet-server" OTEL_TRACES_EXPORTER=${exporter} ./dev/instrument.sh ASPNETCORE_URLS="http://127.0.0.1:8080/" dotnet ./examples/AspNetCoreMvc/bin/${configuration}/${aspNetAppTargetFramework}/Examples.AspNetCoreMvc.dll &
 unset OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS
 ./dev/wait-local-port.sh 8080
 
 # instrument and run HTTP client app
-ENABLE_PROFILING=${enableProfiling} OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS="HttpClient" OTEL_SERVICE_NAME=${exampleApp} OTEL_TRACES_EXPORTER=${exporter} OTEL_DOTNET_AUTO_LOAD_AT_STARTUP=${exampleAppInjectSDK} ./dev/instrument.sh $exampleAppDotnetCli ./examples/${exampleApp}/bin/$configuration/${exampleAppTargetFramework}/Examples.${exampleApp}.${exampleAppExt}
+ENABLE_PROFILING=${enableProfiling} OTEL_DOTNET_AUTO_ENABLED_INSTRUMENTATIONS="HttpClient" OTEL_SERVICE_NAME=${exampleApp} OTEL_TRACES_EXPORTER=${exporter} OTEL_DOTNET_AUTO_LOAD_AT_STARTUP=${exampleAppInjectSDK} ./dev/instrument.sh $exampleAppDotnetCli ./examples/${exampleApp}/bin/$configuration/${exampleAppTargetFramework}/Examples.${exampleApp}.${exampleAppExt}
 
 # verify if it works
 read -p "Check traces under: http://localhost:16686/search. Press enter to close containers and stop example apps"

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -5,17 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc4" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0-rc5" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/Samples.AspNet.csproj
@@ -41,10 +41,10 @@
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-rc4\lib\net461\OpenTelemetry.Api.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0-rc5\lib\net461\OpenTelemetry.Api.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc9.1\lib\net461\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc9.2\lib\net461\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
+++ b/test/test-applications/integrations/aspnet/Samples.AspNet/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
-  <package id="OpenTelemetry.Api" version="1.2.0-rc4" targetFramework="net462" />
-  <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc9.1" targetFramework="net462" />
+  <package id="OpenTelemetry.Api" version="1.2.0-rc5" targetFramework="net462" />
+  <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc9.2" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net462" />
   <package id="System.Memory" version="4.5.4" targetFramework="net462" />


### PR DESCRIPTION
Changes proposed in this pull request:
* Bump otel sdk code components to 1.2.0 rc5 and non-core components to 1.0.0-rc9.2.
* Use default value for `OTEL_EXPORTER_OTLP_ENDPOINT`- manual setting is no longer needed https://github.com/open-telemetry/opentelemetry-dotnet/pull/3098

Based on https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.2 and https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0-rc5 readme updates are no needed (the used version is the only exception).