### PR TITLE
Use Testcontainers instead of DotNet.Testcontainers

### DIFF
--- a/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
+++ b/test/integration-tests/IntegrationTests.Helpers/IntegrationTests.Helpers.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+
     <PackageReference Include="Google.Protobuf" Version="3.21.1" />
     <PackageReference Include="Grpc.Tools" Version="2.46.3" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="Testcontainers" Version="2.0.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 

--- a/test/integration-tests/IntegrationTests.MongoDB/IntegrationTests.MongoDB.csproj
+++ b/test/integration-tests/IntegrationTests.MongoDB/IntegrationTests.MongoDB.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageReference Include="Testcontainers" Version="2.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/integration-tests/IntegrationTests.StartupHook/IntegrationTests.StartupHook.csproj
+++ b/test/integration-tests/IntegrationTests.StartupHook/IntegrationTests.StartupHook.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageReference Include="Testcontainers" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/integration-tests/aspnet/IntegrationTests.AspNet/IntegrationTests.AspNet.csproj
+++ b/test/integration-tests/aspnet/IntegrationTests.AspNet/IntegrationTests.AspNet.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageReference Include="Testcontainers" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Why

`DotNet.Testcontainers` is now `Testcontainers`

Fixes #854

## What

Use the latest Testcontainers 2.0.0 instead of DotNet.Testcontainers 1.6.0

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
