### PR TITLE
Run all integration tests on .NET 4.6.2

### DIFF
--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -305,6 +305,7 @@ partial class Build
             Project[] integrationTests = Solution.GetCrossPlatformIntegrationTests();
 
             string filter = IsWin ? null : "WindowsOnly!=true";
+            IEnumerable<TargetFramework> frameworks = IsWin ? TestFrameworks : TestFrameworks.ExceptNetFramework();
 
             DotNetTest(config => config
                 .SetConfiguration(BuildConfiguration)
@@ -312,7 +313,7 @@ partial class Build
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .SetFilter(filter)
-                .CombineWith(TestFrameworks.ExceptNetFramework(), (s, fx) => s
+                .CombineWith(frameworks, (s, fx) => s
                     .SetFramework(fx)
                 )
                 .CombineWith(integrationTests, (s, project) => s

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,5 @@
 # Release Process
 
-0. Run tests on .NET 4.6.2 locally: they do not run in GitHub.
-
 1. Update the version in the following files:
 
    - `*.cs` (TODO: extract as a constant to reduce the number of occurances)


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/471 

Changes proposed in this pull request:
- Run integration tests on .NET 4.6.2 in CI so that it does not have to be checked manually during the release

```
  08:55:59 [DBG] Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: < 1 ms - IntegrationTests.GraphQL.dll (net5.0)
  08:55:59 [DBG] Test run for D:\a\opentelemetry-dotnet-instrumentation\opentelemetry-dotnet-instrumentation\test\integration-tests\IntegrationTests.GraphQL\bin\x64\Release\net462\IntegrationTests.GraphQL.dll (.NETFramework,Version=v4.6.2)
  08:55:59 [DBG] Microsoft (R) Test Execution Command Line Tool Version 17.1.0
  08:55:59 [DBG] Copyright (c) Microsoft Corporation.  All rights reserved.
  08:55:59 [DBG] 
  08:55:59 [DBG] Starting test execution, please wait...
  08:55:59 [DBG] A total of 1 test files matched the specified pattern.
  08:55:59 [DBG] Results File: D:\a\opentelemetry-dotnet-instrumentation\opentelemetry-dotnet-instrumentation\build_data\results\IntegrationTests.GraphQL\runneradmin_fv-az449-259_2022-04-21_08_55_19.trx
  08:55:59 [DBG] 
  08:55:59 [DBG] Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration:  - IntegrationTests.GraphQL.dll (net462)
```

side note:

<img width="679" alt="image" src="https://user-images.githubusercontent.com/5067549/164442875-bd2bd5bb-7654-43bf-8926-43997fb24fb2.png">

🤯 reference (thanks to @RassK) : https://jonhilton.net/2016/09/07/using-asp-net-core-against-net-4-6/