### PR TITLE
Bump OpenTelemetry core packages to 1.3.0 and non-core to 1.0.0-rc9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.1.0-beta.1...HEAD)
 
+This release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
+
+- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
+  [`1.3.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.0)
+- Non-core components: [`1.0.0-rc9.4`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.4)
+- `System.Diagnostics.DiagnosticSource`: [`6.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/6.0.0)
+
 ### Added
 
 - Adds MongoDB instrumentation support from .NET Core 3.1+.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,8 @@ OpenTelemetry .NET Automatic Instrumentation is built on top of
 [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
-[`1.2.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.2.0)
-- Non-core components: [`1.0.0-rc9.2`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.2)
+[`1.3.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.0)
+- Non-core components: [`1.0.0-rc9.4`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.0.0-rc9.4)
 - `System.Diagnostics.DiagnosticSource`: [`6.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/6.0.0)
 
 To automatically instrument applications, the OpenTelemetry .NET Automatic

--- a/docs/config.md
+++ b/docs/config.md
@@ -81,7 +81,7 @@ Exporters output the telemetry.
 
 To enable the Jaeger exporter, set the `OTEL_TRACES_EXPORTER` environment variable
 to `jaeger`. To customize the Jaeger exporter using environment variables, see the
-[Jaeger exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.2.0/src/OpenTelemetry.Exporter.Jaeger#environment-variables).
+[Jaeger exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.3.0/src/OpenTelemetry.Exporter.Jaeger#environment-variables).
 Important environment variables include:
 
 | Environment variable | Description | Default value |
@@ -95,7 +95,7 @@ Important environment variables include:
 
 To enable the OTLP exporter, set the `OTEL_TRACES_EXPORTER` environment variable
 to `otlp`. To customize the OTLP exporter using environment variables, see the
-[OTLP exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.2.0/src/OpenTelemetry.Exporter.OpenTelemetryProtocol#environment-variables).
+[OTLP exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.3.0/src/OpenTelemetry.Exporter.OpenTelemetryProtocol#environment-variables).
 Important environment variables include:
 
 | Environment variable | Description | Default value |
@@ -125,7 +125,7 @@ environment variables for the OTLP exporter:
 
 To enable the Zipkin exporter, set the `OTEL_TRACES_EXPORTER` environment
 variable to `zipkin`. To customize the Zipkin exporter using environment
-variables, see the [Zipkin exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.2.0/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables).
+variables, see the [Zipkin exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.3.0/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables).
 Important environment variables include:
 
 | Environment variable | Description | Default value |

--- a/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
+++ b/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.4" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
+++ b/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
@@ -10,15 +10,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' != 'net462'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.4" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" Condition="'$(TargetFramework)' != 'net462'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.4" />
   </ItemGroup>
   
 </Project>

--- a/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
+++ b/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -5,18 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="0.1.0-alpha.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.2" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0" />
-    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.4" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
+++ b/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
 
     <!-- Hack to fix SDK dependencies -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #684

Changes proposed in this pull request:

Bump OpenTelemetry core packages to 1.3.0 and non-core to 1.0.0-rc9.4