### PR TITLE
Improve local documentation validation

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+node_modules
+packages

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Application to configure and execute markdownlint and spellcheck documentation.",
   "scripts": {
-    "markdownlint": "npx markdownlint . -i node_modules",
-    "markdownlint-fix": "npx markdownlint . -i node_modules --fix",
+    "markdownlint": "npx markdownlint .",
+    "markdownlint-fix": "npx markdownlint . --fix",
     "cspell": "npx cspell **/*.md --gitignore"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Why

When running the ValidateDocumentation command locally after running a build, the markdown linter picks up the nuget packages folder and adds noise too much noise to the commands output.

## What

This PR moves the current ignore list into a markdownlintignore file, and adds the nuget packages directory to the ignore list.

## Tests

The change was validated locally by running the build commands.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

No new functionality was added.

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
