### PR TITLE
Cleanup Examples.AspNetCoreMvc

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "9090:9090"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.51.0
+    image: otel/opentelemetry-collector-contrib:0.57.2
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
     command: --config /etc/otel/config.yaml

--- a/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
+++ b/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
     <PackageReference Include="OpenTelemetry" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.7" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.48" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/examples/AspNetCoreMvc/OtelSdkPlugin.cs
+++ b/examples/AspNetCoreMvc/OtelSdkPlugin.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using Examples.AspNetCoreMvc.Controllers;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -27,7 +26,7 @@ public class OtelSdkPlugin
     {
         var typeName = this.ToString();
         Console.WriteLine($"Hello from Tracer Plugin - {typeName}");
-        return builder.AddRedisInstrumentation(RedisController.Connection);
+        return builder;
     }
 
     public MeterProviderBuilder ConfigureMeterProvider(MeterProviderBuilder builder)


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #993

## What

Cleanup `Example.AspNetMVC.Core`. Rrmoved reference to `OpenTelemetry.Instrumentation.StackExchangeRedis`.
Bump otel collector contrib to 0.57.2 (the latest version).

## Tests

Manual testing. Spans for Redis are created when dotnet.exe process is not excluded by env. vars, https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/a777c1eba056e00c4701b6e3f30cb1659382c7a5/dev/envvars.sh#L68

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
