### PR TITLE
Bump Microsoft.NETFramework.ReferenceAssemblies

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,6 +30,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" Link="GlobalSuppressions.src.cs" />
 
     <!-- reference assemblies let us target .NET Framework without the SDK (for example, on non-Windows) -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: N/A

Changes proposed in this pull request:
Bump Microsoft.NETFramework.ReferenceAssemblies from 1.0.0 to 1.0.2

detected while bumping Otel to 1.3.0


