### PR TITLE
MySql.Data intrumentation (.NET Core 3.1+)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -179,6 +179,12 @@ updates:
     open-pull-requests-limit: 20
 
   - package-ecosystem: nuget
+    directory: /test/test-applications/integrations/TestApplication.MySqlData
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
     directory: /test/test-applications/integrations/TestApplication.Npgsql
     schedule:
       interval: "daily"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add Npgsql and MySql.Data traces instrumentation.
+- Add MySql.Data traces instrumentation.
+- Add Npgsql traces instrumentation.
 - Add configuration option `none` to `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS`
   and `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Add Npgsql traces instrumentation.
+- Add Npgsql and MySql.Data traces instrumentation.
 - Add configuration option `none` to `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS`
   and `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS`.
 

--- a/OpenTelemetry.AutoInstrumentation.sln
+++ b/OpenTelemetry.AutoInstrumentation.sln
@@ -127,9 +127,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.SqlClient",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.Plugins", "test\test-applications\integrations\TestApplication.Plugins\TestApplication.Plugins.csproj", "{42BABA6C-1954-4F52-85C8-D336C00F06D9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication.Npgsql", "test\test-applications\integrations\TestApplication.Npgsql\TestApplication.Npgsql.csproj", "{DC54F01E-1D5C-4ECF-B5B9-14EECD2B4CF6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.Npgsql", "test\test-applications\integrations\TestApplication.Npgsql\TestApplication.Npgsql.csproj", "{DC54F01E-1D5C-4ECF-B5B9-14EECD2B4CF6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication.Shared", "test\test-applications\integrations\dependency-libs\TestApplication.Shared\TestApplication.Shared.csproj", "{CB4EA9F4-EE1B-4009-B3CD-215DCE8BE214}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.Shared", "test\test-applications\integrations\dependency-libs\TestApplication.Shared\TestApplication.Shared.csproj", "{CB4EA9F4-EE1B-4009-B3CD-215DCE8BE214}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.MySqlData", "test\test-applications\integrations\TestApplication.MySqlData\TestApplication.MySqlData.csproj", "{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -543,6 +545,18 @@ Global
 		{CB4EA9F4-EE1B-4009-B3CD-215DCE8BE214}.Release|x64.Build.0 = Release|x64
 		{CB4EA9F4-EE1B-4009-B3CD-215DCE8BE214}.Release|x86.ActiveCfg = Release|x86
 		{CB4EA9F4-EE1B-4009-B3CD-215DCE8BE214}.Release|x86.Build.0 = Release|x86
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Debug|Any CPU.Build.0 = Debug|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Debug|x64.ActiveCfg = Debug|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Debug|x64.Build.0 = Debug|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Debug|x86.ActiveCfg = Debug|x86
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Debug|x86.Build.0 = Debug|x86
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Release|Any CPU.ActiveCfg = Release|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Release|Any CPU.Build.0 = Release|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Release|x64.ActiveCfg = Release|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Release|x64.Build.0 = Release|x64
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Release|x86.ActiveCfg = Release|x86
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -587,6 +601,7 @@ Global
 		{42BABA6C-1954-4F52-85C8-D336C00F06D9} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 		{DC54F01E-1D5C-4ECF-B5B9-14EECD2B4CF6} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 		{CB4EA9F4-EE1B-4009-B3CD-215DCE8BE214} = {82A3CE96-0935-45E5-A9AA-A93A5B63500B}
+		{E7C2D2CF-C965-449D-A02C-02F7837D0C6D} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/docs/config.md
+++ b/docs/config.md
@@ -40,6 +40,7 @@ for more details.
 | `GraphQL` | [GraphQL](https://www.nuget.org/packages/GraphQL/) | ≥2.3.0 & < 3.0.0 | bytecode |
 | `HttpClient` | [System.Net.Http.HttpClient](https://docs.microsoft.com/dotnet/api/system.net.http.httpclient) and [System.Net.HttpWebRequest](https://docs.microsoft.com/dotnet/api/system.net.httpwebrequest) | * | source |
 | `MongoDB` | [MongoDB.Driver.Core](https://www.nuget.org/packages/MongoDB.Driver.Core) **Not supported on .NET Framework** | ≥2.3.0 & < 3.0.0 | source & bytecode |
+| `MySql.Data` | [MySql.Data](https://www.nuget.org/packages/MySql.Data) | ≥6.10.7 | source |
 | `Npgsql` | [Npgsql](https://www.nuget.org/packages/Npgsql) | ≥6.0.0 | source |
 | `SqlClient` | [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient) and [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient) | * | source |
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -40,7 +40,7 @@ for more details.
 | `GraphQL` | [GraphQL](https://www.nuget.org/packages/GraphQL/) | ≥2.3.0 & < 3.0.0 | bytecode |
 | `HttpClient` | [System.Net.Http.HttpClient](https://docs.microsoft.com/dotnet/api/system.net.http.httpclient) and [System.Net.HttpWebRequest](https://docs.microsoft.com/dotnet/api/system.net.httpwebrequest) | * | source |
 | `MongoDB` | [MongoDB.Driver.Core](https://www.nuget.org/packages/MongoDB.Driver.Core) **Not supported on .NET Framework** | ≥2.3.0 & < 3.0.0 | source & bytecode |
-| `MySql.Data` | [MySql.Data](https://www.nuget.org/packages/MySql.Data) | ≥6.10.7 | source |
+| `MySql.Data` | [MySql.Data](https://www.nuget.org/packages/MySql.Data)  **Not supported on .NET Framework** | ≥6.10.7 | source |
 | `Npgsql` | [Npgsql](https://www.nuget.org/packages/Npgsql) | ≥6.0.0 | source |
 | `SqlClient` | [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient) and [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient) | * | source |
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -29,8 +29,10 @@ internal static class EnvironmentConfigurationTracerHelper
         [TracerInstrumentation.HttpClient] = builder => builder.AddHttpClientInstrumentation(),
         [TracerInstrumentation.AspNet] = builder => builder.AddSdkAspNetInstrumentation(),
         [TracerInstrumentation.SqlClient] = builder => builder.AddSqlClientInstrumentation(),
+#if NETCOREAPP3_1_OR_GREATER
         [TracerInstrumentation.MongoDB] = builder => builder.AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources"),
         [TracerInstrumentation.MySqlData] = builder => builder.AddSource("OpenTelemetry.Instrumentation.MySqlData"),
+#endif
         [TracerInstrumentation.Npgsql] = builder => builder.AddSource("Npgsql")
     };
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -30,6 +30,7 @@ internal static class EnvironmentConfigurationTracerHelper
         [TracerInstrumentation.AspNet] = builder => builder.AddSdkAspNetInstrumentation(),
         [TracerInstrumentation.SqlClient] = builder => builder.AddSqlClientInstrumentation(),
         [TracerInstrumentation.MongoDB] = builder => builder.AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources"),
+        [TracerInstrumentation.MySqlData] = builder => builder.AddSource("OpenTelemetry.Instrumentation.MySqlData"),
         [TracerInstrumentation.Npgsql] = builder => builder.AddSource("Npgsql")
     };
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/IConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/IConfigurationSource.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
-
 namespace OpenTelemetry.AutoInstrumentation.Configuration;
 
 /// <summary>

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
@@ -24,35 +24,39 @@ public enum TracerInstrumentation
     /// <summary>
     /// HttpClient instrumentation.
     /// </summary>
-    HttpClient,
+    HttpClient = 0,
 
     /// <summary>
     /// ASP.NET instrumentation.
     /// </summary>
-    AspNet,
+    AspNet = 1,
 
     /// <summary>
     /// SqlClient instrumentation.
     /// </summary>
-    SqlClient,
+    SqlClient = 2,
 
     /// <summary>
     /// GraphQL instrumentation.
     /// </summary>
-    GraphQL,
+    GraphQL = 3,
 
+#if NETCOREAPP3_1_OR_GREATER
     /// <summary>
     /// MongoDB instrumentation.
     /// </summary>
-    MongoDB,
+    MongoDB = 4,
+#endif
 
     /// <summary>
     /// Npgsql instrumentation.
     /// </summary>
-    Npgsql,
+    Npgsql = 5,
 
+#if NETCOREAPP3_1_OR_GREATER
     /// <summary>
     /// MySqlData instrumentation.
     /// </summary>
-    MySqlData
+    MySqlData = 6
+#endif
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerInstrumentation.cs
@@ -49,5 +49,10 @@ public enum TracerInstrumentation
     /// <summary>
     /// Npgsql instrumentation.
     /// </summary>
-    Npgsql
+    Npgsql,
+
+    /// <summary>
+    /// MySqlData instrumentation.
+    /// </summary>
+    MySqlData
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -19,7 +19,9 @@ using System.Diagnostics.Tracing;
 using System.Threading;
 using OpenTelemetry.AutoInstrumentation.Configuration;
 using OpenTelemetry.AutoInstrumentation.Diagnostics;
+#if NETCOREAPP3_1_OR_GREATER
 using OpenTelemetry.AutoInstrumentation.Loading;
+#endif
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Metrics;
@@ -37,7 +39,9 @@ public static class Instrumentation
 {
     private static readonly ILogger Logger = OtelLogging.GetLogger();
     private static readonly ResourceBuilder _resourceBuilder = ResourceBuilder.CreateDefault();
+#if NETCOREAPP3_1_OR_GREATER
     private static readonly LazyInstrumentationLoader LazyInstrumentationLoader = new();
+#endif
 
     private static int _firstInitialization = 1;
     private static int _isExiting = 0;
@@ -106,10 +110,13 @@ public static class Instrumentation
                 // -> this should be refactored in a separate PR
                 // e.g. we could have a static method that returns a collection of initializers
                 //      and TracerSettings.EnabledInstrumentations would be passed as input
+#if NETCOREAPP3_1_OR_GREATER
+
                 if (TracerSettings.EnabledInstrumentations.Contains(TracerInstrumentation.MySqlData))
                 {
                     LazyInstrumentationLoader.Add(new MySqlDataInitializer());
                 }
+#endif
 
                 var builder = Sdk
                     .CreateTracerProviderBuilder()
@@ -177,7 +184,9 @@ public static class Instrumentation
 
         try
         {
+#if NETCOREAPP3_1_OR_GREATER
             LazyInstrumentationLoader?.Dispose();
+#endif
             _tracerProvider?.Dispose();
             _meterProvider?.Dispose();
             _sdkEventListener.Dispose();
@@ -188,7 +197,7 @@ public static class Instrumentation
         {
             try
             {
-                Logger.Error(ex, "An error occured while attempting to exit.");
+                Logger.Error(ex, "An error occurred while attempting to exit.");
             }
             catch
             {

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+#if NETCOREAPP3_1_OR_GREATER
 namespace OpenTelemetry.AutoInstrumentation.Loading;
 
 internal interface ILifespanManager
@@ -23,3 +24,4 @@ internal interface ILifespanManager
     // it will be disposed together with the manager.
     void Track(object instance);
 }
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
@@ -1,0 +1,25 @@
+// <copyright file="ILifespanManager.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal interface ILifespanManager
+{
+    // Track an object so that it is not garbage collected.
+    // Additionally, if the objects implements IDisposable,
+    // it will be disposed together with the manager.
+    void Track(object instance);
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
@@ -19,9 +19,12 @@ namespace OpenTelemetry.AutoInstrumentation.Loading;
 
 internal interface ILifespanManager
 {
-    // Track an object so that it is not garbage collected.
-    // Additionally, if the objects implements IDisposable,
-    // it will be disposed together with the manager.
+    /// <summary>
+    /// Track an object so that it is not garbage collected.
+    /// Additionally, if the objects implements IDisposable,
+    /// it will be disposed together with the manager.
+    /// </summary>
+    /// <param name="instance">Trackable object</param>
     void Track(object instance);
 }
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
@@ -1,0 +1,29 @@
+// <copyright file="InstrumentationInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal abstract class InstrumentationInitializer
+{
+    protected InstrumentationInitializer(params string[] requiredAssemblies)
+    {
+        RequiredAssemblies = requiredAssemblies;
+    }
+
+    public string[] RequiredAssemblies { get; }
+
+    public abstract void Initialize(ILifespanManager lifespanManager);
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+#if NETCOREAPP3_1_OR_GREATER
 namespace OpenTelemetry.AutoInstrumentation.Loading;
 
 internal abstract class InstrumentationInitializer
@@ -27,3 +28,4 @@ internal abstract class InstrumentationInitializer
 
     public abstract void Initialize(ILifespanManager lifespanManager);
 }
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
@@ -17,6 +17,10 @@
 #if NETCOREAPP3_1_OR_GREATER
 namespace OpenTelemetry.AutoInstrumentation.Loading;
 
+/// <summary>
+/// InstrumentationInitializer encapsulates instrumentation initialization
+/// together with the assemblies which are required by the implementation.
+/// </summary>
 internal abstract class InstrumentationInitializer
 {
     protected InstrumentationInitializer(params string[] requiredAssemblies)

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
@@ -24,6 +24,9 @@ using OpenTelemetry.AutoInstrumentation.Logging;
 
 namespace OpenTelemetry.AutoInstrumentation.Loading;
 
+/// <summary>
+/// LazyInstrumentationLoader is responsible for managing deferred instrumentation initialization.
+/// </summary>
 internal class LazyInstrumentationLoader : ILifespanManager, IDisposable
 {
     // some instrumentations requires to keep references to objects

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#if NETCOREAPP3_1_OR_GREATER
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -91,3 +93,4 @@ internal class LazyInstrumentationLoader : ILifespanManager, IDisposable
         }
     }
 }
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
@@ -1,0 +1,93 @@
+// <copyright file="LazyInstrumentationLoader.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class LazyInstrumentationLoader : ILifespanManager, IDisposable
+{
+    // some instrumentations requires to keep references to objects
+    // so that they are not garbage collected
+    private readonly ConcurrentBag<object> _instrumentations = new();
+
+    public void Dispose()
+    {
+        while (_instrumentations.TryTake(out var instrumentation))
+        {
+            if (instrumentation is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+
+    public void Add(InstrumentationInitializer loader)
+    {
+        _ = new OnAssemblyLoadInitializer(this, loader);
+    }
+
+    void ILifespanManager.Track(object instance)
+    {
+        _instrumentations.Add(instance);
+    }
+
+    private class OnAssemblyLoadInitializer
+    {
+        private static readonly ILogger Logger = OtelLogging.GetLogger();
+        private readonly InstrumentationInitializer _instrumentationInitializer;
+        private readonly LazyInstrumentationLoader _manager;
+        private readonly HashSet<string> _requiredAssemblies;
+        private int _loadedCount;
+
+        public OnAssemblyLoadInitializer(LazyInstrumentationLoader manager, InstrumentationInitializer instrumentationInitializer)
+        {
+            _instrumentationInitializer = instrumentationInitializer;
+            _manager = manager;
+            _requiredAssemblies = new HashSet<string>(instrumentationInitializer.RequiredAssemblies);
+            AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+        }
+
+        private void CurrentDomain_AssemblyLoad(object sender, AssemblyLoadEventArgs args)
+        {
+            var assemblyName = args.LoadedAssembly.FullName.Split(new[] { ',' }, count: 2)[0];
+
+            if (_requiredAssemblies.Contains(assemblyName))
+            {
+                if (Interlocked.Increment(ref _loadedCount) == _requiredAssemblies.Count)
+                {
+                    var initializerName = _instrumentationInitializer.GetType().Name;
+                    Logger.Debug("'{0}' started", initializerName);
+
+                    try
+                    {
+                        _instrumentationInitializer.Initialize(_manager);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "'{0}' failed", initializerName);
+                    }
+
+                    AppDomain.CurrentDomain.AssemblyLoad -= CurrentDomain_AssemblyLoad;
+                }
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
@@ -27,6 +27,10 @@ namespace OpenTelemetry.AutoInstrumentation.Loading;
 /// <summary>
 /// LazyInstrumentationLoader is responsible for managing deferred instrumentation initialization.
 /// </summary>
+/// <remarks>
+/// Some instrumentations require setup that can be preformed
+/// when some prerequisites are met.
+/// </remarks>
 internal class LazyInstrumentationLoader : ILifespanManager, IDisposable
 {
     // some instrumentations requires to keep references to objects

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/MySqlDataInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/MySqlDataInitializer.cs
@@ -1,0 +1,38 @@
+// <copyright file="MySqlDataInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class MySqlDataInitializer : InstrumentationInitializer
+{
+    public MySqlDataInitializer()
+        : base(requiredAssemblies: "MySql.Data")
+    {
+    }
+
+    public override void Initialize(ILifespanManager lifespanManager)
+    {
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.MySqlData.MySqlDataInstrumentation, OpenTelemetry.Instrumentation.MySqlData");
+        var optionsInstrumentationType = Type.GetType("OpenTelemetry.Instrumentation.MySqlData.MySqlDataInstrumentationOptions, OpenTelemetry.Instrumentation.MySqlData");
+
+        var options = Activator.CreateInstance(optionsInstrumentationType);
+        var instrumentation = Activator.CreateInstance(instrumentationType, options);
+
+        lifespanManager.Track(instrumentation);
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/MySqlDataInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/MySqlDataInitializer.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#if NETCOREAPP3_1_OR_GREATER
+
 using System;
 
 namespace OpenTelemetry.AutoInstrumentation.Loading;
@@ -36,3 +38,4 @@ internal class MySqlDataInitializer : InstrumentationInitializer
         lifespanManager.Track(instrumentation);
     }
 }
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -18,9 +18,9 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.3" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <!--MySql.Data is required by OpenTelemetry.Instrumentation.MySqlData. ExcludeAssets="all" prevents copying it to the output-->
-    <PackageReference Include="MySql.Data" Version="6.10.7" ExcludeAssets="all" />
+    <PackageReference Include="MySql.Data" Version="6.10.7" ExcludeAssets="all" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -18,6 +18,9 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.3" />
+    <!--MySql.Data is required by OpenTelemetry.Instrumentation.MySqlData. ExcludeAssets="all" prevents copying it to the output-->
+    <PackageReference Include="MySql.Data" Version="6.10.7" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.3" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <!--MySql.Data is required by OpenTelemetry.Instrumentation.MySqlData. ExcludeAssets="all" prevents copying it to the output-->
+    <!-- MySql.Data is required by OpenTelemetry.Instrumentation.MySqlData. ExcludeAssets="all" prevents copying it to the output -->
     <PackageReference Include="MySql.Data" Version="6.10.7" ExcludeAssets="all" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
 

--- a/test/IntegrationTests/MySqlDataCollection.cs
+++ b/test/IntegrationTests/MySqlDataCollection.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+#if NETCOREAPP3_1_OR_GREATER
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -76,3 +77,4 @@ public class MySqlDataFixture : IAsyncLifetime
         await container.DisposeAsync();
     }
 }
+#endif

--- a/test/IntegrationTests/MySqlDataCollection.cs
+++ b/test/IntegrationTests/MySqlDataCollection.cs
@@ -1,0 +1,78 @@
+// <copyright file="MySqlDataCollection.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using IntegrationTests.Helpers;
+using Xunit;
+
+namespace IntegrationTests;
+
+[CollectionDefinition(Name)]
+public class MySqlDataCollection : ICollectionFixture<MySqlDataFixture>
+{
+    public const string Name = nameof(MySqlDataCollection);
+}
+
+public class MySqlDataFixture : IAsyncLifetime
+{
+    private const int MySqlPort = 3306;
+    private const string MySqlImage = "mysql:8.0.29";
+
+    private TestcontainersContainer _container;
+
+    public MySqlDataFixture()
+    {
+        Port = TcpPortProvider.GetOpenPort();
+    }
+
+    public int Port { get; }
+
+    public async Task InitializeAsync()
+    {
+        _container = await LaunchMySqlContainerAsync(Port);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container != null)
+        {
+            await ShutdownMySqlContainerAsync(_container);
+        }
+    }
+
+    private async Task<TestcontainersContainer> LaunchMySqlContainerAsync(int port)
+    {
+        var containersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            .WithImage(MySqlImage)
+            .WithName($"mysql-{port}")
+            .WithPortBinding(port, MySqlPort)
+            .WithEnvironment("MYSQL_ALLOW_EMPTY_PASSWORD", "true")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MySqlPort));
+
+        var container = containersBuilder.Build();
+        await container.StartAsync();
+
+        return container;
+    }
+
+    private async Task ShutdownMySqlContainerAsync(TestcontainersContainer container)
+    {
+        await container.CleanUpAsync();
+        await container.DisposeAsync();
+    }
+}

--- a/test/IntegrationTests/MySqlDataTests.cs
+++ b/test/IntegrationTests/MySqlDataTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Linq;
 using FluentAssertions;
@@ -55,3 +56,4 @@ public class MySqlDataTests : TestHelper
         }
     }
 }
+#endif

--- a/test/IntegrationTests/MySqlDataTests.cs
+++ b/test/IntegrationTests/MySqlDataTests.cs
@@ -1,0 +1,57 @@
+// <copyright file="MySqlDataTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using IntegrationTests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTests;
+
+[Collection(MySqlDataCollection.Name)]
+public class MySqlDataTests : TestHelper
+{
+    private const string ServiceName = "TestApplication.MySqlData";
+    private readonly MySqlDataFixture _mySqlData;
+
+    public MySqlDataTests(ITestOutputHelper output, MySqlDataFixture mySqlData)
+        : base("MySqlData", output)
+    {
+        _mySqlData = mySqlData;
+        SetEnvironmentVariable("OTEL_SERVICE_NAME", ServiceName);
+    }
+
+    [Fact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Containers", "Linux")]
+    public void SubmitsTraces()
+    {
+        using var agent = new MockZipkinCollector(Output);
+
+        RunTestApplication(agent.Port, arguments: $"--mysql {_mySqlData.Port}");
+
+        var spans = agent.WaitForSpans(1, TimeSpan.FromSeconds(5));
+
+        using (new AssertionScope())
+        {
+            spans.Should().NotBeNullOrEmpty();
+            spans.First().Tags["db.system"].Should().Be("mysql");
+        }
+    }
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -116,8 +116,10 @@ public class SettingsTests : IDisposable
     [InlineData(nameof(TracerInstrumentation.AspNet), TracerInstrumentation.AspNet)]
     [InlineData(nameof(TracerInstrumentation.GraphQL), TracerInstrumentation.GraphQL)]
     [InlineData(nameof(TracerInstrumentation.HttpClient), TracerInstrumentation.HttpClient)]
+#if NETCOREAPP3_1_OR_GREATER
     [InlineData(nameof(TracerInstrumentation.MongoDB), TracerInstrumentation.MongoDB)]
     [InlineData(nameof(TracerInstrumentation.MySqlData), TracerInstrumentation.MySqlData)]
+#endif
     [InlineData(nameof(TracerInstrumentation.Npgsql), TracerInstrumentation.Npgsql)]
     [InlineData(nameof(TracerInstrumentation.SqlClient), TracerInstrumentation.SqlClient)]
     public void TracerSettings_Instrumentations_SupportedValues(string tracerInstrumentation, TracerInstrumentation expectedTracerInstrumentation)

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -117,6 +117,7 @@ public class SettingsTests : IDisposable
     [InlineData(nameof(TracerInstrumentation.GraphQL), TracerInstrumentation.GraphQL)]
     [InlineData(nameof(TracerInstrumentation.HttpClient), TracerInstrumentation.HttpClient)]
     [InlineData(nameof(TracerInstrumentation.MongoDB), TracerInstrumentation.MongoDB)]
+    [InlineData(nameof(TracerInstrumentation.MySqlData), TracerInstrumentation.MySqlData)]
     [InlineData(nameof(TracerInstrumentation.Npgsql), TracerInstrumentation.Npgsql)]
     [InlineData(nameof(TracerInstrumentation.SqlClient), TracerInstrumentation.SqlClient)]
     public void TracerSettings_Instrumentations_SupportedValues(string tracerInstrumentation, TracerInstrumentation expectedTracerInstrumentation)

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -76,3 +77,4 @@ public class LazyInstrumentationLoaderTests
         }
     }
 }
+#endif

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
@@ -1,0 +1,78 @@
+// <copyright file="LazyInstrumentationLoaderTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using OpenTelemetry.AutoInstrumentation.Loading;
+using Xunit;
+
+namespace OpenTelemetry.AutoInstrumentation.Tests.Loading;
+
+public class LazyInstrumentationLoaderTests
+{
+    [Fact]
+    public void InitializesOnAssemblyLoad()
+    {
+        var initializer = new DummyInitializer();
+        using (var loader = new LazyInstrumentationLoader())
+        {
+            loader.Add(initializer);
+
+            CreateDummyAssembly(); // Creates and loads assembly dynamically. This should trigger also assembly load event.
+        }
+
+        using (new AssertionScope())
+        {
+            initializer.Initialized.Should().BeTrue();
+            initializer.Disposed.Should().BeTrue();
+        }
+    }
+
+    private void CreateDummyAssembly()
+    {
+        var assemblyName = new AssemblyName(DummyInitializer.DummyAssemblyName);
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        assemblyBuilder.DefineDynamicModule(assemblyName.Name);
+    }
+
+    private class DummyInitializer : InstrumentationInitializer, IDisposable
+    {
+        public const string DummyAssemblyName = "Dummy.Assembly";
+
+        public DummyInitializer()
+            : base(requiredAssemblies: DummyAssemblyName)
+        {
+        }
+
+        public bool Initialized { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public override void Initialize(ILifespanManager lifespanManager)
+        {
+            Initialized = true;
+            lifespanManager.Track(this);
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+}

--- a/test/test-applications/integrations/TestApplication.MySqlData/Program.cs
+++ b/test/test-applications/integrations/TestApplication.MySqlData/Program.cs
@@ -1,0 +1,54 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using TestApplication.Shared;
+
+namespace TestApplication.MySqlData;
+
+public static class Program
+{
+    public static async Task Main(string[] args)
+    {
+        ConsoleHelper.WriteSplashScreen(args);
+
+        var mySqlPort = GetMySqlPort(args);
+
+        var connString = $@"Server=127.0.0.1;Port={mySqlPort};Uid=root";
+
+        using var connection = new MySqlConnection(connString);
+        await connection.OpenAsync();
+
+        using var cmd = new MySqlCommand(@"SELECT 123;", connection);
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            Console.WriteLine(reader.GetInt32(0));
+        }
+    }
+
+    private static string GetMySqlPort(string[] args)
+    {
+        if (args.Length > 1)
+        {
+            return args[1];
+        }
+
+        return "3306";
+    }
+}

--- a/test/test-applications/integrations/TestApplication.MySqlData/TestApplication.MySqlData.csproj
+++ b/test/test-applications/integrations/TestApplication.MySqlData/TestApplication.MySqlData.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MySql.Data" Version="6.10.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\TestApplication.Shared\TestApplication.Shared.csproj" />
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #907

## What

MySql.Data instrumentation for .NET Core 3.1+.
It utilize `OpenTelemetry.Instrumentation.MySqlData`.
Lazy loading based on: #903.

Support for .NET Framework has similar issues like MongoDB. It is candidate for separate task.

## Tests

New test created.
CI
Tested locally also with `MySql.Data` v. 8.0.29.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.

## Code review

Please double check the way how `OpenTelemetry.Instrumentation.MySqlData` is referenced.
