### PR TITLE
Remove hardcoded pwd from SqlClient test

### DIFF
--- a/test/integration-tests/IntegrationTests.SqlClient/SqlClientCollection.cs
+++ b/test/integration-tests/IntegrationTests.SqlClient/SqlClientCollection.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Containers.Builders;
 using DotNet.Testcontainers.Containers.Modules;
@@ -33,7 +34,6 @@ namespace IntegrationTests.SqlClient
     {
         private const int DatabasePort = 1433;
         private const string DatabaseImage = "mcr.microsoft.com/mssql/server:2019-CU15-ubuntu-20.04";
-        private const string DatabasePassword = "@someThingComplicated1234";
 
         private TestcontainersContainer _container;
 
@@ -41,6 +41,8 @@ namespace IntegrationTests.SqlClient
         {
             Port = TcpPortProvider.GetOpenPort();
         }
+
+        public string Password { get; } = $"@{Guid.NewGuid().ToString("N")}";
 
         public int Port { get; }
 
@@ -69,7 +71,7 @@ namespace IntegrationTests.SqlClient
                 .WithImage(DatabaseImage)
                 .WithName($"sql-server-{Port}")
                 .WithPortBinding(Port, DatabasePort)
-                .WithEnvironment("SA_PASSWORD", DatabasePassword)
+                .WithEnvironment("SA_PASSWORD", Password)
                 .WithEnvironment("ACCEPT_EULA", "Y")
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(DatabasePort));
 

--- a/test/integration-tests/IntegrationTests.SqlClient/SqlTests.cs
+++ b/test/integration-tests/IntegrationTests.SqlClient/SqlTests.cs
@@ -47,7 +47,7 @@ namespace IntegrationTests.SqlClient
 
             const int expectedSpanCount = 8;
 
-            using var processResult = RunTestApplicationAndWaitForExit(agent.Port, arguments: $"--database-port {_sqlClientFixture.Port}", enableStartupHook: true);
+            using var processResult = RunTestApplicationAndWaitForExit(agent.Port, arguments: $"{_sqlClientFixture.Password} {_sqlClientFixture.Port}", enableStartupHook: true);
             Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
             var spans = agent.WaitForSpans(expectedSpanCount, TimeSpan.FromSeconds(5));
 

--- a/test/test-applications/integrations/TestApplication.SqlClient/Program.cs
+++ b/test/test-applications/integrations/TestApplication.SqlClient/Program.cs
@@ -34,8 +34,8 @@ namespace TestApplication.SqlClient
             Console.WriteLine($"Profiler attached: {IsProfilerAttached()}");
             Console.WriteLine($"Platform: {(Environment.Is64BitProcess ? "x64" : "x32")}");
 
-            var databasePort = GetPort(args);
-            var connectionString = GetConnectionString(databasePort);
+            (string databasePassword, string databasePort) = ParseArgs(args);
+            var connectionString = GetConnectionString(databasePassword, databasePort);
 
             using (var connection = new SqlConnection(connectionString))
             {
@@ -134,9 +134,9 @@ namespace TestApplication.SqlClient
             await ExecuteCommandAsync(DropCommand, connection);
         }
 
-        private static string GetConnectionString(string databasePort)
+        private static string GetConnectionString(string databasePassword, string databasePort)
         {
-            return $"Server=localhost,{databasePort};User=sa;Password=@someThingComplicated1234;TrustServerCertificate=True;";
+            return $"Server=localhost,{databasePort};User=sa;Password={databasePassword};TrustServerCertificate=True;";
         }
 
         private static bool? IsProfilerAttached()
@@ -154,9 +154,14 @@ namespace TestApplication.SqlClient
             return isAttached ?? false;
         }
 
-        private static string GetPort(IReadOnlyList<string> args)
+        private static (string DatabasePassword, string Port) ParseArgs(IReadOnlyList<string> args)
         {
-            return args.Count > 0 ? args[1] : "1433";
+            if (args?.Count != 2)
+            {
+                throw new ArgumentException($"{nameof(TestApplication.SqlClient)}: requires two command-line arguments: <dbPassword> <dbPort>");
+            }
+
+            return (DatabasePassword: args[0], Port: args[1]);
         }
     }
 }


### PR DESCRIPTION
Removing hardcoded password from integration test. The password is now passed as a parameter to the test application, it is not using a secret store (the ideal) but a guid seems good enough to avoid the hard coded password.