### PR TITLE
Fix flaky test PrometheusExporter

### DIFF
--- a/test/test-applications/integrations/TestApplication.Smoke/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Smoke/Program.cs
@@ -35,10 +35,17 @@ namespace TestApplication.Smoke
             EmitTraces();
             EmitMetrics();
 
+            // The "LONG_RUNNING" environment variable is used by tests that access/receive
+            // data that takes time to be produced.
             var longRunning = Environment.GetEnvironmentVariable("LONG_RUNNING");
             while (longRunning == "true")
             {
-                Thread.Yield();
+                // In this case it is necessary to ensure that the test has a chance to read the
+                // expected data, only by keeping the application alive for some time that can
+                // be ensured. Anyway, tests that set "LONG_RUNNING" env var to true are expected
+                // to kill the process directly.
+                Console.WriteLine("LONG_RUNNING is true, waiting for process to be killed...");
+                Console.ReadLine();
             }
         }
 


### PR DESCRIPTION
## Why

To improve reliability of PrometheusExporter smoke test, see #978

Fixes #978

## What

The test application uses `Thread.Yield()` when `LONG_RUNNING` environment variable is set on the test. However, `Thread.Yield()` is non-deterministic and the application may terminate before the test can successfully retrieve the data. There is also no guarantee that the expected counter is going to be there on the first read of the endpoint. The test application now won't terminate when `LONG_RUNNING` is set to true. The tests using this setting are expected to kill the process when they finish.

## Tests

Ran the tests multiple times on dev box.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
