### PR TITLE
remove .NET 5 installation from GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           dotnet-version: | 
             3.1.x
-            5.0.x
             6.0.x
       - name: Start MongoDB service
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           dotnet-version: | 
             3.1.x
-            5.0.x
             6.0.x
       - run: ./build.cmd
       - name: Upload binaries


### PR DESCRIPTION
Fixes #641

Changes proposed in this pull request:
remove .NET 5 installation from GitHub actions
