### PR TITLE
Consolidate settings separators

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
@@ -123,7 +123,10 @@ internal class StartupHook
             return excludedProcesses;
         }
 
-        foreach (var processName in environmentValue.Split(','))
+        // The separator should always match the Settings.Separator. However, to avoid
+        // creating a dependecy in the StartupHook project the separator is being redefined here.
+        const char settingsSeparator = ',';
+        foreach (var processName in environmentValue.Split(settingsSeparator))
         {
             if (!string.IsNullOrWhiteSpace(processName))
             {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/CompositeConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/CompositeConfigurationSource.cs
@@ -114,18 +114,4 @@ public class CompositeConfigurationSource : IConfigurationSource, IEnumerable<IC
     {
         return _sources.GetEnumerator();
     }
-
-    /// <inheritdoc />
-    public IDictionary<string, string> GetDictionary(string key)
-    {
-        return _sources.Select(source => source.GetDictionary(key))
-            .FirstOrDefault(value => value != null);
-    }
-
-    /// <inheritdoc />
-    public IDictionary<string, string> GetDictionary(string key, bool allowOptionalMappings)
-    {
-        return _sources.Select(source => source.GetDictionary(key, allowOptionalMappings))
-            .FirstOrDefault(value => value != null);
-    }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/IConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/IConfigurationSource.cs
@@ -54,21 +54,4 @@ public interface IConfigurationSource
     /// <param name="key">The key that identifies the setting.</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
     bool? GetBool(string key);
-
-    /// <summary>
-    /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
-    /// the setting with the specified key.
-    /// </summary>
-    /// <param name="key">The key that identifies the setting.</param>
-    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    IDictionary<string, string> GetDictionary(string key);
-
-    /// <summary>
-    /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
-    /// the setting with the specified key.
-    /// </summary>
-    /// <param name="key">The key that identifies the setting.</param>
-    /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
-    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    IDictionary<string, string> GetDictionary(string key, bool allowOptionalMappings);
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/MeterSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/MeterSettings.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
             var enabledInstrumentations = source.GetString(ConfigurationKeys.Metrics.Instrumentations);
             if (enabledInstrumentations != null)
             {
-                foreach (var instrumentation in enabledInstrumentations.Split(separator: ','))
+                foreach (var instrumentation in enabledInstrumentations.Split(Separator))
                 {
                     if (Enum.TryParse(instrumentation, out MeterInstrumentation parsedType))
                     {
@@ -56,7 +56,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
             var disabledInstrumentations = source.GetString(ConfigurationKeys.Metrics.DisabledInstrumentations);
             if (disabledInstrumentations != null)
             {
-                foreach (var instrumentation in disabledInstrumentations.Split(separator: ','))
+                foreach (var instrumentation in disabledInstrumentations.Split(Separator))
                 {
                     instrumentations.Remove(instrumentation);
                 }
@@ -67,7 +67,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
             var providerPlugins = source.GetString(ConfigurationKeys.Metrics.ProviderPlugins);
             if (providerPlugins != null)
             {
-                foreach (var pluginAssemblyQualifiedName in providerPlugins.Split(':'))
+                foreach (var pluginAssemblyQualifiedName in providerPlugins.Split(DotNetQualifiedNameSeparator))
                 {
                     MetricPlugins.Add(pluginAssemblyQualifiedName);
                 }
@@ -76,7 +76,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
             var additionalSources = source.GetString(ConfigurationKeys.Metrics.AdditionalSources);
             if (additionalSources != null)
             {
-                foreach (var sourceName in additionalSources.Split(separator: ','))
+                foreach (var sourceName in additionalSources.Split(Separator))
                 {
                     Meters.Add(sourceName);
                 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Settings.cs
@@ -25,6 +25,18 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
     public abstract class Settings
     {
         /// <summary>
+        /// Default delimiter for textual representation of multi-valued settings.
+        /// </summary>
+        public const char Separator = ',';
+
+        /// <summary>
+        /// Delimiter for textual representation of settings that contains multiple
+        /// fully qualifined .NET names, e.g.: assembly or type names. Comma is part
+        /// of a fully qualified name and can't be used here.
+        /// </summary>
+        public const char DotNetQualifiedNameSeparator = ':';
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Settings"/> class
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/StringConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/StringConfigurationSource.cs
@@ -61,7 +61,7 @@ public abstract class StringConfigurationSource : IConfigurationSource
             return dictionary;
         }
 
-        var entries = data.Split(',');
+        var entries = data.Split(Settings.Separator);
 
         foreach (var e in entries)
         {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/StringConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/StringConfigurationSource.cs
@@ -26,67 +26,6 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 /// </summary>
 public abstract class StringConfigurationSource : IConfigurationSource
 {
-    /// <summary>
-    /// Returns a <see cref="IDictionary{TKey, TValue}"/> from parsing
-    /// <paramref name="data"/>.
-    /// </summary>
-    /// <param name="data">A string containing key-value pairs which are comma-separated, and for which the key and value are colon-separated.</param>
-    /// <returns><see cref="IDictionary{TKey, TValue}"/> of key value pairs.</returns>
-    public static IDictionary<string, string> ParseCustomKeyValues(string data)
-    {
-        return ParseCustomKeyValues(data, allowOptionalMappings: false);
-    }
-
-    /// <summary>
-    /// Returns a <see cref="IDictionary{TKey, TValue}"/> from parsing
-    /// <paramref name="data"/>.
-    /// </summary>
-    /// <param name="data">A string containing key-value pairs which are comma-separated, and for which the key and value are colon-separated.</param>
-    /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
-    /// <returns><see cref="IDictionary{TKey, TValue}"/> of key value pairs.</returns>
-    public static IDictionary<string, string> ParseCustomKeyValues(string data, bool allowOptionalMappings)
-    {
-        var dictionary = new ConcurrentDictionary<string, string>();
-
-        // A null return value means the key was not present,
-        // and CompositeConfigurationSource depends on this behavior
-        // (it returns the first non-null value it finds).
-        if (data == null)
-        {
-            return null;
-        }
-
-        if (string.IsNullOrWhiteSpace(data))
-        {
-            return dictionary;
-        }
-
-        var entries = data.Split(Settings.Separator);
-
-        foreach (var e in entries)
-        {
-            var kv = e.Split(':');
-            if (allowOptionalMappings && kv.Length == 1)
-            {
-                var key = kv[0];
-                var value = string.Empty;
-                dictionary[key] = value;
-            }
-            else if (kv.Length != 2)
-            {
-                continue;
-            }
-            else
-            {
-                var key = kv[0];
-                var value = kv[1];
-                dictionary[key] = value;
-            }
-        }
-
-        return dictionary;
-    }
-
     /// <inheritdoc />
     public abstract string GetString(string key);
 
@@ -115,26 +54,5 @@ public abstract class StringConfigurationSource : IConfigurationSource
     {
         var value = GetString(key);
         return bool.TryParse(value, out bool result) ? result : null;
-    }
-
-    /// <summary>
-    /// Gets a <see cref="ConcurrentDictionary{TKey, TValue}"/> from parsing
-    /// </summary>
-    /// <param name="key">The key</param>
-    /// <returns><see cref="ConcurrentDictionary{TKey, TValue}"/> containing all of the key-value pairs.</returns>
-    public IDictionary<string, string> GetDictionary(string key)
-    {
-        return ParseCustomKeyValues(GetString(key), allowOptionalMappings: false);
-    }
-
-    /// <summary>
-    /// Gets a <see cref="ConcurrentDictionary{TKey, TValue}"/> from parsing
-    /// </summary>
-    /// <param name="key">The key</param>
-    /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
-    /// <returns><see cref="ConcurrentDictionary{TKey, TValue}"/> containing all of the key-value pairs.</returns>
-    public IDictionary<string, string> GetDictionary(string key, bool allowOptionalMappings)
-    {
-        return ParseCustomKeyValues(GetString(key), allowOptionalMappings);
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
@@ -41,7 +41,7 @@ public class TracerSettings : Settings
         var enabledInstrumentations = source.GetString(ConfigurationKeys.Traces.Instrumentations);
         if (enabledInstrumentations != null)
         {
-            foreach (var instrumentation in enabledInstrumentations.Split(separator: ','))
+            foreach (var instrumentation in enabledInstrumentations.Split(Separator))
             {
                 if (Enum.TryParse(instrumentation, out TracerInstrumentation parsedType))
                 {
@@ -57,7 +57,7 @@ public class TracerSettings : Settings
         var disabledInstrumentations = source.GetString(ConfigurationKeys.Traces.DisabledInstrumentations);
         if (disabledInstrumentations != null)
         {
-            foreach (var instrumentation in disabledInstrumentations.Split(separator: ','))
+            foreach (var instrumentation in disabledInstrumentations.Split(Separator))
             {
                 instrumentations.Remove(instrumentation);
             }
@@ -68,7 +68,7 @@ public class TracerSettings : Settings
         var providerPlugins = source.GetString(ConfigurationKeys.Traces.ProviderPlugins);
         if (providerPlugins != null)
         {
-            foreach (var pluginAssemblyQualifiedName in providerPlugins.Split(':'))
+            foreach (var pluginAssemblyQualifiedName in providerPlugins.Split(DotNetQualifiedNameSeparator))
             {
                 TracerPlugins.Add(pluginAssemblyQualifiedName);
             }
@@ -77,7 +77,7 @@ public class TracerSettings : Settings
         var additionalSources = source.GetString(ConfigurationKeys.Traces.AdditionalSources);
         if (additionalSources != null)
         {
-            foreach (var sourceName in additionalSources.Split(separator: ','))
+            foreach (var sourceName in additionalSources.Split(Separator))
             {
                 ActivitySources.Add(sourceName);
             }
@@ -86,7 +86,7 @@ public class TracerSettings : Settings
         var legacySources = source.GetString(ConfigurationKeys.Traces.LegacySources);
         if (legacySources != null)
         {
-            foreach (var sourceName in legacySources.Split(separator: ','))
+            foreach (var sourceName in legacySources.Split(Separator))
             {
                 LegacySources.Add(sourceName);
             }


### PR DESCRIPTION
Fixes #678

Consolidate the separator used for list of values on `Settings` to a single constant. In process found some code in IConfigurationSource that was not being used and removed it.

See this [review comment](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/675#discussion_r872754550) for context.

