### PR TITLE
Remove reference to libddwaf

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/packages.config
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nlohmann.json" version="3.9.1" targetFramework="native" />
-  <package id="libddwaf" version="1.0.7" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Fixes # N/A

Changes proposed in this pull request:
Remove reference to libddwaf
it was used in upstream for AppSec feature
