### PR TITLE
Correct the case for MongoDB

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -41,7 +41,7 @@ for more details.
 | `AspNet` | ASP.NET Core | * | source |
 | `GraphQL` | [GraphQL](https://www.nuget.org/packages/GraphQL/) | ≥2.3.0 & < 3.0.0 | bytecode |
 | `HttpClient` | [System.Net.Http.HttpClient](https://docs.microsoft.com/dotnet/api/system.net.http.httpclient) and [System.Net.HttpWebRequest](https://docs.microsoft.com/dotnet/api/system.net.httpwebrequest) | * | source |
-| `MongoDb` | [MongoDB.Driver.Core](https://www.nuget.org/packages/MongoDB.Driver.Core) **Not supported on .NET Framework** | ≥2.3.0 & < 3.0.0 | source & bytecode |
+| `MongoDB` | [MongoDB.Driver.Core](https://www.nuget.org/packages/MongoDB.Driver.Core) **Not supported on .NET Framework** | ≥2.3.0 & < 3.0.0 | source & bytecode |
 | `SqlClient` | [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient) and [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient) | * | source |
 
 ### Instrumented metrics libraries and frameworks

--- a/examples/AspNetCoreMvc/Controllers/MongoDBController.cs
+++ b/examples/AspNetCoreMvc/Controllers/MongoDBController.cs
@@ -1,4 +1,4 @@
-// <copyright file="MongoDbController.cs" company="OpenTelemetry Authors">
+// <copyright file="MongoDBController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ using MongoDB.Driver;
 namespace Examples.AspNetCoreMvc.Controllers;
 
 [Route("api/mongo")]
-public class MongoDbController : ControllerBase
+public class MongoDBController : ControllerBase
 {
     private const string ConnectionString = "mongodb://localhost:27017";
 

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "MongoDb",
+    "name": "MongoDB",
     "method_replacements": [
       {
         "caller": {},
@@ -21,7 +21,7 @@
         },
         "wrapper": {
           "assembly": "OpenTelemetry.AutoInstrumentation",
-          "type": "OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDb.MongoClientIntegration",
+          "type": "OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration",
           "action": "CallTargetModification"
         }
       }

--- a/run-example.sh
+++ b/run-example.sh
@@ -60,7 +60,7 @@ docker-compose -f ./dev/docker-compose.yaml -f ./examples/docker-compose.yaml up
 
 # instrument and run HTTP server app in background
 export {OTEL_DOTNET_AUTO_TRACES_PLUGINS,OTEL_DOTNET_AUTO_METRICS_PLUGINS}="Examples.AspNetCoreMvc.OtelSdkPlugin, Examples.AspNetCoreMvc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null:Examples.Vendor.Distro.Plugin, Examples.Vendor.Distro, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null"
-ENABLE_PROFILING=${enableProfiling} OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS="AspNet,MongoDb,SqlClient" OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES="MyCompany.MyProduct.MyLibrary" OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS="AspNet,NetRuntime,HttpClient" OTEL_SERVICE_NAME="aspnet-server" OTEL_TRACES_EXPORTER=${tracesExporter} OTEL_METRICS_EXPORTER=${metricsExporter} ./dev/instrument.sh ASPNETCORE_URLS="http://127.0.0.1:8080/" dotnet ./examples/AspNetCoreMvc/bin/${configuration}/${aspNetAppTargetFramework}/Examples.AspNetCoreMvc.dll &
+ENABLE_PROFILING=${enableProfiling} OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS="AspNet,MongoDB,SqlClient" OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES="MyCompany.MyProduct.MyLibrary" OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS="AspNet,NetRuntime,HttpClient" OTEL_SERVICE_NAME="aspnet-server" OTEL_TRACES_EXPORTER=${tracesExporter} OTEL_METRICS_EXPORTER=${metricsExporter} ./dev/instrument.sh ASPNETCORE_URLS="http://127.0.0.1:8080/" dotnet ./examples/AspNetCoreMvc/bin/${configuration}/${aspNetAppTargetFramework}/Examples.AspNetCoreMvc.dll &
 unset OTEL_DOTNET_AUTO_TRACES_PLUGINS OTEL_DOTNET_AUTO_METRICS_PLUGINS
 ./dev/wait-local-port.sh 8080
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -29,7 +29,7 @@ internal static class EnvironmentConfigurationTracerHelper
         [TracerInstrumentation.HttpClient] = builder => builder.AddHttpClientInstrumentation(),
         [TracerInstrumentation.AspNet] = builder => builder.AddSdkAspNetInstrumentation(),
         [TracerInstrumentation.SqlClient] = builder => builder.AddSqlClientInstrumentation(),
-        [TracerInstrumentation.MongoDb] = builder => builder.AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources")
+        [TracerInstrumentation.MongoDB] = builder => builder.AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources")
     };
 
     public static TracerProviderBuilder UseEnvironmentVariables(this TracerProviderBuilder builder, TracerSettings settings)

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
@@ -42,7 +42,7 @@ public enum TracerInstrumentation
     GraphQL,
 
     /// <summary>
-    /// MongoDb instrumentation.
+    /// MongoDB instrumentation.
     /// </summary>
-    MongoDb
+    MongoDB
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDb/MongoClientIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDb/MongoClientIntegration.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using OpenTelemetry.AutoInstrumentation.CallTarget;
 
-namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDb
+namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB
 {
     /// <summary>
     /// MongoDB.Driver.MongoClient calltarget instrumentation
@@ -34,7 +34,7 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDb
         ParameterTypeNames = new[] { "MongoDB.Driver.MongoClientSettings" },
         MinimumVersion = "2.3.0",
         MaximumVersion = "2.65535.65535",
-        IntegrationName = "MongoDb")]
+        IntegrationName = "MongoDB")]
     public class MongoClientIntegration
     {
 #if NETCOREAPP3_1_OR_GREATER

--- a/test/IntegrationTests/MongoDBCollection.cs
+++ b/test/IntegrationTests/MongoDBCollection.cs
@@ -1,4 +1,4 @@
-// <copyright file="MongoDbCollection.cs" company="OpenTelemetry Authors">
+// <copyright file="MongoDBCollection.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,19 +24,19 @@ using Xunit;
 namespace IntegrationTests.MongoDB;
 
 [CollectionDefinition(Name)]
-public class MongoDbCollection : ICollectionFixture<MongoDbFixture>
+public class MongoDBCollection : ICollectionFixture<MongoDBFixture>
 {
-    public const string Name = nameof(MongoDbCollection);
+    public const string Name = nameof(MongoDBCollection);
 }
 
-public class MongoDbFixture : IAsyncLifetime
+public class MongoDBFixture : IAsyncLifetime
 {
-    private const int MongoDbPort = 27017;
-    private const string MongoDbImage = "mongo:5.0.6";
+    private const int MongoDBPort = 27017;
+    private const string MongoDBImage = "mongo:5.0.6";
 
     private TestcontainersContainer _container;
 
-    public MongoDbFixture()
+    public MongoDBFixture()
     {
         Port = TcpPortProvider.GetOpenPort();
     }
@@ -59,10 +59,10 @@ public class MongoDbFixture : IAsyncLifetime
     private async Task<TestcontainersContainer> LaunchMongoContainerAsync(int port)
     {
         var mongoContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
-            .WithImage(MongoDbImage)
+            .WithImage(MongoDBImage)
             .WithName($"mongo-db-{port}")
-            .WithPortBinding(port, MongoDbPort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MongoDbPort));
+            .WithPortBinding(port, MongoDBPort)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MongoDBPort));
 
         var container = mongoContainersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/MongoDBTests.cs
+++ b/test/IntegrationTests/MongoDBTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="MongoDbTests.cs" company="OpenTelemetry Authors">
+// <copyright file="MongoDBTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,17 +24,17 @@ using Xunit.Abstractions;
 
 namespace IntegrationTests.MongoDB
 {
-    [Collection(MongoDbCollection.Name)]
-    public class MongoDbTests : TestHelper
+    [Collection(MongoDBCollection.Name)]
+    public class MongoDBTests : TestHelper
     {
-        private readonly MongoDbFixture _mongoDb;
+        private readonly MongoDBFixture _mongoDB;
 
-        public MongoDbTests(ITestOutputHelper output, MongoDbFixture mongoDb)
+        public MongoDBTests(ITestOutputHelper output, MongoDBFixture mongoDB)
             : base("MongoDB", output)
         {
-            _mongoDb = mongoDb;
+            _mongoDB = mongoDB;
 
-            SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS", "MongoDb");
+            SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS", "MongoDB");
             SetEnvironmentVariable("OTEL_SERVICE_NAME", "TestApplication.MongoDB");
         }
 
@@ -46,7 +46,7 @@ namespace IntegrationTests.MongoDB
             int agentPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockZipkinCollector(Output, agentPort))
-            using (var processResult = RunTestApplicationAndWaitForExit(agent.Port, arguments: $"--mongo-db {_mongoDb.Port}", enableStartupHook: true))
+            using (var processResult = RunTestApplicationAndWaitForExit(agent.Port, arguments: $"--mongo-db {_mongoDB.Port}", enableStartupHook: true))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -117,7 +117,7 @@ public class SettingsTests : IDisposable
     [InlineData(nameof(TracerInstrumentation.AspNet), TracerInstrumentation.AspNet)]
     [InlineData(nameof(TracerInstrumentation.GraphQL), TracerInstrumentation.GraphQL)]
     [InlineData(nameof(TracerInstrumentation.HttpClient), TracerInstrumentation.HttpClient)]
-    [InlineData(nameof(TracerInstrumentation.MongoDb), TracerInstrumentation.MongoDb)]
+    [InlineData(nameof(TracerInstrumentation.MongoDB), TracerInstrumentation.MongoDB)]
     [InlineData(nameof(TracerInstrumentation.SqlClient), TracerInstrumentation.SqlClient)]
     public void TracerSettings_Instrumentations_SupportedValues(string tracerInstrumentation, TracerInstrumentation expectedTracerInstrumentation)
     {

--- a/test/test-applications/integrations/TestApplication.MongoDB/Properties/launchSettings.json
+++ b/test/test-applications/integrations/TestApplication.MongoDB/Properties/launchSettings.json
@@ -12,7 +12,7 @@
         "DOTNET_ADDITIONAL_DEPS": "$(SolutionDir)bin\\tracer-home\\AdditionalDeps",
         "OTEL_TRACES_EXPORTER": "zipkin",
         "OTEL_EXPORTER_ZIPKIN_ENDPOINT": "http://127.0.0.1:9411/api/v2/spans",
-        "OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS": "MongoDb",
+        "OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS": "MongoDB",
         "OTEL_DOTNET_AUTO_DEBUG": "1",
         "OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED": "true",
         "OTEL_DOTNET_AUTO_INTEGRATIONS_FILE": "$(SolutionDir)bin\\tracer-home\\integrations.json",


### PR DESCRIPTION
## Why

Incorrect casing for MongoDB, context: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/888#discussion_r908277557

## What

Fixes the remaining locations with incorrect casing.

## Tests

- Target `Workflow` completed successfuly on Windows.
- Checked that spans for MongoDB are present when running `./run-example.sh`

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

Although the instrumentation names are case sensitive I'm opting to not modify the CHANGELOG.md because the MongoDB was not released yet.

~~- [ ] `CHANGELOG.md` is updated.~~ 
- [X] Documentation is updated.

~~- [] New features are covered by tests.~~
