### PR TITLE
Add link to released documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,15 @@
 This project adds [OpenTelemetry instrumentation](https://opentelemetry.io/docs/concepts/instrumenting/#automatic-instrumentation)
 to .NET applications without having to modify their source code.
 
+---
+
+⚠️ The following documentation refers to the in-development version
+of OpenTelemetry .NET Automatic Instrumentation. Docs for the latest version
+([v0.1.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
+can be found [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/README.md).
+
+---
+
 OpenTelemetry .NET Automatic Instrumentation is built on top of
 [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 


### PR DESCRIPTION
We have an issue reported on slack. The customer missed that he is using in-development documentation.

