### PR TITLE
[WIP | PoC] Move OTel libs to separate load context

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.NetCore.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.NetCore.cs
@@ -15,9 +15,9 @@
 // </copyright>
 
 #if NETCOREAPP
-using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Loader;
 
 namespace OpenTelemetry.AutoInstrumentation.Loader
 {
@@ -26,7 +26,17 @@ namespace OpenTelemetry.AutoInstrumentation.Loader
     /// </summary>
     public partial class Startup
     {
-        internal static System.Runtime.Loader.AssemblyLoadContext DependencyLoadContext { get; } = new ManagedProfilerAssemblyLoadContext();
+        internal static AssemblyLoadContext OpenTelemetryLoadContext { get; set; }
+
+        private static void Initialize()
+        {
+            OpenTelemetryLoadContext = new ManagedProfilerAssemblyLoadContext(ManagedProfilerDirectory);
+        }
+
+        private static Assembly LoadAssembly(string name)
+        {
+            return OpenTelemetryLoadContext.LoadFromAssemblyName(new AssemblyName(name));
+        }
 
         private static string ResolveManagedProfilerDirectory()
         {
@@ -34,45 +44,6 @@ namespace OpenTelemetry.AutoInstrumentation.Loader
             string tracerHomeDirectory = ReadEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? string.Empty;
 
             return Path.Combine(tracerHomeDirectory, tracerFrameworkDirectory);
-        }
-
-        private static Assembly AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
-        {
-            var assemblyName = new AssemblyName(args.Name);
-
-            // On .NET Framework, having a non-US locale can cause mscorlib
-            // to enter the AssemblyResolve event when searching for resources
-            // in its satellite assemblies. This seems to have been fixed in
-            // .NET Core in the 2.0 servicing branch, so we should not see this
-            // occur, but guard against it anyways. If we do see it, exit early
-            // so we don't cause infinite recursion.
-            if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-
-            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
-
-            // Only load the main profiler into the default Assembly Load Context.
-            // If OpenTelemetry.AutoInstrumentation or other libraries are provided by the NuGet package their loads are handled in the following two ways.
-            // 1) The AssemblyVersion is greater than or equal to the version used by OpenTelemetry.AutoInstrumentation, the assembly
-            //    will load successfully and will not invoke this resolve event.
-            // 2) The AssemblyVersion is lower than the version used by OpenTelemetry.AutoInstrumentation, the assembly will fail to load
-            //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
-            //    load the originally referenced version
-            if (assemblyName.Name.StartsWith("OpenTelemetry.AutoInstrumentation", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
-            {
-                StartupLogger.Debug("Loading {0} with Assembly.LoadFrom", path);
-                return Assembly.LoadFrom(path);
-            }
-            else if (File.Exists(path))
-            {
-                StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
-                return DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
-            }
-
-            return null;
         }
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.NetFramework.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.NetFramework.cs
@@ -27,6 +27,23 @@ namespace OpenTelemetry.AutoInstrumentation.Loader
     /// </summary>
     public partial class Startup
     {
+        private static void Initialize()
+        {
+            try
+            {
+                AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve_ManagedProfilerDependencies;
+            }
+            catch (Exception ex)
+            {
+                StartupLogger.Log(ex, "Unable to register a callback to the CurrentDomain.AssemblyResolve event.");
+            }
+        }
+
+        private static Assembly LoadAssembly(string name)
+        {
+            return Assembly.Load(name);
+        }
+
         private static string ResolveManagedProfilerDirectory()
         {
             var tracerHomeDirectory = ReadEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? string.Empty;

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.cs
@@ -33,15 +33,7 @@ public partial class Startup
     {
         ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
 
-        try
-        {
-            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve_ManagedProfilerDependencies;
-        }
-        catch (Exception ex)
-        {
-            StartupLogger.Log(ex, "Unable to register a callback to the CurrentDomain.AssemblyResolve event.");
-        }
-
+        Initialize();
         TryLoadManagedAssembly();
     }
 
@@ -53,7 +45,7 @@ public partial class Startup
 
         try
         {
-            var assembly = Assembly.Load("OpenTelemetry.AutoInstrumentation");
+            var assembly = LoadAssembly("OpenTelemetry.AutoInstrumentation");
             if (assembly == null)
             {
                 throw new FileNotFoundException("The assembly OpenTelemetry.AutoInstrumentation could not be loaded");


### PR DESCRIPTION
### What

Moves all OpenTelemetry libraries and it's dependencies to a separate load context. 
Reduces conflicts between already loaded SDK libs and conflicting subdependencies.

Works best with:
* Small Nuget package that syncs shared state libraries (Eg DiagnosticSource, ILogger etc)
* OR with bridge that syncs two different versions (does not need Nuget any more then)

### Architectural view
![dependencies_updated](https://user-images.githubusercontent.com/4929112/167105883-0b0fdf79-45bb-4512-a7aa-b2092d626206.jpg)

