### PR TITLE
MongoDB GetClusterConfiguratorExpression method is used only on netcoreapp3.1

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDb/MongoClientIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDb/MongoClientIntegration.cs
@@ -68,6 +68,7 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB
             return CallTargetState.GetDefault();
         }
 
+#if NETCOREAPP3_1_OR_GREATER
         private static object GetInstrumentationOptions()
         {
             Type optionsType = Type.GetType("MongoDB.Driver.Core.Extensions.DiagnosticSources.InstrumentationOptions, MongoDB.Driver.Core.Extensions.DiagnosticSources");
@@ -97,7 +98,6 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB
             return shouldStartActivityLambda;
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         private static LambdaExpression GetClusterConfiguratorExpression()
         {
             Type eventSubscriberInterface = Type.GetType("MongoDB.Driver.Core.Events.IEventSubscriber, MongoDB.Driver.Core");

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDb/MongoClientIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDb/MongoClientIntegration.cs
@@ -97,6 +97,7 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB
             return shouldStartActivityLambda;
         }
 
+#if NETCOREAPP3_1_OR_GREATER
         private static LambdaExpression GetClusterConfiguratorExpression()
         {
             Type eventSubscriberInterface = Type.GetType("MongoDB.Driver.Core.Events.IEventSubscriber, MongoDB.Driver.Core");
@@ -120,5 +121,6 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB
 
             return setListenerLambda;
         }
+#endif
     }
 }


### PR DESCRIPTION
## Why

IDE suggest that the method is not used when the target is set to .NET Framework 4.6.2.
I have almost removed it.

## What

Conditional compilation for private method

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
