### PR TITLE
Fix SdkSelfDiagnosticsEventListener logger leaking scope in tests

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Diagnostics/SdkSelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Diagnostics/SdkSelfDiagnosticsEventListener.cs
@@ -31,13 +31,14 @@ internal class SdkSelfDiagnosticsEventListener : EventListener
 {
     private const string EventSourceNamePrefix = "OpenTelemetry-";
 
-    private static readonly ILogger Log = OtelLogging.GetLogger();
     private readonly object lockObj = new();
     private readonly EventLevel logLevel;
+    private readonly ILogger log;
     private readonly List<EventSource> eventSourcesBeforeConstructor = new();
 
-    public SdkSelfDiagnosticsEventListener(EventLevel eventLevel)
+    public SdkSelfDiagnosticsEventListener(EventLevel eventLevel, ILogger logger)
     {
+        log = logger;
         logLevel = eventLevel;
 
         List<EventSource> eventSources;
@@ -94,17 +95,17 @@ internal class SdkSelfDiagnosticsEventListener : EventListener
         {
             case EventLevel.Critical:
             case EventLevel.Error:
-                Log.Error("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
+                log.Error("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
                 break;
             case EventLevel.Warning:
-                Log.Warning("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
+                log.Warning("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
                 break;
             case EventLevel.LogAlways:
             case EventLevel.Informational:
-                Log.Information("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
+                log.Information("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
                 break;
             case EventLevel.Verbose:
-                Log.Debug("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
+                log.Debug("EventSource={0}, Message={1}", eventData.EventSource.Name, string.Format(eventData.Message, payloadArray));
                 break;
         }
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -86,7 +86,7 @@ public static class Instrumentation
             if (TracerSettings.LoadTracerAtStartup || MeterSettings.LoadMetricsAtStartup)
             {
                 // Initialize SdkSelfDiagnosticsEventListener to create an EventListener for the OpenTelemetry SDK
-                _sdkEventListener = new(EventLevel.Warning);
+                _sdkEventListener = new(EventLevel.Warning, Logger);
 
                 // Register to shutdown events
                 AppDomain.CurrentDomain.ProcessExit += OnExit;


### PR DESCRIPTION
## What

Fixes leaking logger scope in SdkSelfDiagnosticsEventListener tests. Unit tests that are running parallel preserve static instances, causing race condition in tests.

Separated fix from https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/903

## Tests

Fixed existing ones.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
