### PR TITLE
Add Prometheus exporter integration test

### DIFF
--- a/test/IntegrationTests/GraphQLTests.cs
+++ b/test/IntegrationTests/GraphQLTests.cs
@@ -84,7 +84,7 @@ public class GraphQLTests : TestHelper
 
         int aspNetCorePort = TcpPortProvider.GetOpenPort();
         using (var agent = new MockZipkinCollector(Output))
-        using (Process process = StartTestApplication(agent.Port, arguments: null, packageVersion: string.Empty, aspNetCorePort: aspNetCorePort))
+        using (var process = StartTestApplication(agent.Port, aspNetCorePort: aspNetCorePort))
         {
             if (process.HasExited)
             {

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -121,17 +121,22 @@ public abstract class TestHelper
     /// StartTestApplication starts the test application
     // and returns the Process instance for further interaction.
     /// </summary>
-    public Process StartTestApplication(int traceAgentPort, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool enableStartupHook = true)
+    public Process StartTestApplication(int traceAgentPort = 0, string arguments = null, string packageVersion = "", int aspNetCorePort = 0, string framework = "", bool enableStartupHook = true)
     {
         var testSettings = new TestSettings
         {
-            TracesSettings = new TracesSettings { Port = traceAgentPort },
             Arguments = arguments,
             PackageVersion = packageVersion,
             AspNetCorePort = aspNetCorePort,
             Framework = framework,
             EnableStartupHook = enableStartupHook
         };
+
+        if (traceAgentPort != 0)
+        {
+            testSettings.TracesSettings = new() { Port = traceAgentPort };
+        }
+
         return StartTestApplication(testSettings);
     }
 

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -162,7 +162,7 @@ public class SmokeTests : TestHelper
 
         try
         {
-            Func<Task> assert = async () =>
+            var assert = async () =>
             {
                 var response = await new HttpClient().GetAsync(defaultPrometheusMetricsEndpoint);
                 response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/test/test-applications/integrations/TestApplication.Smoke/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Smoke/Program.cs
@@ -14,10 +14,12 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Net.Http;
+using System.Threading;
 
 namespace TestApplication.Smoke
 {
@@ -29,6 +31,12 @@ namespace TestApplication.Smoke
         {
             EmitTraces();
             EmitMetrics();
+
+            var longRunning = Environment.GetEnvironmentVariable("LONG_RUNNING");
+            while (longRunning == "true")
+            {
+                Thread.Yield();
+            }
         }
 
         private static void EmitTraces()


### PR DESCRIPTION
## Why

Part of #665

## What

Add Prometheus exporter integration test.

Because Prometheus exporter exposes the metrics as an endpoint therefore the test uses an "asynchronous assertion". It verifies if the expected metrics data is eventually available at the Prometheus exporter endpoint.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] ~~Documentation is updated.~~
- [x] ~~New features are covered by tests.~~
