### PR TITLE
Document IIS instrumentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@ DOTNET_SHARED_STORE=%InstallationLocation%/store
 DOTNET_STARTUP_HOOKS=%InstallationLocation%/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll
 OTEL_DOTNET_AUTO_HOME=%InstallationLocation%
 OTEL_DOTNET_AUTO_INTEGRATIONS_FILE=%InstallationLocation%/integrations.json
+OTEL_SERVICE_NAME=my-service-name
 ```
 
 ### Instrument a .NET application on Linux
@@ -130,6 +131,7 @@ DOTNET_SHARED_STORE=%InstallationLocation%/store
 DOTNET_STARTUP_HOOKS=%InstallationLocation%/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll
 OTEL_DOTNET_AUTO_HOME=%InstallationLocation%
 OTEL_DOTNET_AUTO_INTEGRATIONS_FILE=%InstallationLocation%/integrations.json
+OTEL_SERVICE_NAME=my-service-name
 ```
 
 ### Instrument a .NET application on macOS
@@ -145,11 +147,16 @@ DOTNET_SHARED_STORE=%InstallationLocation%/store
 DOTNET_STARTUP_HOOKS=%InstallationLocation%/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll
 OTEL_DOTNET_AUTO_HOME=%InstallationLocation%
 OTEL_DOTNET_AUTO_INTEGRATIONS_FILE=%InstallationLocation%/integrations.json
+OTEL_SERVICE_NAME=my-service-name
 ```
 
 ## Instrument a Windows Service running a .NET application
 
 See [windows-service-instrumentation.md](windows-service-instrumentation.md).
+
+## Instrument an ASP.NET application deployed on IIS
+
+See [iis-instrumentation.md](iis-instrumentation.md).
 
 ## Configuration
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -41,14 +41,6 @@ for more details.
 | `MongoDb` | [MongoDB.Driver.Core](https://www.nuget.org/packages/MongoDB.Driver.Core) | ≥2.3.0 & < 3.0.0 | source & bytecode |
 | `SqlClient` | [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient) and [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient) | * | source |
 
-## ASP.NET (.NET Framework) Instrumentation
-
-ASP.NET instrumentation on .NET Framework requires to install the
-[`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
-NuGet package in the instrumented project.
-See [the WebConfig section](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.AspNet#step-2-modify-webconfig)
-for more information.
-
 ## Logging
 
 The default log directory paths are:

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -11,8 +11,7 @@ by setting the required environment variables for
   Therefore all applications will share
   the same configuration (e.g. `OTEL_SERVICE_NAME`).
 
-ASP.NET instrumentation on .NET Framework requires to install the
-[`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
+Install the [`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
 NuGet package in the instrumented project.
 
 Make sure to enable the ASP.NET instrumentation by setting

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -51,7 +51,7 @@ You can add it in the following places:
 
 The ASP.NET HTTP module can be also set in `applicationHost.config`.
 Here is an example where you can add the module
-to set it for all ASP.NET application runing in Integrated Pipeline Mode:
+to set it for all ASP.NET application running in Integrated Pipeline Mode:
 
 ```xml
   <location path="" overrideMode="Allow">

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -6,13 +6,35 @@ You can instrumental all ASP.NET 4.x application deployed to IIS
 by setting the required environment variables for
 `W3SVC` and `WAS` Windows Services as described in [windows-service-instrumentation.md](windows-service-instrumentation.md).
 
-Unfortunately it is not possible to set distinct environment variables
-values for the instrumented ASP.NET application.
-Therefore all applications will share
-the same configuration (e.g. `OTEL_SERVICE_NAME`).
+> Unfortunately it is not possible to set distinct environment variables
+  values for the instrumented ASP.NET application.
+  Therefore all applications will share
+  the same configuration (e.g. `OTEL_SERVICE_NAME`).
+
+ASP.NET instrumentation on .NET Framework requires to install the
+[`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
+NuGet package in the instrumented project.
+The following shows changes required to your `Web.config`:
+
+```xml
+<system.webServer>
+  <modules>
+    <add
+      name="TelemetryHttpModule"
+      type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule"
+      preCondition="integratedMode,managedHandler" />
+    </modules>
+</system.webServer>
+```
+
+Make sure to enable the ASP.NET instrumentation by setting
+`OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS=AspNet`.
 
 ## Instrument an ASP.NET Core application
 
 Use the [`environmentVariable`](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/web-config#set-environment-variables)
 elements inside the `<aspNetCore>` block of your `web.config` file
 to set environment variables.
+
+Make sure to enable the ASP.NET instrumentation by setting
+`OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS=AspNet`.

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -14,18 +14,6 @@ by setting the required environment variables for
 ASP.NET instrumentation on .NET Framework requires to install the
 [`OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/)
 NuGet package in the instrumented project.
-The following shows changes required to your `Web.config`:
-
-```xml
-<system.webServer>
-  <modules>
-    <add
-      name="TelemetryHttpModule"
-      type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule"
-      preCondition="integratedMode,managedHandler" />
-    </modules>
-</system.webServer>
-```
 
 Make sure to enable the ASP.NET instrumentation by setting
 `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS=AspNet`.

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -1,0 +1,18 @@
+# Instrument an ASP.NET application deployed on IIS
+
+## Instrument an ASP.NET 4.x application
+
+You can instrumental all ASP.NET 4.x application deployed to IIS
+by setting the required environment variables for
+`W3SVC` and `WAS` Windows Services as described in [windows-service-instrumentation.md](windows-service-instrumentation.md).
+
+Unfortunately it is not possible to set distinct environment variables
+values for the instrumented ASP.NET application.
+Therefore all applications will share
+the same configuration (e.g. `OTEL_SERVICE_NAME`).
+
+## Instrument an ASP.NET Core application
+
+Use the [`environmentVariable`](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/web-config#set-environment-variables)
+elements inside the `<aspNetCore>` block of your `web.config` file
+to set environment variables.

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -33,7 +33,7 @@ Make sure to enable the ASP.NET instrumentation by setting
 ## Instrument an ASP.NET Core application
 
 Use the [`environmentVariable`](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/web-config#set-environment-variables)
-elements inside the `<aspNetCore>` block of your `web.config` file
+elements inside the `<aspNetCore>` block of your `Web.config` file
 to set environment variables.
 
 Make sure to enable the ASP.NET instrumentation by setting

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,12 +40,6 @@ If the system or user scope is intended, use the `OTEL_DOTNET_AUTO_EXCLUDE_PROCE
 and `OTEL_DOTNET_AUTO_INCLUDE_PROCESSES` environment variables to include or exclude
 applications from the automatic instrumentation.
 
-## ASP.NET instrumentation is not producing spans
-
-Make sure that your instrumented application's `Web.config` has
-added the `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`
-ASP.NET HTTP module.
-
 ## Collect debug logs
 
 Detailed debug logs can help you troubleshoot instrumentation issues, and can be

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,6 +40,12 @@ If the system or user scope is intended, use the `OTEL_DOTNET_AUTO_EXCLUDE_PROCE
 and `OTEL_DOTNET_AUTO_INCLUDE_PROCESSES` environment variables to include or exclude
 applications from the automatic instrumentation.
 
+## ASP.NET instrumentation is not producing spans
+
+Make sure that your instrumented application's `Web.config` has
+added the `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule`
+ASP.NET HTTP module.
+
 ## Collect debug logs
 
 Detailed debug logs can help you troubleshoot instrumentation issues, and can be
@@ -55,3 +61,12 @@ environment variable.
 
 After obtaining the logs, remove the `OTEL_DOTNET_AUTO_DEBUG`
 environment variable to avoid unnecessary overhead.
+
+## Nothing happens
+
+It may occur that the .NET Profiler is unable to attach
+and therefore no logs would be emited.
+
+The most common reason is that the instrumented application
+has no permissions to load the OpenTelemetry .NET Automatic Instrumentation
+assemblies.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,7 +65,7 @@ environment variable to avoid unnecessary overhead.
 ## Nothing happens
 
 It may occur that the .NET Profiler is unable to attach
-and therefore no logs would be emited.
+and therefore no logs would be emitted.
 
 The most common reason is that the instrumented application
 has no permissions to load the OpenTelemetry .NET Automatic Instrumentation

--- a/test/test-applications/integrations/aspnet/TestApplication.AspNet/TestApplication.AspNet.csproj
+++ b/test/test-applications/integrations/aspnet/TestApplication.AspNet/TestApplication.AspNet.csproj
@@ -44,9 +44,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -83,17 +80,6 @@
     <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
-    </Reference>
-    <Reference Include="System.Web.Optimization">
-      <HintPath>..\..\..\..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
-    </Reference>
-    <Reference Include="WebGrease">
-      <Private>True</Private>
-      <HintPath>..\..\..\..\..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
-    </Reference>
-    <Reference Include="Antlr3.Runtime">
-      <Private>True</Private>
-      <HintPath>..\..\..\..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/test-applications/integrations/aspnet/TestApplication.AspNet/TestApplication.AspNet.csproj
+++ b/test/test-applications/integrations/aspnet/TestApplication.AspNet/TestApplication.AspNet.csproj
@@ -40,33 +40,12 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OpenTelemetry.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Api.1.2.0\lib\net461\OpenTelemetry.Api.dll</HintPath>
-    </Reference>
-    <Reference Include="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.1.0.0-rc9.2\lib\net461\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Buffers.4.5.1\lib\net462\System.Buffers.dll</HintPath>
-    </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Diagnostics.DiagnosticSource.6.0.0\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
-    </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Memory.4.5.4\lib\net462\System.Memory.dll</HintPath>
-    </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/test/test-applications/integrations/aspnet/TestApplication.AspNet/Web.config
+++ b/test/test-applications/integrations/aspnet/TestApplication.AspNet/Web.config
@@ -37,26 +37,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
@@ -67,10 +47,6 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.8.0" newVersion="5.2.8.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/test-applications/integrations/aspnet/TestApplication.AspNet/packages.config
+++ b/test/test-applications/integrations/aspnet/TestApplication.AspNet/packages.config
@@ -8,13 +8,4 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
-  <package id="OpenTelemetry.Api" version="1.2.0" targetFramework="net462" />
-  <package id="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" version="1.0.0-rc9.2" targetFramework="net462" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
-  <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net462" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net462" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
-  <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net462" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Fixes #632
Fixes #689

Changes proposed in this pull request:
- Document how to instrument an ASP.NET and ASP.NET Core application deployed on IIS 
- Remove necessary references from `TestApplication.AspNet`

Docs preview: https://github.com/pellared/opentelemetry-dotnet-instrumentation/blob/docs-iis/docs/iis-instrumentation.md

## Testing

I was testing against an ASP.NET Web API application created using the Visual Studio template.

```
otel-collector_1  | 2022-05-19T11:42:39.726Z    DEBUG   loggingexporter/logging_exporter.go:49  ResourceSpans #0
otel-collector_1  | Resource SchemaURL:
otel-collector_1  | Resource labels:
otel-collector_1  |      -> service.name: STRING(unknown_service:w3wp)
otel-collector_1  | ScopeSpans #0
otel-collector_1  | ScopeSpans SchemaURL:
otel-collector_1  | InstrumentationScope OpenTelemetry.Instrumentation.AspNet.Telemetry 1.0.0.0
otel-collector_1  | Span #0
otel-collector_1  |     Trace ID       : 8a066413b0daa361ddb238e95d967ce2
otel-collector_1  |     Parent ID      :
otel-collector_1  |     ID             : 8a06ce6e7f8884b7
otel-collector_1  |     Name           : api/{controller}/{id}
otel-collector_1  |     Kind           : SPAN_KIND_SERVER
otel-collector_1  |     Start time     : 2022-05-19 11:42:36.612067 +0000 UTC
otel-collector_1  |     End time       : 2022-05-19 11:42:36.6126715 +0000 UTC
otel-collector_1  |     Status code    : STATUS_CODE_UNSET
otel-collector_1  |     Status message :
otel-collector_1  | Attributes:
otel-collector_1  |      -> http.host: STRING(localhost:8881)
otel-collector_1  |      -> http.method: STRING(GET)
otel-collector_1  |      -> http.target: STRING(/api/values)
otel-collector_1  |      -> http.user_agent: STRING(Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36)
otel-collector_1  |      -> http.url: STRING(http://localhost:8881/api/values)
otel-collector_1  |      -> http.status_code: INT(200)
otel-collector_1  |      -> http.route: STRING(api/{controller}/{id})
````

I was testing it also against an ASP.NET Core Web API application created using the Visual Studio template.


```
2022-05-20T10:18:30.736Z DEBUG loggingexporter/logging_exporter.go:49 ResourceSpans #0
Resource SchemaURL: 
Resource labels:
     -> service.name: STRING(CoreWebApp1)
ScopeSpans #0
ScopeSpans SchemaURL: 
InstrumentationScope OpenTelemetry.Instrumentation.AspNetCore 1.0.0.0
Span #0
    Trace ID       : ea73bcc63f83d87d6e15a264cd8b1330
    Parent ID      : 
    ID             : ab98e96dea4228c9
    Name           : WeatherForecast
    Kind           : SPAN_KIND_SERVER
    Start time     : 2022-05-20 10:18:26.1864498 +0000 UTC
    End time       : 2022-05-20 10:18:26.5124016 +0000 UTC
    Status code    : STATUS_CODE_UNSET
    Status message : 
Attributes:
     -> http.host: STRING(localhost:8885)
     -> http.method: STRING(GET)
     -> http.target: STRING(/WeatherForecast)
     -> http.url: STRING(http://localhost:8885/WeatherForecast)
     -> http.user_agent: STRING(Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36)
     -> http.route: STRING(WeatherForecast)
     -> http.status_code: INT(200)
```