### PR TITLE
Configure dependabot to bump test/Directory.Build.props

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,6 +104,12 @@ updates:
     open-pull-requests-limit: 20
 
   - package-ecosystem: nuget
+    directory: /test
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
     directory: /test/integration-tests/aspnet/IntegrationTests.AspNet
     schedule:
       interval: "daily"

--- a/test/Empty.csproj
+++ b/test/Empty.csproj
@@ -1,0 +1,6 @@
+<!-- This is an empty *.csproj so that dependabot can bump dependencies in Directory.Build.props. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DefaultItemExcludes>**</DefaultItemExcludes>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #356

Changes proposed in this pull request:
- Configure dependabot to bump references defined in `test/Directory.Build.props`.

Kudos to @lachmatt for his initial work that led to this solution.

## Testing

I changed the default branch to `dependabot-for-propos` on my fork and depdabot created:

- https://github.com/pellared/opentelemetry-dotnet-instrumentation/pull/130
- https://github.com/pellared/opentelemetry-dotnet-instrumentation/pull/129
- https://github.com/pellared/opentelemetry-dotnet-instrumentation/pull/128
- https://github.com/pellared/opentelemetry-dotnet-instrumentation/pull/127

Output from dependabot logs:

```
updater | +---------+---------------------------------------------------+
updater | |             Changes to Dependabot Pull Requests             |
updater | +---------+---------------------------------------------------+
updater | | created | Microsoft.NET.Test.Sdk ( from 17.0.0 to 17.2.0 )  |
updater | | created | FluentAssertions ( from 6.4.0 to 6.7.0 )          |
updater | | created | xunit.runner.visualstudio ( from 2.4.3 to 2.4.5 ) |
updater | | created | Moq ( from 4.16.1 to 4.18.1 )                     |
updater | +---------+---------------------------------------------------+
```



