### PR TITLE
Update troubleshooting doc

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,19 +26,6 @@ The example can only run successfully under the instrumentation, as the
 binding redirect makes the application dependent on a version of `System.Diagnostics.DiagnosticSource`
 that is not available at build time.
 
-### .NET Core dependency file
-
-To fix assembly version conflicts in .NET Core, edit the default
-`<application>.deps.json` file generated at build for .NET Core applications.
-Build a .NET Core app with package references using the required version,
-and use the respective `deps.json` file to see what changes are needed.
-
-To test your edits to the `deps.json` file, add a reference to the required
-version of the OpenTelemetry package to the [examples/CoreAppOldReference](./../examples/CoreAppOldReference/)
-example and rebuild the application. Save the generated `deps.json` file,
-remove the package reference, and rebuild the example app.
-Compare the files to explore the changes.
-
 ## No proper relationship between spans
 
 On .NET Framework, strong name signing can force the loading of multiple versions

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,29 +2,27 @@
 
 ## Handling of assembly version conflicts
 
-OpenTelemetry SDK NuGet packages are deployed with the OpenTelemetry .NET Instrumentation.
+OpenTelemetry .NET NuGet packages are deployed with
+the OpenTelemetry .NET Automatic Instrumentation.
 To handle conflicts in assemblies referenced by "source instrumentations",
 update the project references to ensure that they are on the same versions
 as the ones used by the instrumentation.
 
-Previous workarounds only work at build time. When a rebuild is not possible,
+This workaround only work at build time. When a rebuild is not possible,
 use one of the following suggestions to force the application to use
 the assembly versions shipped with the instrumentation.
 
 For .NET Framework applications, the workaround is to use binding redirects.
+The [examples/BindingRedirect](./../examples/BindingRedirect/) app shows how
+to use the `app.config` file to solve version conflicts.
+The example can only run successfully under the instrumentation, as the
+binding redirect makes the application dependent on a version of
+`System.Diagnostics.DiagnosticSource` that is not available at build time.
+
 For .NET Core [Framework-dependent deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/deploy-with-vs?tabs=vs156#framework-dependent-deployment)
 applications, [Additional-deps](https://github.com/dotnet/runtime/blob/main/docs/design/features/additional-deps.md),
 and [runtime package store](https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-store)
 from OpenTelemetry .NET, use the automatic instrumentation installation path.
-For other .NET Core deployment models, edit the `deps.json` file.
-
-### .NET Framework binding redirects
-
-The [examples/BindingRedirect](./../examples/BindingRedirect/) app shows how
-to use the `app.config` file to solve version conflicts.
-The example can only run successfully under the instrumentation, as the
-binding redirect makes the application dependent on a version of `System.Diagnostics.DiagnosticSource`
-that is not available at build time.
 
 ## No proper relationship between spans
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ To handle conflicts in assemblies referenced by "source instrumentations",
 update the project references to ensure that they are on the same versions
 as the ones used by the instrumentation.
 
-This workaround only work at build time. When a rebuild is not possible,
+This workaround works only at build time. When a rebuild is not possible,
 use one of the following suggestions to force the application to use
 the assembly versions shipped with the instrumentation.
 


### PR DESCRIPTION
### What

Removes block of troubleshooting net core dependencies, as it's not valid.
* There is no way to change compile time direct dependency version.
* Additional deps corrects the version when there is no direct dependency.

@pellared suggested currently not to add details about build time fixing, to better estimate the scope of the issue.
