### PR TITLE
Remove CorProfiler::GetAssemblyReferences

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -46,7 +46,6 @@ private:
 
     // Cor assembly properties
     AssemblyProperty corAssemblyProperty{};
-    AssemblyReference* managed_profiler_assembly_reference;
 
     //
     // OpCodes helper
@@ -129,12 +128,6 @@ public:
                                          HRESULT hrStatus) override;
 
     HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchStarted(FunctionID functionId, BOOL* pbUseCachedFunction) override;
-
-    //
-    // ICorProfilerCallback6 methods
-    //
-    HRESULT STDMETHODCALLTYPE GetAssemblyReferences(const WCHAR* wszAssemblyPath,
-                                                    ICorProfilerAssemblyReferenceProvider* pAsmRefProvider) override;
 };
 
 // Note: Generally you should not have a single, global callback implementation,


### PR DESCRIPTION
## Why

Fixes #942

## What

Remove `CorProfiler::GetAssemblyReferences`

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~
