### PR TITLE
Update troubleshooting.md

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,27 +2,19 @@
 
 ## Handling of assembly version conflicts
 
-OpenTelemetry .NET NuGet packages are deployed with
-the OpenTelemetry .NET Automatic Instrumentation.
-To handle conflicts in assemblies referenced by "source instrumentations",
-update the project references to ensure that they are on the same versions
-as the ones used by the instrumentation.
+OpenTelemetry .NET NuGet packages and its dependencies
+are deployed with the OpenTelemetry .NET Automatic Instrumentation.
+To handle dependency versions conflicts,
+update the instrumented application's project references
+to use the same versions.
 
-This workaround works only at build time. When a rebuild is not possible,
-use one of the following suggestions to force the application to use
-the assembly versions shipped with the instrumentation.
-
-For .NET Framework applications, the workaround is to use binding redirects.
+When a rebuild is not possible,
+for .NET Framework applications the workaround is to use binding redirects.
 The [examples/BindingRedirect](./../examples/BindingRedirect/) app shows how
 to use the `app.config` file to solve version conflicts.
 The example can only run successfully under the instrumentation, as the
 binding redirect makes the application dependent on a version of
 `System.Diagnostics.DiagnosticSource` that is not available at build time.
-
-For .NET Core [Framework-dependent deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/deploy-with-vs?tabs=vs156#framework-dependent-deployment)
-applications, [Additional-deps](https://github.com/dotnet/runtime/blob/main/docs/design/features/additional-deps.md),
-and [runtime package store](https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-store)
-from OpenTelemetry .NET, use the automatic instrumentation installation path.
 
 ## No proper relationship between spans
 


### PR DESCRIPTION
Fixes #624


I think that this whole section about additional-deps and runtime package store could be removed. \Wwe ask to set these env vars in `README.md`. Moreover, the `design.md` has a nice short description regarding additional-deps and runtime package in the `Configuration resolution` section. 

I am open to any changes to make it simpler and clearer.

