### PR TITLE
Bump macos-10.15 to macos-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: [ windows-2022, ubuntu-20.04, macos-10.15 ]
+        machine: [ windows-2022, ubuntu-20.04, macos-11 ]
     runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: [ windows-2022, ubuntu-20.04, macos-10.15 ]
+        machine: [ windows-2022, ubuntu-20.04, macos-11 ]
     runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v3.0.2

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,7 @@ and [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework).
 
 CI tests run against the following operating systems:
 
-- [macOS 11](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md)
+- [macOS Big Sur 11](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md)
 - [Microsoft Windows Server 2022](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md)
 - [Ubuntu 20.04 LTS](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,9 +75,9 @@ and [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework).
 
 CI tests run against the following operating systems:
 
-- Microsoft Windows Server 2022
-- macOS Catalina 10.15
-- Ubuntu 20.04 LTS
+- [macOS 11](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md)
+- [Microsoft Windows Server 2022](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md)
+- [Ubuntu 20.04 LTS](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md)
 
 ### Instrumented libraries and frameworks
 


### PR DESCRIPTION
## Why



Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/994

## What

Bump macos-10.15 to macos-11

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- [x] ~~New features are covered by tests.~~
