### PR TITLE
Refactor SetupIntegrationTestsNetwork async code

### DIFF
--- a/test/integration-tests/IntegrationTests.Helpers/DockerNetworkHelper.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/DockerNetworkHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 
@@ -35,10 +36,10 @@ internal static class DockerNetworkHelper
     /// if named network exists with specified fixed gateway address, gets the existing one.
     /// </summary>
     /// <returns>Docker network ID</returns>
-    internal static string SetupIntegrationTestsNetwork()
+    internal static async Task<string> SetupIntegrationTestsNetwork()
     {
         var client = new DockerClientConfiguration().CreateClient();
-        var networks = client.Networks.ListNetworksAsync().Result;
+        var networks = await client.Networks.ListNetworksAsync();
         var network = networks.FirstOrDefault(x => x.Name == IntegrationTestsNetworkName);
 
         if (network != null)
@@ -49,7 +50,7 @@ internal static class DockerNetworkHelper
             }
             else
             {
-                client.Networks.DeleteNetworkAsync(network.ID).Wait();
+                await client.Networks.DeleteNetworkAsync(network.ID);
             }
         }
 
@@ -69,7 +70,7 @@ internal static class DockerNetworkHelper
             Subnet = "10.1.1.0/24"
         });
 
-        var result = client.Networks.CreateNetworkAsync(networkParams).Result;
+        var result = await client.Networks.CreateNetworkAsync(networkParams);
         if (string.IsNullOrWhiteSpace(result.ID))
         {
             throw new Exception("Could not create docker network");

--- a/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/TestHelper.cs
@@ -61,7 +61,7 @@ public abstract class TestHelper
         string agentHealthzUrl = $"{agentBaseUrl}/healthz";
         string zipkinEndpoint = $"{agentBaseUrl}/api/v2/spans";
         string networkName = DockerNetworkHelper.IntegrationTestsNetworkName;
-        string networkId = DockerNetworkHelper.SetupIntegrationTestsNetwork();
+        string networkId = await DockerNetworkHelper.SetupIntegrationTestsNetwork();
 
         Output.WriteLine($"Zipkin Endpoint: {zipkinEndpoint}");
 


### PR DESCRIPTION
## Why

Potentially improper async code spotted when reading the codebase.


## What

Use `await` in `SetupIntegrationTestsNetwork` where applicable.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
