### PR TITLE
[DoNotMergeYet] Fix env var seperator in native code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ This release is built on top of [OpenTelemetry .NET](https://github.com/open-tel
 
 - Support for .NET 5.0
 
+### Fixed
+
+- `OTEL_DOTNET_AUTO_INCLUDE_PROCESSES`, `OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES`,
+  `OTEL_DOTNET_AUTO_TRACES_DISABLED_INSTRUMENTATIONS`,
+  `OTEL_DOTNET_AUTO_INTEGRATIONS_FILE` use `,` as seperator
+  instead of `;`.
+
 ## [0.1.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.1.0-beta.1)
 
 The is an initial, official beta release,

--- a/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
@@ -94,7 +94,7 @@ std::vector<WSTRING> GetEnvironmentValues(const WSTRING& name, const wchar_t del
 
 std::vector<WSTRING> GetEnvironmentValues(const WSTRING& name)
 {
-    return GetEnvironmentValues(name, L';');
+    return GetEnvironmentValues(name, L',');
 }
 
 constexpr char HexMap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/integration_loader_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/integration_loader_test.cpp
@@ -181,7 +181,7 @@ TEST(IntegrationLoaderTest, LoadsFromEnvironment)
     )TEXT";
     f.close();
 
-    auto name = tmpname1.wstring() + L";" + tmpname2.wstring();
+    auto name = tmpname1.wstring() + L"," + tmpname2.wstring();
 
     SetEnvironmentVariableW(trace::environment::integrations_path.data(), name.data());
 


### PR DESCRIPTION
## Why

The separator was different than documented.

## What

`OTEL_DOTNET_AUTO_INCLUDE_PROCESSES`, `OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES`,
  `OTEL_DOTNET_AUTO_TRACES_DISABLED_INSTRUMENTATIONS` use `,` as seperator
  instead of `;`.

## Tests

I have no idea how this test is passing: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/ea1f47855d8fc019aace6fea9e9a70a8cd304342/test/IntegrationTests/StartupHookTests.cs#L67-L86

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
