### PR TITLE
Fix loading vendor plugin in AspNetCoreMvc-example app

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,17 +31,18 @@ To run the example applications:
 
 You can customize the script using the following environment variables:
 
-| Environment variable | Description | Default |
-|-|-|-|
-| **aspNetAppTargetFramework** | Target framework for the `aspnet-server` service | `netcoreapp3.1` |
-| **configuration** | Build configuration for example apps, either `Release` or `Debug` | `Release` |
-| **enableProfiling** | Value of `COR_ENABLE_PROFILING` and `CORECLR_ENABLE_PROFILING` for the example apps | `1` |
-| **exampleApp** | Application selected for the `http-client` service | `ConsoleApp` |
-| **exampleAppInjectSDK** | Whether automatic instrumentation injects the SDK on the `http-client` service | `true` |
-| **exampleAppTargetFramework** | Target framework for the `http-client` service | `netcoreapp3.1` |
-| **exporter** | Value for [`OTEL_TRACES_EXPORTER`](../docs/config.md#exporters) env. variable | `otlp` |
-| **keepContainers** | Whether the docker containers are preserved after the script execution | `false` |
-| **skipAppBuild** | Whether the script skips building the example apps | `false` |
+| Environment variable            | Description                                                                         | Default                                                                       |
+|---------------------------------|-------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| **aspNetAppTargetFramework**    | Target framework for the `aspnet-server` service                                    | `netcoreapp3.1`                                                               |
+| **configuration**               | Build configuration for example apps, either `Release` or `Debug`                   | `Release`                                                                     |
+| **enableProfiling**             | Value of `COR_ENABLE_PROFILING` and `CORECLR_ENABLE_PROFILING` for the example apps | `1`                                                                           |
+| **exampleApp**                  | Application selected for the `http-client` service                                  | `ConsoleApp`                                                                  |
+| **exampleAppInjectSDK**         | Whether automatic instrumentation injects the SDK on the `http-client` service      | `true`                                                                        |
+| **exampleAppTargetFramework**   | Target framework for the `http-client` service                                      | `netcoreapp3.1`                                                               |
+| **exporter**                    | Value for [`OTEL_TRACES_EXPORTER`](../docs/config.md#exporters) env. variable       | `otlp`                                                                        |
+| **keepContainers**              | Whether the docker containers are preserved after the script execution              | `false`                                                                       |
+| **skipAppBuild**                | Whether the script skips building the example apps                                  | `false`                                                                       |
+| **vendorPluginTargetFramework** | Target framework for the `aspnet-server` service                                    | `net462` if `aspNetAppTargetFramework` is `net462`, `netcoreapp3.1` otherwise |
 
 Usage example:
 

--- a/run-example.sh
+++ b/run-example.sh
@@ -15,6 +15,13 @@ aspNetAppTargetFramework=${aspNetAppTargetFramework:-netcoreapp3.1}
 exampleAppTargetFramework=${exampleAppTargetFramework:-netcoreapp3.1}
 exampleApp=${exampleApp:-ConsoleApp}
 
+if [[ $aspNetAppTargetFramework == net462 ]];
+then
+  vendorPluginTargetFramework=${exampleAppTargetFramework:-net462}
+else
+  vendorPluginTargetFramework=${exampleAppTargetFramework:-netcoreapp3.1}
+fi
+
 # Handle the differences between launching a dll and exe
 exampleAppExt="dll"
 exampleAppDotnetCli="dotnet"
@@ -33,7 +40,7 @@ if [[ $skipAppBuild != "true" && $skipAppBuild != "1" ]]; then
   dotnet publish -f $aspNetAppTargetFramework -c $configuration ./examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
 
   # build plugin for HTTP server app
-  dotnet publish -f $aspNetAppTargetFramework -c $configuration ./examples/Vendor.Distro/Examples.Vendor.Distro.csproj -o bin/tracer-home/$aspNetAppTargetFramework
+  dotnet publish -f $vendorPluginTargetFramework -c $configuration ./examples/Vendor.Distro/Examples.Vendor.Distro.csproj -o bin/tracer-home/$vendorPluginTargetFramework
 
   # build the client app
   dotnet publish -f $exampleAppTargetFramework -c $configuration ./examples/${exampleApp}/Examples.${exampleApp}.csproj


### PR DESCRIPTION
Fixes #820

Changes proposed in this pull request:
Fix loading vendor plugin in AspNetCoreMvc-example app.
Vendor plugin is loaded directly from the `tracer-home` directory. Publish catalog should be equal to on of the tracer framework version (`net462` or `netcoreapp3.1`)