### PR TITLE
Adds configuration to control the processing of unhandled exceptions.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -111,7 +111,7 @@ The batch span processor batches finished spans before sending them through the 
 | `OTEL_DOTNET_AUTO_LOAD_AT_STARTUP` | Whether the tracer is created by the automatic instrumentation library or not. Set to `false` when the application initializes the OpenTelemetry .NET SDK Tracer on its own. This configuration can be used, for example, to retrieve the bytecode instrumentations. | `true` |
 | `OTEL_DOTNET_AUTO_ADDITIONAL_SOURCES` | Comma-separated list of additional `ActivitySource` names to be added to the tracer at the startup. Use it to capture manually instrumented spans. |  |
 | `OTEL_DOTNET_AUTO_LEGACY_SOURCES` | Comma-separated list of additional legacy source names to be added to the tracer at the startup. Use it to capture `Activity` objects created without using the `ActivitySource` API. |  |
-| `OTEL_DOTNET_AUTO_UNHANDLEDEXCEPTION_ENABLED` | Controls listening to the [AppDomain.UnhandledException](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.unhandledexception) event. Set to `true` when you suspect that you are experiencing a problem related to unhandled exceptions. | `false` |
+| `OTEL_DOTNET_AUTO_FLUSH_ON_UNHANDLEDEXCEPTION` | Controls whether the telemetry data is flushed when an [AppDomain.UnhandledException](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.unhandledexception) event is raised. Set to `true` when you suspect that you are experiencing a problem with missing telemetry data and also experiencing unhandled exceptions. | `false` |
 | `OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS` | Colon-separated list of OTel SDK instrumentation plugins represented by `System.Type.AssemblyQualifiedName`. | |
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -111,6 +111,7 @@ The batch span processor batches finished spans before sending them through the 
 | `OTEL_DOTNET_AUTO_LOAD_AT_STARTUP` | Whether the tracer is created by the automatic instrumentation library or not. Set to `false` when the application initializes the OpenTelemetry .NET SDK Tracer on its own. This configuration can be used, for example, to retrieve the bytecode instrumentations. | `true` |
 | `OTEL_DOTNET_AUTO_ADDITIONAL_SOURCES` | Comma-separated list of additional `ActivitySource` names to be added to the tracer at the startup. Use it to capture manually instrumented spans. |  |
 | `OTEL_DOTNET_AUTO_LEGACY_SOURCES` | Comma-separated list of additional legacy source names to be added to the tracer at the startup. Use it to capture `Activity` objects created without using the `ActivitySource` API. |  |
+| `OTEL_DOTNET_AUTO_UNHANDLEDEXCEPTION_ENABLED` | Controls listening to the [AppDomain.UnhandledException](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.unhandledexception) event. Set to `true` when you suspect that you are experiencing a problem related to unhandled exceptions. | `false` |
 | `OTEL_DOTNET_AUTO_INSTRUMENTATION_PLUGINS` | Colon-separated list of OTel SDK instrumentation plugins represented by `System.Type.AssemblyQualifiedName`. | |
 
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -93,9 +93,9 @@ public class ConfigurationKeys
     public const string LogDirectory = "OTEL_DOTNET_AUTO_LOG_DIRECTORY";
 
     /// <summary>
-    /// Configuration key for enabling the notification of unhandled exceptions.
+    /// Configuration key for enabling the flushing of telemetry data when an unhandled exception occurs.
     /// </summary>
-    public const string UnhandledExceptionsEnabled = "OTEL_DOTNET_AUTO_UNHANDLEDEXCEPTION_ENABLED";
+    public const string FlushOnUnhandledException = "OTEL_DOTNET_AUTO_FLUSH_ON_UNHANDLEDEXCEPTION";
 
     /// <summary>
     /// String format patterns used to match integration-specific configuration keys.

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -93,6 +93,11 @@ public class ConfigurationKeys
     public const string LogDirectory = "OTEL_DOTNET_AUTO_LOG_DIRECTORY";
 
     /// <summary>
+    /// Configuration key for enabling the notification of unhandled exceptions.
+    /// </summary>
+    public const string UnhandledExceptionsEnabled = "OTEL_DOTNET_AUTO_UNHANDLEDEXCEPTION_ENABLED";
+
+    /// <summary>
     /// String format patterns used to match integration-specific configuration keys.
     /// </summary>
     internal static class Integrations

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -170,7 +170,7 @@ public class Settings
     public bool Http2UnencryptedSupportEnabled { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the <see cref="E:System.AppDomain.CurrentDomain.UnhandledException"/> event should be enabled.
+    /// Gets a value indicating whether the <see cref="AppDomain.UnhandledException"/> event should be enabled.
     /// Default is <c>false</c>.
     /// </summary>
     public bool UnhandledExceptionsEnabled { get; }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -106,7 +106,7 @@ public class Settings
 
         Http2UnencryptedSupportEnabled = source.GetBool(ConfigurationKeys.Http2UnencryptedSupportEnabled) ?? false;
 
-        UnhandledExceptionsEnabled = source.GetBool(ConfigurationKeys.UnhandledExceptionsEnabled) ?? false;
+        FlushOnUnhandledException = source.GetBool(ConfigurationKeys.FlushOnUnhandledException) ?? false;
     }
 
     /// <summary>
@@ -170,10 +170,11 @@ public class Settings
     public bool Http2UnencryptedSupportEnabled { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the <see cref="AppDomain.UnhandledException"/> event should be enabled.
+    /// Gets a value indicating whether the <see cref="AppDomain.UnhandledException"/> event should trigger
+    /// the flushing of telemetry data.
     /// Default is <c>false</c>.
     /// </summary>
-    public bool UnhandledExceptionsEnabled { get; }
+    public bool FlushOnUnhandledException { get; }
 
     internal static Settings FromDefaultSources()
     {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -170,7 +170,7 @@ public class Settings
     public bool Http2UnencryptedSupportEnabled { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the `AppDomain.UnhandledException` event should be enabled.
+    /// Gets a value indicating whether the <see cref="AppDomain.CurrentDomain.UnhandledException"/> event should be enabled.
     /// Default is <c>false</c>.
     /// </summary>
     public bool UnhandledExceptionsEnabled { get; }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -170,7 +170,7 @@ public class Settings
     public bool Http2UnencryptedSupportEnabled { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the <see cref="AppDomain.CurrentDomain.UnhandledException"/> event should be enabled.
+    /// Gets a value indicating whether the <see cref="E:System.AppDomain.CurrentDomain.UnhandledException"/> event should be enabled.
     /// Default is <c>false</c>.
     /// </summary>
     public bool UnhandledExceptionsEnabled { get; }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -105,6 +105,8 @@ public class Settings
         Integrations = new IntegrationSettingsCollection(source);
 
         Http2UnencryptedSupportEnabled = source.GetBool(ConfigurationKeys.Http2UnencryptedSupportEnabled) ?? false;
+
+        UnhandledExceptionsEnabled = source.GetBool(ConfigurationKeys.UnhandledExceptionsEnabled) ?? false;
     }
 
     /// <summary>
@@ -166,6 +168,12 @@ public class Settings
     /// Default is <c>false</c>.
     /// </summary>
     public bool Http2UnencryptedSupportEnabled { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the `AppDomain.UnhandledException` event should be enabled.
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool UnhandledExceptionsEnabled { get; }
 
     internal static Settings FromDefaultSources()
     {

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -95,7 +95,11 @@ public static class Instrumentation
                 // Register to shutdown events
                 AppDomain.CurrentDomain.ProcessExit += OnExit;
                 AppDomain.CurrentDomain.DomainUnload += OnExit;
-                AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+
+                if (TracerSettings.UnhandledExceptionsEnabled)
+                {
+                    AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+                }
             }
         }
         catch (Exception ex)

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -96,7 +96,7 @@ public static class Instrumentation
                 AppDomain.CurrentDomain.ProcessExit += OnExit;
                 AppDomain.CurrentDomain.DomainUnload += OnExit;
 
-                if (TracerSettings.UnhandledExceptionsEnabled)
+                if (TracerSettings.FlushOnUnhandledException)
                 {
                     AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
                 }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -54,7 +54,7 @@ public class SettingsTests : IDisposable
             settings.LegacySources.Should().BeEmpty();
             settings.Integrations.Should().NotBeNull();
             settings.Http2UnencryptedSupportEnabled.Should().BeFalse();
-            settings.UnhandledExceptionsEnabled.Should().BeFalse();
+            settings.FlushOnUnhandledException.Should().BeFalse();
         }
     }
 
@@ -117,13 +117,13 @@ public class SettingsTests : IDisposable
     [InlineData("true", true)]
     [InlineData("false", false)]
     [InlineData(null, false)]
-    public void UnhandledExceptionsEnabled_DependsOnCorrespondingEnvVariable(string unhandledExceptionsEnabled, bool expectedValue)
+    public void FlushOnUnhandledException_DependsOnCorrespondingEnvVariable(string flushOnUnhandledException, bool expectedValue)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.UnhandledExceptionsEnabled, unhandledExceptionsEnabled);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.FlushOnUnhandledException, flushOnUnhandledException);
 
         var settings = Settings.FromDefaultSources();
 
-        settings.UnhandledExceptionsEnabled.Should().Be(expectedValue);
+        settings.FlushOnUnhandledException.Should().Be(expectedValue);
     }
 
     private static void ClearEnvVars()
@@ -131,6 +131,6 @@ public class SettingsTests : IDisposable
         Environment.SetEnvironmentVariable(ConfigurationKeys.TracesExporter, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Http2UnencryptedSupportEnabled, null);
-        Environment.SetEnvironmentVariable(ConfigurationKeys.UnhandledExceptionsEnabled, null);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.FlushOnUnhandledException, null);
     }
 }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -54,6 +54,7 @@ public class SettingsTests : IDisposable
             settings.LegacySources.Should().BeEmpty();
             settings.Integrations.Should().NotBeNull();
             settings.Http2UnencryptedSupportEnabled.Should().BeFalse();
+            settings.UnhandledExceptionsEnabled.Should().BeFalse();
         }
     }
 
@@ -112,10 +113,24 @@ public class SettingsTests : IDisposable
         settings.Http2UnencryptedSupportEnabled.Should().Be(expectedValue);
     }
 
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData(null, false)]
+    public void UnhandledExceptionsEnabled_DependsOnCorrespondingEnvVariable(string unhandledExceptionsEnabled, bool expectedValue)
+    {
+        Environment.SetEnvironmentVariable(ConfigurationKeys.UnhandledExceptionsEnabled, unhandledExceptionsEnabled);
+
+        var settings = Settings.FromDefaultSources();
+
+        settings.UnhandledExceptionsEnabled.Should().Be(expectedValue);
+    }
+
     private static void ClearEnvVars()
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.TracesExporter, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Http2UnencryptedSupportEnabled, null);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.UnhandledExceptionsEnabled, null);
     }
 }


### PR DESCRIPTION
Fixes # 321

Changes proposed in this pull request:

Adds a configuration option to control whether or not unhandled exceptions should be processed.

Due to the [concerns about the potential impact on the running application](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/386#discussion_r820063893), the default value for this setting is "false" (or turned off).
