### PR TITLE
Add none option to instrumentations configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add Npgsql traces instrumentation.
-- Configuration option `none` to `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS`
+- Add configuration option `none` to `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS`
   and `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Add Npgsql traces instrumentation.
+- Configuration option `none` to `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS`
+  and `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS`.
 
 ### Changed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,17 +143,6 @@ OTEL_SERVICE_NAME=my-service
 OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging,service.version=1.0.0
 ```
 
-Enable desired library instrumentations using `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS`
-and `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS` environment variables.
-NOTE: By default all available instrumentations are included automatically.
-
-For example:
-
-```env
-OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS=AspNet,HttpClient
-OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS=AspNet,HttpClient,NetRuntime
-```
-
 ## Instrument a Windows Service running a .NET application
 
 See [windows-service-instrumentation.md](windows-service-instrumentation.md).

--- a/docs/config.md
+++ b/docs/config.md
@@ -26,9 +26,9 @@ for more details.
 | Environment variable | Description | Default value |
 |-|-|-|
 | `OTEL_DOTNET_AUTO_INTEGRATIONS_FILE` | List of bytecode instrumentations JSON configuration filepaths, delimited by the platform-specific path separator (`;` on Windows, `:` on Linux and macOS). For example: `%ProfilerDirectory%/integrations.json` | |
-| `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS` | Comma-separated list of traces source instrumentations you want to enable. | all available instrumentations |
+| `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS` | Comma-separated list of traces source instrumentations you want to enable. Set `none` to disable all trace instrumentations. | all available instrumentations |
 | `OTEL_DOTNET_AUTO_TRACES_DISABLED_INSTRUMENTATIONS` | Comma-separated list of traces source and bytecode instrumentations you want to disable. | |
-| `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS` | Comma-separated list of metrics source instrumentations you want to enable. | all available instrumentations |
+| `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS` | Comma-separated list of metrics source instrumentations you want to enable. Set `none` to disable all metric instrumentations. | all available instrumentations |
 | `OTEL_DOTNET_AUTO_METRICS_DISABLED_INSTRUMENTATIONS` | Comma-separated list of metrics source instrumentations you want to disable. | |
 | `OTEL_DOTNET_AUTO_{0}_ENABLED` | Configuration pattern for enabling or disabling specific bytecode. For example, to disable GraphQL instrumentation, set the `OTEL_TRACE_GraphQL_ENABLED` environment variable to `false`. | `true` |
 | `OTEL_DOTNET_AUTO_DOMAIN_NEUTRAL_INSTRUMENTATION` | Whether to intercept method calls when the caller method is inside a domain-neutral assembly. Useful when instrumenting IIS applications. | `false` |

--- a/src/OpenTelemetry.AutoInstrumentation/Util/ConfigurationSourceExtensions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Util/ConfigurationSourceExtensions.cs
@@ -1,0 +1,73 @@
+// <copyright file="ConfigurationSourceExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.AutoInstrumentation.Configuration;
+
+namespace OpenTelemetry.AutoInstrumentation.Util
+{
+    internal static class ConfigurationSourceExtensions
+    {
+        private const string None = "none";
+
+        public static IList<TEnum> ParseEnabledEnumList<TEnum>(this IConfigurationSource source, string enabledConfiguration, string disabledConfiguration, char separator, string error)
+            where TEnum : struct, IConvertible
+        {
+            var instrumentations = new Dictionary<string, TEnum>();
+            var enabledInstrumentations = source.GetString(enabledConfiguration);
+            if (enabledInstrumentations != null)
+            {
+                if (enabledInstrumentations == None)
+                {
+                    return Array.Empty<TEnum>();
+                }
+
+                foreach (var instrumentation in enabledInstrumentations.Split(separator))
+                {
+                    if (Enum.TryParse(instrumentation, out TEnum parsedType))
+                    {
+                        instrumentations[instrumentation] = parsedType;
+                    }
+                    else
+                    {
+                        throw new FormatException(string.Format(error, instrumentation));
+                    }
+                }
+            }
+            else
+            {
+                instrumentations = Enum.GetValues(typeof(TEnum))
+                    .Cast<TEnum>()
+                    .ToDictionary(
+                        key => Enum.GetName(typeof(TEnum), key),
+                        val => val);
+            }
+
+            var disabledInstrumentations = source.GetString(disabledConfiguration);
+            if (disabledInstrumentations != null)
+            {
+                foreach (var instrumentation in disabledInstrumentations.Split(separator))
+                {
+                    instrumentations.Remove(instrumentation);
+                }
+            }
+
+            return instrumentations.Values.ToList();
+        }
+    }
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ConfigurationSourceExtensionsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ConfigurationSourceExtensionsTests.cs
@@ -43,10 +43,7 @@ namespace OpenTelemetry.AutoInstrumentation.Tests.Util
                 separator: ',',
                 error: "Invalid enum value: {0}");
 
-            list.Should().NotBeEmpty()
-                .And.HaveCount(3)
-                .And.ContainInOrder(new[] { TestEnum.Test1, TestEnum.Test2, TestEnum.Test3 })
-                .And.ContainItemsAssignableTo<TestEnum>();
+            list.Should().Equal(TestEnum.Test1, TestEnum.Test2, TestEnum.Test3);
         }
 
         [Fact]
@@ -63,10 +60,7 @@ namespace OpenTelemetry.AutoInstrumentation.Tests.Util
                 separator: ',',
                 error: "Invalid enum value: {0}");
 
-            list.Should().NotBeEmpty()
-                .And.HaveCount(2)
-                .And.ContainInOrder(new[] { TestEnum.Test1, TestEnum.Test3 })
-                .And.ContainItemsAssignableTo<TestEnum>();
+            list.Should().Equal(TestEnum.Test1, TestEnum.Test3);
         }
 
         [Fact]
@@ -83,10 +77,7 @@ namespace OpenTelemetry.AutoInstrumentation.Tests.Util
                 separator: ',',
                 error: "Invalid enum value: {0}");
 
-            list.Should().NotBeEmpty()
-                .And.HaveCount(2)
-                .And.ContainInOrder(new[] { TestEnum.Test1, TestEnum.Test3 })
-                .And.ContainItemsAssignableTo<TestEnum>();
+            list.Should().Equal(TestEnum.Test1, TestEnum.Test3);
         }
 
         [Fact]
@@ -114,13 +105,14 @@ namespace OpenTelemetry.AutoInstrumentation.Tests.Util
                 { "TEST_ENABLED_VALUES", "invalid" }
             });
 
-            source.Invoking(s => s.ParseEnabledEnumList<TestEnum>(
+            var act = () => source.ParseEnabledEnumList<TestEnum>(
                 enabledConfiguration: "TEST_ENABLED_VALUES",
                 disabledConfiguration: "TEST_DISABLED_VALUES",
                 separator: ',',
-                error: "Invalid enum value: {0}"))
-                .Should().Throw<FormatException>()
-                .WithMessage("Invalid enum value: invalid");
+                error: "Invalid enum value: {0}");
+
+            act.Should().Throw<FormatException>()
+               .WithMessage("Invalid enum value: invalid");
         }
     }
 }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ConfigurationSourceExtensionsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ConfigurationSourceExtensionsTests.cs
@@ -1,0 +1,126 @@
+// <copyright file="ConfigurationSourceExtensionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Specialized;
+using FluentAssertions;
+using OpenTelemetry.AutoInstrumentation.Configuration;
+using OpenTelemetry.AutoInstrumentation.Util;
+using Xunit;
+
+namespace OpenTelemetry.AutoInstrumentation.Tests.Util
+{
+    public class ConfigurationSourceExtensionsTests
+    {
+        private enum TestEnum
+        {
+            Test1,
+            Test2,
+            Test3
+        }
+
+        [Fact]
+        public void ParseEnabledEnumList_Default()
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection());
+
+            var list = source.ParseEnabledEnumList<TestEnum>(
+                enabledConfiguration: "TEST_ENABLED_VALUES",
+                disabledConfiguration: "TEST_DISABLED_VALUES",
+                separator: ',',
+                error: "Invalid enum value: {0}");
+
+            list.Should().NotBeEmpty()
+                .And.HaveCount(3)
+                .And.ContainInOrder(new[] { TestEnum.Test1, TestEnum.Test2, TestEnum.Test3 })
+                .And.ContainItemsAssignableTo<TestEnum>();
+        }
+
+        [Fact]
+        public void ParseEnabledEnumList_Enabled()
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection()
+            {
+                { "TEST_ENABLED_VALUES", "Test1,Test3" }
+            });
+
+            var list = source.ParseEnabledEnumList<TestEnum>(
+                enabledConfiguration: "TEST_ENABLED_VALUES",
+                disabledConfiguration: "TEST_DISABLED_VALUES",
+                separator: ',',
+                error: "Invalid enum value: {0}");
+
+            list.Should().NotBeEmpty()
+                .And.HaveCount(2)
+                .And.ContainInOrder(new[] { TestEnum.Test1, TestEnum.Test3 })
+                .And.ContainItemsAssignableTo<TestEnum>();
+        }
+
+        [Fact]
+        public void ParseEnabledEnumList_Disabled()
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection()
+            {
+                { "TEST_DISABLED_VALUES", "Test2" }
+            });
+
+            var list = source.ParseEnabledEnumList<TestEnum>(
+                enabledConfiguration: "TEST_ENABLED_VALUES",
+                disabledConfiguration: "TEST_DISABLED_VALUES",
+                separator: ',',
+                error: "Invalid enum value: {0}");
+
+            list.Should().NotBeEmpty()
+                .And.HaveCount(2)
+                .And.ContainInOrder(new[] { TestEnum.Test1, TestEnum.Test3 })
+                .And.ContainItemsAssignableTo<TestEnum>();
+        }
+
+        [Fact]
+        public void ParseEnabledEnumList_None()
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection()
+            {
+                { "TEST_ENABLED_VALUES", "none" }
+            });
+
+            var list = source.ParseEnabledEnumList<TestEnum>(
+                enabledConfiguration: "TEST_ENABLED_VALUES",
+                disabledConfiguration: "TEST_DISABLED_VALUES",
+                separator: ',',
+                error: "Invalid enum value: {0}");
+
+            list.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ParseEnabledEnumList_Invalid()
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection()
+            {
+                { "TEST_ENABLED_VALUES", "invalid" }
+            });
+
+            source.Invoking(s => s.ParseEnabledEnumList<TestEnum>(
+                enabledConfiguration: "TEST_ENABLED_VALUES",
+                disabledConfiguration: "TEST_DISABLED_VALUES",
+                separator: ',',
+                error: "Invalid enum value: {0}"))
+                .Should().Throw<FormatException>()
+                .WithMessage("Invalid enum value: invalid");
+        }
+    }
+}


### PR DESCRIPTION
## Why

Followup of #903
Followup of #934

Fixes #388 

## What

Adds `none` option to configure `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS` and `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS`

Cleans up readme as concluded in #934

## Tests

`ConfigurationSourceExtensionsTests` unit tests.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
