### PR TITLE
Add retry to Restore Nuke task

### DIFF
--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -69,8 +69,9 @@ partial class Build
     Target Restore => _ => _
         .After(Clean)
         .Unlisted()
-        .Executes(() =>
+        .Executes(() => ControlFlow.ExecuteWithRetry(() =>
         {
+            
             if (IsWin)
             {
                 NuGetTasks.NuGetRestore(s => s
@@ -89,7 +90,7 @@ partial class Build
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
                         o.SetPackageDirectory(NugetPackageDirectory)));
             }
-        });
+        }));
 
     Target CompileManagedSrc => _ => _
         .Unlisted()


### PR DESCRIPTION
## Why

Recently the NuGet restore step is falling more frequently.


## What

Restore tasks executes up to 3 times before it fails

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
