### PR TITLE
Make StartupTests.Ctor_LoadsManagedAssembly more accurate

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.cs
@@ -25,6 +25,8 @@ namespace OpenTelemetry.AutoInstrumentation.Loader;
 /// </summary>
 public partial class Startup
 {
+    private static readonly string ManagedProfilerDirectory;
+
     /// <summary>
     /// Initializes static members of the <see cref="Startup"/> class.
     /// This method also attempts to load the OpenTelemetry.AutoInstrumentation .NET assembly.
@@ -44,8 +46,6 @@ public partial class Startup
 
         TryLoadManagedAssembly();
     }
-
-    private static readonly string ManagedProfilerDirectory;
 
     private static void TryLoadManagedAssembly()
     {

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Startup.cs
@@ -45,7 +45,7 @@ public partial class Startup
         TryLoadManagedAssembly();
     }
 
-    internal static string ManagedProfilerDirectory { get; }
+    private static readonly string ManagedProfilerDirectory;
 
     private static void TryLoadManagedAssembly()
     {

--- a/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/StartupTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/StartupTests.cs
@@ -29,7 +29,7 @@ public class StartupTests
         var directory = Directory.GetCurrentDirectory();
         Environment.SetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME", Path.Combine(directory, "..", "Profiler"));
 
-        var exception = Record.Exception(() => AutoInstrumentation.Loader.Startup.ManagedProfilerDirectory);
+        var exception = Record.Exception(() => new AutoInstrumentation.Loader.Startup());
 
         // That means the assembly was loaded successfully and Initialize method was called.
         Assert.Null(exception);


### PR DESCRIPTION
## Why

Make `StartupTests.Ctor_LoadsManagedAssembly` test more accurate.

## What

- Call `Startup` constructor in the test
- Change an internal property to a private field.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
