### PR TITLE
Enabled/Disabled Instrumentations tests for Meter and Tracer 

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
@@ -36,7 +36,7 @@ internal static class EnvironmentConfigurationMetricHelper
             .SetExporter(settings)
             .AddMeter(settings.Meters.ToArray());
 
-        foreach (var enabledMeter in settings.EnabledInstrumentation)
+        foreach (var enabledMeter in settings.EnabledInstrumentations)
         {
             if (AddMeters.TryGetValue(enabledMeter, out var addMeter))
             {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/MeterSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/MeterSettings.cs
@@ -62,7 +62,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
                 }
             }
 
-            EnabledInstrumentation = instrumentations.Values.ToList();
+            EnabledInstrumentations = instrumentations.Values.ToList();
 
             var providerPlugins = source.GetString(ConfigurationKeys.Metrics.ProviderPlugins);
             if (providerPlugins != null)
@@ -116,7 +116,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
         /// <summary>
         /// Gets the list of enabled meters.
         /// </summary>
-        public IList<MeterInstrumentation> EnabledInstrumentation { get; }
+        public IList<MeterInstrumentation> EnabledInstrumentations { get; }
 
         /// <summary>
         /// Gets the list of meters to be added to the MeterProvider at the startup.

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/MeterSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/MeterSettings.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
                     }
                     else
                     {
-                        throw new ArgumentException($"The \"{instrumentation}\" is not recognized as supported metrics instrumentation and cannot be enabled");
+                        throw new FormatException($"The \"{instrumentation}\" is not recognized as supported metrics instrumentation and cannot be enabled");
                     }
                 }
             }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
@@ -49,7 +49,7 @@ public class TracerSettings : Settings
                 }
                 else
                 {
-                    throw new ArgumentException($"The \"{instrumentation}\" is not recognized as supported trace instrumentation and cannot be enabled");
+                    throw new FormatException($"The \"{instrumentation}\" is not recognized as supported trace instrumentation and cannot be enabled");
                 }
             }
         }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -78,7 +78,7 @@ public class SettingsTests : IDisposable
             settings.MetricExporter.Should().Be(MetricsExporter.Otlp);
             settings.OtlpExportProtocol.Should().Be(OtlpExportProtocol.HttpProtobuf);
             settings.ConsoleExporterEnabled.Should().BeFalse();
-            settings.EnabledInstrumentation.Should().BeEmpty();
+            settings.EnabledInstrumentations.Should().BeEmpty();
             settings.MetricPlugins.Should().BeEmpty();
             settings.Meters.Should().BeEmpty();
             settings.Http2UnencryptedSupportEnabled.Should().BeFalse();
@@ -149,7 +149,7 @@ public class SettingsTests : IDisposable
 
         var settings = MeterSettings.FromDefaultSources();
 
-        settings.EnabledInstrumentation.Should().BeEquivalentTo(new List<MeterInstrumentation> { expectedMeterInstrumentation });
+        settings.EnabledInstrumentations.Should().BeEquivalentTo(new List<MeterInstrumentation> { expectedMeterInstrumentation });
     }
 
     [Fact]
@@ -160,7 +160,7 @@ public class SettingsTests : IDisposable
 
         var settings = MeterSettings.FromDefaultSources();
 
-        settings.EnabledInstrumentation.Should().BeEquivalentTo(new List<MeterInstrumentation> { MeterInstrumentation.NetRuntime });
+        settings.EnabledInstrumentations.Should().BeEquivalentTo(new List<MeterInstrumentation> { MeterInstrumentation.NetRuntime });
     }
 
     [Theory]


### PR DESCRIPTION
## Why

Fixes #839

## What

* Tests for parsing instrumentation for metrics and traces.
* Change exception type when value is not supported from `ArgumentException` to `FormatException`. It follows convention from OTel SDK https://github.com/open-telemetry/opentelemetry-dotnet/blob/4b3ee96ffc39bc24c3b8377455b2c099bd9da6b0/src/OpenTelemetry/Internal/EnvironmentVariableHelper.cs and also for other env vars in this project.
* `EnabledInstrumentation` -> `EnabledInstrumentations`

## Tests

 Only tests :)

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
