### PR TITLE
Ignore GraphQL updates for GraphQL test app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -168,6 +168,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
+    ignore:
+      # The instrumentation only supports specific versions of GraphQL and the test app needs to test against a specific version
+      - dependency-name: "GraphQL*"
 
   - package-ecosystem: nuget
     directory: /test/test-applications/integrations/dependency-libs/TestApplication.ExampleLibraryTracer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -168,9 +168,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
-    ignore:
-      # The instrumentation only supports specific versions of GraphQL and the test app needs to test against a specific version
-      - dependency-name: "GraphQL*"
 
   - package-ecosystem: nuget
     directory: /test/test-applications/integrations/dependency-libs/TestApplication.ExampleLibraryTracer
@@ -183,6 +180,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
+    ignore:
+      # The instrumentation only supports specific versions of GraphQL and the test app needs to test against a specific version
+      - dependency-name: "GraphQL*"
 
   - package-ecosystem: nuget
     directory: /test/test-applications/integrations/TestApplication.Http


### PR DESCRIPTION
Relates to #679, #680, #681 

Changes proposed in this pull request: 

Adds an explicit ignore in the dependabot configuration with a comment to both ignore future updates to the GraphQL libraries and explain why they are ignored. I think that ignoring these specific updates in this manner will be more discoverable and maintainable in the future, and it is the [guidance provided by github](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-with-comment-commands).

