### PR TITLE
[Testing]: MockZipkin: Bind to localhost instead of *

### DIFF
--- a/test/integration-tests/IntegrationTests.Helpers/MockZipkinCollector.cs
+++ b/test/integration-tests/IntegrationTests.Helpers/MockZipkinCollector.cs
@@ -52,7 +52,7 @@ public class MockZipkinCollector : IDisposable
             try
             {
                 listener.Start();
-                listener.Prefixes.Add($"http://*:{port}/"); // Warning: Requires admin access
+                listener.Prefixes.Add($"http://localhost:{port}/");
 
                 // successfully listening
                 Port = port;


### PR DESCRIPTION
Per SIG meeting regarding issue #850 checking if using localhost breaks CI - depending on the results will update the description accordingly.