### PR TITLE
Bump OpenTelemetry.Instrumentation.Runtime to 0.2.0-alpha.1

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="OpenTelemetry.Api" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="0.1.0-alpha.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="0.2.0-alpha.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.4" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />


### PR DESCRIPTION
## Why

New version released ~1 week ago. I am not sure why dependabot is not updating it.

Fixes N/A

## What

Bump `OpenTelemetry.Instrumentation.Runtime` from 0.1.0-alpha.1 to 0.2.0-alpha.1

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->
CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~ - nothing to change
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
