### PR TITLE
Downgrade deps in test apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -164,10 +164,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
-    labels:
-      - "dependencies"
-      - ".NET"
-      - "do NOT merge"
 
   - package-ecosystem: nuget
     directory: /test/test-applications/integrations/TestApplication.GraphQL

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -166,6 +166,11 @@ against its lowest supported version.
 The pull requests created by @dependabot with `do NOT merge` label
 are used to test against higher library versions when they are released.
 
+> `TestApplication.AspNet` is an exception to this strategy
+> as it would not work well, because of multiple dependent packages.
+> `TestApplication.AspNet` references the latest versions
+> of the ASP.NET packages.
+
 ## Debug the .NET runtime on Linux
 
 - [Requirements](https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/linux-requirements.md)

--- a/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
+++ b/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
@@ -6,7 +6,6 @@
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.4.0" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
+++ b/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">2.13.1</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">2.13.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'>='2.15.0'">$(DefineConstants);MONGODB_2_15</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'>='2.7.0'">$(DefineConstants);MONGODB_2_7</DefineConstants>
 

--- a/test/test-applications/integrations/TestApplication.SqlClient/TestApplication.SqlClient.csproj
+++ b/test/test-applications/integrations/TestApplication.SqlClient/TestApplication.SqlClient.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Why

I downgraded some dependencies in the test apps. 

I only left the ASP.NET test application untouched as it would require more work and also because it is not a single dependency and dependabot would not help us with testing against the newest version.

Fixes #969

## What

Downgrade deps in test apps to the lowest supported versions.

Remove unnecessary reference to `Microsoft.Extensions.DependencyInjection.Abstractions`.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] ~~Documentation is updated.~~
- [x] ~~New features are covered by tests.~~
