### PR TITLE
Bump NuGet.CommandLine to 6.2.1

### DIFF
--- a/build/nuke/_build.csproj
+++ b/build/nuke/_build.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageDownload Include="Nuget.CommandLine" Version="[6.0.0]" />
+    <PackageDownload Include="Nuget.CommandLine" Version="[6.2.1]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/security/dependabot/1 (https://github.com/advisories/GHSA-3885-8gqc-3wpf)

## What

Updates the Nuget.commandline dependency to the latest version with the fix.

We do not publish any nuget packages so there is no nuget api key that we need to rotate.

## Tests

Manually ran the workflow locally.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~
