### PR TITLE
Remove redundant references to System.Diagnostics.DiagnosticSource

### DIFF
--- a/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
+++ b/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
@@ -4,7 +4,6 @@
     <PackageReference Include="DotNet.Testcontainers" Version="1.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />

--- a/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
+++ b/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes N/A

Changes proposed in this pull request:

remove redundant references to System.Diagnostics.DiagnosticSource