### PR TITLE
Fix crash ZSpanMock Logs deserialization

### DIFF
--- a/test/IntegrationTests/Helpers/Mocks/ZSpanMock.cs
+++ b/test/IntegrationTests/Helpers/Mocks/ZSpanMock.cs
@@ -81,19 +81,19 @@ internal class ZSpanMock : IMockSpan
 
     public Dictionary<string, string> Tags { get; set; }
 
-    public Dictionary<DateTimeOffset, Dictionary<string, string>> Logs
+    public Dictionary<DateTimeOffset, Dictionary<string, object>> Logs
     {
         get
         {
-            var logs = new Dictionary<DateTimeOffset, Dictionary<string, string>>();
+            var logs = new Dictionary<DateTimeOffset, Dictionary<string, object>>();
 
             if (_zipkinData.TryGetValue("annotations", out JToken annotations))
             {
                 foreach (var item in annotations.ToObject<List<Dictionary<string, object>>>())
                 {
                     DateTimeOffset timestamp = ((long)item["timestamp"]).UnixMicrosecondsToDateTimeOffset();
-                    Dictionary<string, string> fields = JsonConvert.DeserializeObject<Dictionary<string, string>>(item["value"].ToString());
-                    logs[timestamp] = fields;
+                    item.Remove("timestamp");
+                    logs[timestamp] = item;
                 }
             }
 


### PR DESCRIPTION
## Why

When the span contains `Logs` the `ToString()` method crashes.

## What

The `StackExchangeRedis` instrumentation use events and those are translated from Zipkin annotations and finally as Logs in the `ZSpanMock`. However, the `ToString()` method crashes under the debugger when the span actually serialized any annotation. For debugging we want to see whatever was under the annotation so this fix is just grabs the whole content as a dictionary.

## Tests

This is test code and we don't test it, found it while I was curious about the new instrumentation and added a `ToString()` call to the see the spans from the instrumentation.

## Checklist

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
