### PR TITLE
Rename meter to metric in several places

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
@@ -23,14 +23,14 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 
 internal static class EnvironmentConfigurationMetricHelper
 {
-    private static readonly Dictionary<MeterInstrumentation, Action<MeterProviderBuilder>> AddMeters = new()
+    private static readonly Dictionary<MetricInstrumentation, Action<MeterProviderBuilder>> AddMeters = new()
     {
-        [MeterInstrumentation.AspNet] = builder => builder.AddSdkAspNetInstrumentation(),
-        [MeterInstrumentation.HttpClient] = builder => builder.AddHttpClientInstrumentation(),
-        [MeterInstrumentation.NetRuntime] = builder => builder.AddRuntimeInstrumentation(),
+        [MetricInstrumentation.AspNet] = builder => builder.AddSdkAspNetInstrumentation(),
+        [MetricInstrumentation.HttpClient] = builder => builder.AddHttpClientInstrumentation(),
+        [MetricInstrumentation.NetRuntime] = builder => builder.AddRuntimeInstrumentation(),
     };
 
-    public static MeterProviderBuilder UseEnvironmentVariables(this MeterProviderBuilder builder, MeterSettings settings)
+    public static MeterProviderBuilder UseEnvironmentVariables(this MeterProviderBuilder builder, MetricSettings settings)
     {
         builder
             .SetExporter(settings)
@@ -58,7 +58,7 @@ internal static class EnvironmentConfigurationMetricHelper
         return builder;
     }
 
-    private static MeterProviderBuilder SetExporter(this MeterProviderBuilder builder, MeterSettings settings)
+    private static MeterProviderBuilder SetExporter(this MeterProviderBuilder builder, MetricSettings settings)
     {
         if (settings.ConsoleExporterEnabled)
         {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/MetricInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/MetricInstrumentation.cs
@@ -1,4 +1,4 @@
-// <copyright file="MeterInstrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="MetricInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 /// <summary>
 /// Enum representing supported meter instrumentations.
 /// </summary>
-public enum MeterInstrumentation
+public enum MetricInstrumentation
 {
     /// <summary>
     /// ASP.NET instrumentation.

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/MetricSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/MetricSettings.cs
@@ -1,4 +1,4 @@
-// <copyright file="MeterSettings.cs" company="OpenTelemetry Authors">
+// <copyright file="MetricSettings.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,28 +16,27 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenTelemetry.AutoInstrumentation.Util;
 
 namespace OpenTelemetry.AutoInstrumentation.Configuration
 {
     /// <summary>
-    /// Meter Settings
+    /// Metric Settings
     /// </summary>
-    public class MeterSettings : Settings
+    public class MetricSettings : Settings
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MeterSettings"/> class
+        /// Initializes a new instance of the <see cref="MetricSettings"/> class
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
-        private MeterSettings(IConfigurationSource source)
+        private MetricSettings(IConfigurationSource source)
             : base(source)
         {
             MetricExporter = ParseMetricExporter(source);
             ConsoleExporterEnabled = source.GetBool(ConfigurationKeys.Metrics.ConsoleExporterEnabled) ?? false;
 
-            EnabledInstrumentations = source.ParseEnabledEnumList<MeterInstrumentation>(
+            EnabledInstrumentations = source.ParseEnabledEnumList<MetricInstrumentation>(
                 enabledConfiguration: ConfigurationKeys.Metrics.Instrumentations,
                 disabledConfiguration: ConfigurationKeys.Metrics.DisabledInstrumentations,
                 error: "The \"{0}\" is not recognized as supported metrics instrumentation and cannot be enabled");
@@ -100,14 +99,14 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
         /// <summary>
         /// Gets the list of enabled meters.
         /// </summary>
-        public IList<MeterInstrumentation> EnabledInstrumentations { get; }
+        public IList<MetricInstrumentation> EnabledInstrumentations { get; }
 
         /// <summary>
         /// Gets the list of meters to be added to the MeterProvider at the startup.
         /// </summary>
         public IList<string> Meters { get; } = new List<string>();
 
-        internal static MeterSettings FromDefaultSources()
+        internal static MetricSettings FromDefaultSources()
         {
             var configurationSource = new CompositeConfigurationSource
             {
@@ -119,7 +118,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
 #endif
             };
 
-            return new MeterSettings(configurationSource);
+            return new MetricSettings(configurationSource);
         }
 
         private static MetricsExporter ParseMetricExporter(IConfigurationSource source)

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -77,7 +77,7 @@ public static class Instrumentation
 
     internal static TracerSettings TracerSettings { get; } = TracerSettings.FromDefaultSources();
 
-    internal static MeterSettings MeterSettings { get; } = MeterSettings.FromDefaultSources();
+    internal static MetricSettings MetricSettings { get; } = MetricSettings.FromDefaultSources();
 
     /// <summary>
     /// Initialize the OpenTelemetry SDK with a pre-defined set of exporters, shims, and
@@ -93,7 +93,7 @@ public static class Instrumentation
 
         try
         {
-            if (TracerSettings.LoadTracerAtStartup || MeterSettings.LoadMetricsAtStartup)
+            if (TracerSettings.LoadTracerAtStartup || MetricSettings.LoadMetricsAtStartup)
             {
                 // Initialize SdkSelfDiagnosticsEventListener to create an EventListener for the OpenTelemetry SDK
                 _sdkEventListener = new(EventLevel.Warning, Logger);
@@ -102,7 +102,7 @@ public static class Instrumentation
                 AppDomain.CurrentDomain.ProcessExit += OnExit;
                 AppDomain.CurrentDomain.DomainUnload += OnExit;
 
-                if (TracerSettings.FlushOnUnhandledException || MeterSettings.FlushOnUnhandledException)
+                if (TracerSettings.FlushOnUnhandledException || MetricSettings.FlushOnUnhandledException)
                 {
                     AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
                 }
@@ -138,11 +138,11 @@ public static class Instrumentation
                 Logger.Information("OpenTelemetry tracer initialized.");
             }
 
-            if (MeterSettings.LoadMetricsAtStartup)
+            if (MetricSettings.LoadMetricsAtStartup)
             {
 #if NETCOREAPP3_1_OR_GREATER
 
-                if (MeterSettings.EnabledInstrumentations.Contains(MeterInstrumentation.AspNet))
+                if (MetricSettings.EnabledInstrumentations.Contains(MetricInstrumentation.AspNet))
                 {
                     LazyInstrumentationLoader.Add(new AspNetCoreMetricsInitializer());
                 }
@@ -151,8 +151,8 @@ public static class Instrumentation
                 var builder = Sdk
                     .CreateMeterProviderBuilder()
                     .SetResourceBuilder(_resourceBuilder)
-                    .UseEnvironmentVariables(MeterSettings)
-                    .InvokePlugins(MeterSettings.MetricPlugins);
+                    .UseEnvironmentVariables(MetricSettings)
+                    .InvokePlugins(MetricSettings.MetricPlugins);
 
                 _meterProvider = builder.Build();
                 Logger.Information("OpenTelemetry meter initialized.");

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -35,8 +35,8 @@ public class SettingsTests : IDisposable
     {
         yield return new object[] { ConfigurationKeys.Traces.Exporter, void () => TracerSettings.FromDefaultSources() };
         yield return new object[] { ConfigurationKeys.Traces.Instrumentations, void () => TracerSettings.FromDefaultSources() };
-        yield return new object[] { ConfigurationKeys.Metrics.Exporter, void () => MeterSettings.FromDefaultSources() };
-        yield return new object[] { ConfigurationKeys.Metrics.Instrumentations, void () => MeterSettings.FromDefaultSources() };
+        yield return new object[] { ConfigurationKeys.Metrics.Exporter, void () => MetricSettings.FromDefaultSources() };
+        yield return new object[] { ConfigurationKeys.Metrics.Instrumentations, void () => MetricSettings.FromDefaultSources() };
     }
 
     public void Dispose()
@@ -68,7 +68,7 @@ public class SettingsTests : IDisposable
     [Fact]
     public void MeterSettings_DefaultValues()
     {
-        var settings = MeterSettings.FromDefaultSources();
+        var settings = MetricSettings.FromDefaultSources();
 
         using (new AssertionScope())
         {
@@ -107,7 +107,7 @@ public class SettingsTests : IDisposable
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporter);
 
-        var settings = MeterSettings.FromDefaultSources();
+        var settings = MetricSettings.FromDefaultSources();
 
         settings.MetricExporter.Should().Be(expectedMetricsExporter);
     }
@@ -145,27 +145,27 @@ public class SettingsTests : IDisposable
     }
 
     [Theory]
-    [InlineData(nameof(MeterInstrumentation.NetRuntime), MeterInstrumentation.NetRuntime)]
-    [InlineData(nameof(MeterInstrumentation.AspNet), MeterInstrumentation.AspNet)]
-    [InlineData(nameof(MeterInstrumentation.HttpClient), MeterInstrumentation.HttpClient)]
-    public void MeterSettings_Instrumentations_SupportedValues(string meterInstrumentation, MeterInstrumentation expectedMeterInstrumentation)
+    [InlineData(nameof(MetricInstrumentation.NetRuntime), MetricInstrumentation.NetRuntime)]
+    [InlineData(nameof(MetricInstrumentation.AspNet), MetricInstrumentation.AspNet)]
+    [InlineData(nameof(MetricInstrumentation.HttpClient), MetricInstrumentation.HttpClient)]
+    public void MeterSettings_Instrumentations_SupportedValues(string meterInstrumentation, MetricInstrumentation expectedMetricInstrumentation)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Instrumentations, meterInstrumentation);
 
-        var settings = MeterSettings.FromDefaultSources();
+        var settings = MetricSettings.FromDefaultSources();
 
-        settings.EnabledInstrumentations.Should().BeEquivalentTo(new List<MeterInstrumentation> { expectedMeterInstrumentation });
+        settings.EnabledInstrumentations.Should().BeEquivalentTo(new List<MetricInstrumentation> { expectedMetricInstrumentation });
     }
 
     [Fact]
     public void MeterSettings_DisabledInstrumentations()
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Instrumentations, $"{nameof(MeterInstrumentation.NetRuntime)},{nameof(MeterInstrumentation.AspNet)}");
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.DisabledInstrumentations, nameof(MeterInstrumentation.AspNet));
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Instrumentations, $"{nameof(MetricInstrumentation.NetRuntime)},{nameof(MetricInstrumentation.AspNet)}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.DisabledInstrumentations, nameof(MetricInstrumentation.AspNet));
 
-        var settings = MeterSettings.FromDefaultSources();
+        var settings = MetricSettings.FromDefaultSources();
 
-        settings.EnabledInstrumentations.Should().BeEquivalentTo(new List<MeterInstrumentation> { MeterInstrumentation.NetRuntime });
+        settings.EnabledInstrumentations.Should().BeEquivalentTo(new List<MetricInstrumentation> { MetricInstrumentation.NetRuntime });
     }
 
     [Theory]


### PR DESCRIPTION
## Why

Names are not consistent.

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/707

## What

From the issue description:
- `MetricExporter` is consistent with the spec name for the metrics exporter interface, but, some other properties use metrics (plural) <- I haven't found an example of that besides tests code, I have not changed those.
- `Meter` is used as symmetrical to `Tracer` in certain locations but it is more like a logic grouping of somehow related metrics <- I have renamed Meter to Metric in several places.
- `EnabledInstrumentation` should be plural like the respective value on the tracer <- this one is already named `EnabledInstrumentations` in `MeterSettings`.

## Tests

N/A

## Checklist

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
