### PR TITLE
Add Containers Nuke parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,12 @@ jobs:
           dotnet-version: | 
             3.1.x
             6.0.x
-      - name: Start MongoDB service
+      - run: ./build.cmd Workflow --containers windows
+        if: ${{ runner.os == 'Windows' }}
+      - run: ./build.cmd Workflow --containers linux
+        if: ${{ runner.os == 'Linux' }}
+      - run: ./build.cmd Workflow --containers none
         if: ${{ runner.os == 'macOS' }}
-        run: brew services start mongodb-community
-      - run: ./build.cmd Workflow
       - name: Upload logs
         uses: actions/upload-artifact@v3.0.0
         if: always()

--- a/build/nuke/Build.Steps.Windows.cs
+++ b/build/nuke/Build.Steps.Windows.cs
@@ -118,6 +118,7 @@ partial class Build
         .Unlisted()
         .After(CompileManagedTestsWindows)
         .OnlyWhenStatic(() => IsWin)
+        .OnlyWhenStatic(() => Containers == ContainersWindows)
         .Executes(() =>
         {
             var aspnetFolder = TestsDirectory / "test-applications" / "integrations" / "aspnet";

--- a/build/nuke/Build.Steps.Windows.cs
+++ b/build/nuke/Build.Steps.Windows.cs
@@ -158,6 +158,7 @@ partial class Build
                 .SetConfiguration(BuildConfiguration)
                 .SetTargetPlatform(Platform)
                 .SetFramework(TargetFramework.NET462)
+                .SetFilter(ContainersTestFilter())
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .CombineWith(aspNetTests, (s, project) => s

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -308,6 +308,7 @@ partial class Build
             DotNetTest(config => config
                 .SetConfiguration(BuildConfiguration)
                 .SetTargetPlatform(Platform)
+                .SetFilter(ContainersTestFilter())
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .CombineWith(frameworks, (s, fx) => s

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -303,7 +303,6 @@ partial class Build
         {
             Project[] integrationTests = Solution.GetCrossPlatformIntegrationTests();
 
-            string filter = IsWin ? null : "WindowsOnly!=true";
             IEnumerable<TargetFramework> frameworks = IsWin ? TestFrameworks : TestFrameworks.ExceptNetFramework();
 
             DotNetTest(config => config
@@ -311,7 +310,6 @@ partial class Build
                 .SetTargetPlatform(Platform)
                 .EnableNoRestore()
                 .EnableNoBuild()
-                .SetFilter(filter)
                 .CombineWith(frameworks, (s, fx) => s
                     .SetFramework(fx)
                 )

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -18,8 +18,13 @@ partial class Build : NukeBuild
     [Parameter("Platform to build - x86 or x64. Default is x64")]
     readonly MSBuildTargetPlatform Platform = MSBuildTargetPlatform.x64;
 
-    [Parameter("Docker containers type to be used. One of 'none', 'linux', 'windows'. Default is 'linux'")]
-    readonly string Containers = "linux";
+    [Parameter($"Docker containers type to be used. One of '{ContainersNone}', '{ContainersLinux}', '{ContainersWindows}'. Default is '{ContainersLinux}'")]
+    readonly string Containers = ContainersLinux;
+
+    const string ContainersNone = "none";
+    const string ContainersLinux = "linux";
+    const string ContainersWindows = "windows";
+
 
     [Parameter("Windows Server Core container version. Use it if your Windows does not support the default value. Default is 'ltsc2022'")]
     readonly string WindowsContainerVersion = "ltsc2022";
@@ -104,11 +109,11 @@ partial class Build : NukeBuild
     {
             switch (Containers)
             {
-                case "none":
+                case ContainersNone:
                     return "Containers!=Linux&Containers!=Windows";
-                case "linux":
+                case ContainersLinux:
                     return "Containers!=Windows";
-                case "windows":
+                case ContainersWindows:
                     return "Containers!=Linux";
                 default:
                     throw new InvalidOperationException($"Container={Containers} is not supported");

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using Nuke.Common;
@@ -16,6 +17,9 @@ partial class Build : NukeBuild
 
     [Parameter("Platform to build - x86 or x64. Default is x64")]
     readonly MSBuildTargetPlatform Platform = MSBuildTargetPlatform.x64;
+
+    [Parameter("Docker containers type to be used. One of 'none', 'linux', 'windows'. Default is 'linux'")]
+    readonly string Containers = "linux";
 
     [Parameter("Windows Server Core container version. Use it if your Windows does not support the default value. Default is 'ltsc2022'")]
     readonly string WindowsContainerVersion = "ltsc2022";
@@ -95,4 +99,19 @@ partial class Build : NukeBuild
     Target BuildExamples => _ => _
         .Description("Build the Examples")
         .DependsOn(CompileExamples);
+
+    string ContainersTestFilter()
+    {
+            switch (Containers)
+            {
+                case "none":
+                    return "Containers!=Linux&Containers!=Windows";
+                case "linux":
+                    return "Containers!=Windows";
+                case "windows":
+                    return "Containers!=Linux";
+                default:
+                    throw new InvalidOperationException($"Container={Containers} is not supported");
+            }
+    }
 }

--- a/test/integration-tests/IntegrationTests.MongoDB/MongoDbCollection.cs
+++ b/test/integration-tests/IntegrationTests.MongoDB/MongoDbCollection.cs
@@ -35,26 +35,16 @@ public class MongoDbFixture : IAsyncLifetime
     private const string MongoDbImage = "mongo:5.0.6";
 
     private TestcontainersContainer _container;
-    private bool _shouldLaunchContainer = false;
 
     public MongoDbFixture()
     {
-        _shouldLaunchContainer = ShouldLaunchContainer();
-
-        Port = _shouldLaunchContainer
-            ? TcpPortProvider.GetOpenPort()
-            : MongoDbPort;
+        Port = TcpPortProvider.GetOpenPort();
     }
 
     public int Port { get; }
 
     public async Task InitializeAsync()
     {
-        if (!_shouldLaunchContainer)
-        {
-            return;
-        }
-
         _container = await LaunchMongoContainerAsync(Port);
     }
 
@@ -62,26 +52,8 @@ public class MongoDbFixture : IAsyncLifetime
     {
         if (_container != null)
         {
-            await ShutDownMongoContainerAsync(_container);
+            await ShutdownMongoContainerAsync(_container);
         }
-    }
-
-    private bool ShouldLaunchContainer()
-    {
-        if (EnvironmentHelper.IsRunningOnCI())
-        {
-            if (EnvironmentTools.IsWindows() ||
-                EnvironmentTools.IsMacOS())
-            {
-                return false;
-            }
-            else if (EnvironmentTools.IsLinux())
-            {
-                return true;
-            }
-        }
-
-        return true;
     }
 
     private async Task<TestcontainersContainer> LaunchMongoContainerAsync(int port)
@@ -102,7 +74,7 @@ public class MongoDbFixture : IAsyncLifetime
         return container;
     }
 
-    private async Task ShutDownMongoContainerAsync(TestcontainersContainer container)
+    private async Task ShutdownMongoContainerAsync(TestcontainersContainer container)
     {
         await container.CleanUpAsync();
         await container.DisposeAsync();

--- a/test/integration-tests/IntegrationTests.MongoDB/MongoDbTests.cs
+++ b/test/integration-tests/IntegrationTests.MongoDB/MongoDbTests.cs
@@ -42,6 +42,7 @@ namespace IntegrationTests.MongoDB
 
         [Fact]
         [Trait("Category", "EndToEnd")]
+        [Trait("Containers", "Linux")]
         public void SubmitsTraces()
         {
             int agentPort = TcpPortProvider.GetOpenPort();

--- a/test/integration-tests/aspnet/IntegrationTests.AspNet/AspNetTests.cs
+++ b/test/integration-tests/aspnet/IntegrationTests.AspNet/AspNetTests.cs
@@ -18,7 +18,6 @@ public class AspNetTests : TestHelper
 
     [Fact]
     [Trait("Category", "EndToEnd")]
-    [Trait("WindowsOnly", "True")]
     public async Task SubmitsTraces()
     {
         var agentPort = TcpPortProvider.GetOpenPort();

--- a/test/integration-tests/aspnet/IntegrationTests.AspNet/AspNetTests.cs
+++ b/test/integration-tests/aspnet/IntegrationTests.AspNet/AspNetTests.cs
@@ -18,6 +18,7 @@ public class AspNetTests : TestHelper
 
     [Fact]
     [Trait("Category", "EndToEnd")]
+    [Trait("Containers", "Windows")]
     public async Task SubmitsTraces()
     {
         var agentPort = TcpPortProvider.GetOpenPort();


### PR DESCRIPTION
Fixes #389
Fixes #414 

Changes proposed in this pull request:

- Remove unneeded `[Trait("WindowsOnly", "True")]` as `<WindowsOnly>true</WindowsOnly>` project property is used for running WindowsOnly tests.
- Add `--containers` Nuke parameter which can be used to tell what Docker containers are available on your machine. This enables running the Linux container tests on your Windows and macOS locally using Nuke.
- Run `MongoDbTests` only using Linux containers - the GitHub's Windows environment occurred to be flaky.