### PR TITLE
Bump macOS from 10.15 to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: [ windows-2022, ubuntu-20.04, macos-10.15 ]
+        machine: [ windows-2022, ubuntu-20.04, macos-11 ]
     runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: [ windows-2022, ubuntu-20.04, macos-10.15 ]
+        machine: [ windows-2022, ubuntu-20.04, macos-11 ]
     runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v3.0.2

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,7 @@ and [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework).
 CI tests run against the following operating systems:
 
 - Microsoft Windows Server 2022
-- macOS Catalina 10.15
+- macOS Big Sur 11
 - Ubuntu 20.04 LTS
 
 ### Instrumented libraries and frameworks


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #994

## What

Bump macOS from 10.15 to 11
## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
