### PR TITLE
Fix wrong TestContainers WaitStrategy in MongoDbTests

### DIFF
--- a/test/integration-tests/IntegrationTests.MongoDB/MongoDbCollection.cs
+++ b/test/integration-tests/IntegrationTests.MongoDB/MongoDbCollection.cs
@@ -57,15 +57,11 @@ public class MongoDbFixture : IAsyncLifetime
 
     private async Task<TestcontainersContainer> LaunchMongoContainerAsync(int port)
     {
-        var waitOS = EnvironmentTools.IsWindows()
-            ? Wait.ForWindowsContainer()
-            : Wait.ForUnixContainer();
-
         var mongoContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
             .WithImage(MongoDbImage)
             .WithName($"mongo-db-{port}")
             .WithPortBinding(port, MongoDbPort)
-            .WithWaitStrategy(waitOS.UntilPortIsAvailable(MongoDbPort));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MongoDbPort));
 
         var container = mongoContainersBuilder.Build();
         await container.StartAsync();


### PR DESCRIPTION
## Why

Per https://github.com/testcontainers/testcontainers-dotnet/issues/449#issuecomment-1163374798

## What

Fix wrong TestContainers WaitStrategy in MongoDbTests

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~

## Other

I would be thankful if the reviewers try running `nuke Workflow` on Windows (make sure to use Docker Desktop with Linux containers).
For me it fails - it may be some environmental issue.