### PR TITLE
All signals settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Renamed `OTEL_DOTNET_AUTO_TRACES_ENABLED` to `OTEL_DOTNET_AUTO_ENABLED` since it
+  controls enabling or disabling the CLR profiler independent of the signal type.
 - `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS` default value is changed to
   include all of the available instrumentations.
 - `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS` default value is changed to

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -50,7 +50,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // check if tracing is completely disabled
     if (IsTracingDisabled())
     {
-        Logger::Info("OpenTelemetry TRACER DIAGNOSTICS - Profiler disabled in ", environment::tracing_enabled);
+        Logger::Info("OpenTelemetry Automatic Instrumentation - CLR Profiler disabled via ", environment::clr_profiler_enabled);
         return E_FAIL;
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
@@ -6,9 +6,9 @@
 namespace trace {
 namespace environment {
 
-// Sets whether the profiler is enabled. Default is true.
-// Setting this to false disabled the profiler entirely.
-const WSTRING tracing_enabled = WStr("OTEL_DOTNET_AUTO_TRACES_ENABLED");
+// Sets whether the automatic instrumentation, via the CLR profiler, is enabled.
+// Default is true. Setting this to false disables the CLR profiler.
+const WSTRING tracing_enabled = WStr("OTEL_DOTNET_AUTO_ENABLED");
 
 // Sets whether debug mode is enabled. Default is false.
 const WSTRING debug_enabled = WStr("OTEL_DOTNET_AUTO_DEBUG");

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
@@ -8,7 +8,7 @@ namespace environment {
 
 // Sets whether the automatic instrumentation, via the CLR profiler, is enabled.
 // Default is true. Setting this to false disables the CLR profiler.
-const WSTRING tracing_enabled = WStr("OTEL_DOTNET_AUTO_ENABLED");
+const WSTRING clr_profiler_enabled = WStr("OTEL_DOTNET_AUTO_ENABLED");
 
 // Sets whether debug mode is enabled. Default is false.
 const WSTRING debug_enabled = WStr("OTEL_DOTNET_AUTO_DEBUG");

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.h
@@ -59,7 +59,7 @@ bool IsDumpILRewriteEnabled() {
 }
 
 bool IsTracingDisabled() {
-  CheckIfFalse(GetEnvironmentValue(environment::tracing_enabled));
+  CheckIfFalse(GetEnvironmentValue(environment::clr_profiler_enabled));
 }
 
 bool IsAzureAppServices() {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
@@ -9,7 +9,7 @@
 namespace trace
 {
 
-const WSTRING env_vars_to_display[]{environment::tracing_enabled,
+const WSTRING env_vars_to_display[]{environment::clr_profiler_enabled,
                                     environment::debug_enabled,
                                     environment::profiler_home_path,
                                     environment::integrations_path,


### PR DESCRIPTION
## Why

Config setting named for traces but affecting all signals.

Fixes #706

## What

Renamed OTEL_DOTNET_AUTO_TRACES_ENABLED to OTEL_DOTNET_AUTO_ENABLED.

Opened two related issues:
- #1080
- #1081

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [X] `CHANGELOG.md` is updated.
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
