### PR TITLE
Handle old versions of System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ OpenTelemetry .NET Automatic Instrumentation is built on top of
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
 [`1.3.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.0)
 - `System.Diagnostics.DiagnosticSource`: [`6.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/6.0.0)
+  referencing `System.Runtime.CompilerServices.Unsafe`: [`6.0.0`](https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/6.0.0)
 
 You can find all references in
 [OpenTelemetry.AutoInstrumentation.csproj](../src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj)

--- a/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
@@ -29,7 +29,7 @@ internal class ContinuationGenerator<TTarget, TReturn>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static TReturn ToTReturn<TFrom>(TFrom returnValue)
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         return Unsafe.As<TFrom, TReturn>(ref returnValue);
 #else
         return ContinuationsHelper.Convert<TFrom, TReturn>(returnValue);
@@ -39,7 +39,7 @@ internal class ContinuationGenerator<TTarget, TReturn>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static TTo FromTReturn<TTo>(TReturn returnValue)
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
         return Unsafe.As<TReturn, TTo>(ref returnValue);
 #else
         return ContinuationsHelper.Convert<TReturn, TTo>(returnValue);

--- a/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
@@ -44,8 +44,7 @@ internal static class ContinuationsHelper
         return typeof(object);
     }
 
-#if NETCOREAPP3_1_OR_GREATER
-#else
+#if !NET6_0_OR_GREATER
     internal static TTo Convert<TFrom, TTo>(TFrom value)
     {
         return Converter<TFrom, TTo>.Convert(value);

--- a/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/IntegrationOptions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/IntegrationOptions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.AutoInstrumentation.DuckTyping;
 using OpenTelemetry.AutoInstrumentation.Logging;
@@ -46,6 +47,14 @@ internal static class IntegrationOptions<TIntegration, TTarget>
         {
             Log.Warning($"CallTargetInvokerException has been detected, the integration <{typeof(TIntegration)}, {typeof(TTarget)}> will be disabled.");
             _disableIntegration = true;
+        }
+        else if (exception is FileLoadException fileLoadException)
+        {
+            if (fileLoadException.FileName.StartsWith("System.Diagnostics.DiagnosticSource") || fileLoadException.FileName.StartsWith("System.Runtime.CompilerServices.Unsafe"))
+            {
+                Log.Warning($"FileLoadException for '{fileLoadException.FileName}' has been detected, the integration <{typeof(TIntegration)}, {typeof(TTarget)}> will be disabled.");
+                _disableIntegration = true;
+            }
         }
     }
 }

--- a/test/test-applications/integrations/TestApplication.StackExchangeRedis/TestApplication.StackExchangeRedis.csproj
+++ b/test/test-applications/integrations/TestApplication.StackExchangeRedis/TestApplication.StackExchangeRedis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+    <!-- Workaround! System.Runtime.CompilerServices.Unsafe v. 6.0.0 is minimal version supportef by auto instrumentation.
+    StackExchange.Redis references older version. It prevents to use older version during runtime.-->
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.StackExchangeRedis/TestApplication.StackExchangeRedis.csproj
+++ b/test/test-applications/integrations/TestApplication.StackExchangeRedis/TestApplication.StackExchangeRedis.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
     <!-- Workaround! System.Runtime.CompilerServices.Unsafe v. 6.0.0 is minimal version supportef by auto instrumentation.
-    StackExchange.Redis references older version. It prevents to use older version during runtime.-->
+    Prior StackExchange.Redis v.2.2.3 indirrectly references older version. It prevents to use older version during runtime.-->
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' " />
   </ItemGroup>
 


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #1027

## What

- extend documentation about `System.Runtime.CompilerServices.Unsafe`
- disable binary instrumentation when there is no possibility to load Unsafe or DiagnosticsSource in correct version
- fix Redis test application to be able to work on .NET Core 3.1
- Use internal implementation instead of Unsafe method

## Tests

nuke Workflow on Windows machine with Linux Docker

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~

## Notes

Please consider each commit as separate chuck of the fix.
Technically if we merge df14094dea137aac854b551ea7cb6d4c6ff66107 we can drop 65dda4aafe9ba3537237f53f308ecd76657724c2
