### PR TITLE
Fix DOTNET_STARTUP_HOOKS in defaults.env

### DIFF
--- a/defaults.env
+++ b/defaults.env
@@ -1,6 +1,6 @@
 export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER='{918728DD-259F-4A6A-AC2B-B85E1B658318}'
 export CORECLR_PROFILER_PATH=/opt/opentelemetry-dotnet-autoinstrumentation/OpenTelemetry.AutoInstrumentation.Native.so
-export DOTNET_STARTUP_HOOKS=/opt/opentelemetry-dotnet-autoinstrumentation/OpenTelemetry.AutoInstrumentation.StartupHook.dll
+export DOTNET_STARTUP_HOOKS=/opt/opentelemetry-dotnet-autoinstrumentation/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll
 export OTEL_DOTNET_AUTO_INTEGRATIONS_FILE=/opt/opentelemetry-dotnet-autoinstrumentation/integrations.json
 export OTEL_DOTNET_AUTO_HOME=/opt/opentelemetry-dotnet-autoinstrumentation


### PR DESCRIPTION
Hit this while creating a Dockerfile and using defaults.env