### PR TITLE
Metrics exporter prep - Rename tracer-based files

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -58,7 +58,7 @@ public class ConfigurationKeys
         /// Configuration key for enabling or disabling the Tracer.
         /// Default is value is true (enabled).
         /// </summary>
-        /// <seealso cref="Settings.TraceEnabled"/>
+        /// <seealso cref="TracerSettings.TraceEnabled"/>
         public const string Enabled = "OTEL_DOTNET_AUTO_TRACES_ENABLED";
 
         /// <summary>

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -1,4 +1,4 @@
-// <copyright file="EnvironmentConfigurationHelper.cs" company="OpenTelemetry Authors">
+// <copyright file="EnvironmentConfigurationTracerHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,17 +22,17 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.AutoInstrumentation.Configuration;
 
-internal static class EnvironmentConfigurationHelper
+internal static class EnvironmentConfigurationTracerHelper
 {
-    private static readonly Dictionary<Instrumentation, Action<TracerProviderBuilder>> AddInstrumentation = new()
+    private static readonly Dictionary<TracerInstrumentation, Action<TracerProviderBuilder>> AddInstrumentation = new()
     {
-        [Instrumentation.HttpClient] = builder => builder.AddHttpClientInstrumentation(),
-        [Instrumentation.AspNet] = builder => builder.AddSdkAspNetInstrumentation(),
-        [Instrumentation.SqlClient] = builder => builder.AddSqlClientInstrumentation(),
-        [Instrumentation.MongoDb] = builder => builder.AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources")
+        [TracerInstrumentation.HttpClient] = builder => builder.AddHttpClientInstrumentation(),
+        [TracerInstrumentation.AspNet] = builder => builder.AddSdkAspNetInstrumentation(),
+        [TracerInstrumentation.SqlClient] = builder => builder.AddSqlClientInstrumentation(),
+        [TracerInstrumentation.MongoDb] = builder => builder.AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources")
     };
 
-    public static TracerProviderBuilder UseEnvironmentVariables(this TracerProviderBuilder builder, Settings settings)
+    public static TracerProviderBuilder UseEnvironmentVariables(this TracerProviderBuilder builder, TracerSettings settings)
     {
         var resourceBuilder = ResourceBuilder.CreateDefault();
 
@@ -66,7 +66,7 @@ internal static class EnvironmentConfigurationHelper
 #endif
     }
 
-    private static TracerProviderBuilder SetExporter(this TracerProviderBuilder builder, Settings settings)
+    private static TracerProviderBuilder SetExporter(this TracerProviderBuilder builder, TracerSettings settings)
     {
         if (settings.ConsoleExporterEnabled)
         {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/IntegrationRegistry.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/IntegrationRegistry.cs
@@ -28,12 +28,12 @@ internal static class IntegrationRegistry
 
     static IntegrationRegistry()
     {
-        var values = Enum.GetValues(typeof(Instrumentation));
+        var values = Enum.GetValues(typeof(TracerInstrumentation));
         var ids = new Dictionary<string, int>(values.Length);
 
         Names = new string[values.Cast<int>().Max() + 1];
 
-        foreach (Instrumentation value in values)
+        foreach (TracerInstrumentation value in values)
         {
             var name = value.ToString();
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
@@ -1,4 +1,4 @@
-// <copyright file="Instrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 /// <summary>
 /// Enum representing supported instrumentations.
 /// </summary>
-public enum Instrumentation
+public enum TracerInstrumentation
 {
     /// <summary>
     /// HttpClient instrumentation.

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
@@ -1,4 +1,4 @@
-// <copyright file="Settings.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerSettings.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,16 +23,16 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 // TODO Move settings to more suitable place?
 
 /// <summary>
-/// Settings
+/// Tracer Settings
 /// </summary>
-public class Settings
+public class TracerSettings
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="Settings"/> class
+    /// Initializes a new instance of the <see cref="TracerSettings"/> class
     /// using the specified <see cref="IConfigurationSource"/> to initialize values.
     /// </summary>
     /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
-    private Settings(IConfigurationSource source)
+    private TracerSettings(IConfigurationSource source)
     {
         if (source == null)
         {
@@ -44,13 +44,13 @@ public class Settings
 
         ConsoleExporterEnabled = source.GetBool(ConfigurationKeys.Traces.ConsoleExporterEnabled) ?? false;
 
-        var instrumentations = new Dictionary<string, Instrumentation>();
+        var instrumentations = new Dictionary<string, TracerInstrumentation>();
         var enabledInstrumentations = source.GetString(ConfigurationKeys.Traces.Instrumentations);
         if (enabledInstrumentations != null)
         {
             foreach (var instrumentation in enabledInstrumentations.Split(separator: ','))
             {
-                if (Enum.TryParse(instrumentation, out Instrumentation parsedType))
+                if (Enum.TryParse(instrumentation, out TracerInstrumentation parsedType))
                 {
                     instrumentations[instrumentation] = parsedType;
                 }
@@ -139,7 +139,7 @@ public class Settings
     /// <summary>
     /// Gets the list of enabled instrumentations.
     /// </summary>
-    public IList<Instrumentation> EnabledInstrumentations { get; }
+    public IList<TracerInstrumentation> EnabledInstrumentations { get; }
 
     /// <summary>
     /// Gets the list of plugins represented by <see cref="Type.AssemblyQualifiedName"/>.
@@ -176,7 +176,7 @@ public class Settings
     /// </summary>
     public bool FlushOnUnhandledException { get; }
 
-    internal static Settings FromDefaultSources()
+    internal static TracerSettings FromDefaultSources()
     {
         var configurationSource = new CompositeConfigurationSource
         {
@@ -188,7 +188,7 @@ public class Settings
 #endif
         };
 
-        return new Settings(configurationSource);
+        return new TracerSettings(configurationSource);
     }
 
     private static OtlpExportProtocol? GetExporterOtlpProtocol(IConfigurationSource source)

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -62,7 +62,7 @@ public static class Instrumentation
         }
     }
 
-    internal static Settings TracerSettings { get; } = Settings.FromDefaultSources();
+    internal static TracerSettings TracerSettings { get; } = TracerSettings.FromDefaultSources();
 
     /// <summary>
     /// Initialize the OpenTelemetry SDK with a pre-defined set of exporters, shims, and

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/GraphQLCommon.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/GraphQLCommon.cs
@@ -37,7 +37,7 @@ internal class GraphQLCommon
     internal const string ExecuteOperationName = "graphql.execute";
     internal const string ResolveOperationName = "graphql.resolve"; // Instrumentation not yet implemented
 
-    internal const string IntegrationName = nameof(Configuration.Instrumentation.GraphQL);
+    internal const string IntegrationName = nameof(Configuration.TracerInstrumentation.GraphQL);
     internal static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
 
     internal static readonly ActivitySource ActivitySource = new ActivitySource(

--- a/src/OpenTelemetry.AutoInstrumentation/Util/SettingsExtensions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Util/SettingsExtensions.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.AutoInstrumentation.Util;
 
 internal static class SettingsExtensions
 {
-    internal static bool IsIntegrationEnabled(this Settings settings, IntegrationInfo integration, bool defaultValue = true)
+    internal static bool IsIntegrationEnabled(this TracerSettings settings, IntegrationInfo integration, bool defaultValue = true)
     {
         if (settings.TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
         {

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -39,7 +39,7 @@ public class SettingsTests : IDisposable
     [Fact]
     public void DefaultValues()
     {
-        var settings = Settings.FromDefaultSources();
+        var settings = TracerSettings.FromDefaultSources();
 
         using (new AssertionScope())
         {
@@ -67,7 +67,7 @@ public class SettingsTests : IDisposable
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporter);
 
-        var settings = Settings.FromDefaultSources();
+        var settings = TracerSettings.FromDefaultSources();
 
         settings.TracesExporter.Should().Be(expectedTracesExporter);
     }
@@ -79,7 +79,7 @@ public class SettingsTests : IDisposable
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporter);
 
-        Action act = () => Settings.FromDefaultSources();
+        Action act = () => TracerSettings.FromDefaultSources();
 
         act.Should().Throw<FormatException>();
     }
@@ -94,7 +94,7 @@ public class SettingsTests : IDisposable
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, otlpProtocol);
 
-        var settings = Settings.FromDefaultSources();
+        var settings = TracerSettings.FromDefaultSources();
 
         // null values for expected data will be handled by OTel .NET SDK
         settings.OtlpExportProtocol.Should().Be(expectedOtlpExportProtocol);
@@ -108,7 +108,7 @@ public class SettingsTests : IDisposable
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Http2UnencryptedSupportEnabled, http2UnencryptedSupportEnabled);
 
-        var settings = Settings.FromDefaultSources();
+        var settings = TracerSettings.FromDefaultSources();
 
         settings.Http2UnencryptedSupportEnabled.Should().Be(expectedValue);
     }
@@ -121,7 +121,7 @@ public class SettingsTests : IDisposable
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.FlushOnUnhandledException, flushOnUnhandledException);
 
-        var settings = Settings.FromDefaultSources();
+        var settings = TracerSettings.FromDefaultSources();
 
         settings.FlushOnUnhandledException.Should().Be(expectedValue);
     }


### PR DESCRIPTION
Changes proposed in this pull request:

Renamed the following files

`Settings.cs` &#8594; `TracerSettings.cs`
`EnvironmentConfigurationHelper.cs` &#8594; `EnvironmentConfigurationTracerHelper.cs`
`Instrumentation.cs` &#8594; `TracerInstrumentation.cs`

**TODO**

- Refactor `Settings` in a follow up PR