### PR TITLE
Refine OTEL_METRIC_EXPORT_INTERVAL

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -80,6 +80,7 @@ Exporters output the telemetry.
 |-|-|-|
 | `OTEL_TRACES_EXPORTER` | Traces exporter to be used. The value can be one of the following: `zipkin`, `jaeger`, `otlp`, `none`. | `otlp` |
 | `OTEL_METRICS_EXPORTER` | Metrics exporter to be used. The value can be one of the following: `otlp`, `prometheus`, `none`. | `otlp` |
+| `OTEL_METRIC_EXPORT_INTERVAL` | The time interval (in milliseconds) between the start of two export attempts. | `60000` for OTLP exporter, `10000` for console exporter |
 
 ### Jaeger
 
@@ -147,7 +148,6 @@ Important environment variables include:
 | `OTEL_DOTNET_AUTO_FLUSH_ON_UNHANDLEDEXCEPTION` | Controls whether the telemetry data is flushed when an [AppDomain.UnhandledException](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.unhandledexception) event is raised. Set to `true` when you suspect that you are experiencing a problem with missing telemetry data and also experiencing unhandled exceptions. | `false` |
 | `OTEL_DOTNET_AUTO_TRACES_PLUGINS` | Colon-separated list of OTel SDK instrumentation tracer plugin types, specified with the [assembly-qualified name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname?view=net-6.0#system-type-assemblyqualifiedname). _Note: This list must be colon-separated because the type names may include commas._ | |
 | `OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES` | Comma-separated list of additional `System.Diagnostics.Metrics.Meter` names to be added to the meter at the startup. Use it to capture manually instrumented spans. |  |
-| `OTEL_METRIC_EXPORT_INTERVAL` | The time interval (in milliseconds) between the start of two export attempts. | 6000 |
 | `OTEL_DOTNET_AUTO_METRICS_PLUGINS` | Colon-separated list of OTel SDK instrumentation meter plugin types, specified with the [assembly-qualified name](https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname?view=net-6.0#system-type-assemblyqualifiedname). _Note: This list must be colon-separated because the type names may include commas._ | |
 
 You can use `OTEL_DOTNET_AUTO_TRACES_PLUGINS` to extend the

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
@@ -60,7 +60,13 @@ internal static class EnvironmentConfigurationMetricHelper
     {
         if (settings.ConsoleExporterEnabled)
         {
-            builder.AddConsoleExporter();
+            builder.AddConsoleExporter((_, metricReaderOptions) =>
+            {
+                if (settings.MetricExportInterval != null)
+                {
+                    metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = settings.MetricExportInterval;
+                }
+            });
         }
 
         switch (settings.MetricExporter)


### PR DESCRIPTION
## Why

`OTEL_METRIC_EXPORT_INTERVAL` is not correctly documented and it is not configuring the console metrics exporter.

## What

- `OTEL_METRIC_EXPORT_INTERVAL` also configures the console metrics exporter
- Fix the default value of `OTEL_METRIC_EXPORT_INTERVAL` for OTLP exporter in docs

## Tests

just manual tests

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~ It is already mentioned in the changelog.
- [x] Documentation is updated.
- [x] ~~New features are covered by tests.~~ I do not big value in testing it (especially since testing it would not be simple).
