### PR TITLE
Remove unused env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `OTEL_DOTNET_AUTO_{0}_ENABLED` configuration,
   use `OTEL_DOTNET_AUTO_[TRACES/METRICS]_[ENABLED/DISABLED]_INSTRUMENTATIONS`
   instead.
+- Remove `OTEL_DOTNET_AUTO_METRICS_ENABLED` configuration as it is not needed.
 
 ## [0.2.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.2.0-beta.1)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,8 +5,7 @@
 | Environment variable | Description | Default value |
 |-|-|-|
 | `OTEL_DOTNET_AUTO_HOME` | Installation location. |  |
-| `OTEL_DOTNET_AUTO_TRACES_ENABLED` | Enables the tracer. | `true` |
-| `OTEL_DOTNET_AUTO_METRICS_ENABLED` | Enables the meter. | `true` |
+| `OTEL_DOTNET_AUTO_ENABLED` | Enables CLR profiler needed by Tracer. | `true` |
 | `OTEL_DOTNET_AUTO_INCLUDE_PROCESSES` | Names of the executable files that the profiler can instrument. Supports multiple comma-separated values, for example: `MyApp.exe,dotnet.exe`. If unset, the profiler attaches to all processes by default. |  |
 | `OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES` | Names of the executable files that the profiler cannot instrument. Supports multiple comma-separated values, for example: `ReservedProcess.exe,powershell.exe`. The list is processed after `OTEL_DOTNET_AUTO_INCLUDE_PROCESSES`. If unset, the profiler attaches to all processes by default. |  |
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,7 +5,7 @@
 | Environment variable | Description | Default value |
 |-|-|-|
 | `OTEL_DOTNET_AUTO_HOME` | Installation location. |  |
-| `OTEL_DOTNET_AUTO_ENABLED` | Enables CLR profiler needed by Tracer. | `true` |
+| `OTEL_DOTNET_AUTO_ENABLED` | Enables CLR profiler. If `false`, it disables Automatic Instrumentation for .NET Framework and it disables bytecode instrumentation for .NET (Core). | `true` |
 | `OTEL_DOTNET_AUTO_INCLUDE_PROCESSES` | Names of the executable files that the profiler can instrument. Supports multiple comma-separated values, for example: `MyApp.exe,dotnet.exe`. If unset, the profiler attaches to all processes by default. |  |
 | `OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES` | Names of the executable files that the profiler cannot instrument. Supports multiple comma-separated values, for example: `ReservedProcess.exe,powershell.exe`. The list is processed after `OTEL_DOTNET_AUTO_INCLUDE_PROCESSES`. If unset, the profiler attaches to all processes by default. |  |
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -56,13 +56,6 @@ public class ConfigurationKeys
     public static class Traces
     {
         /// <summary>
-        /// Configuration key for enabling or disabling the Tracer.
-        /// Default is value is true (enabled).
-        /// </summary>
-        /// <seealso cref="TracerSettings.TraceEnabled"/>
-        public const string Enabled = "OTEL_DOTNET_AUTO_TRACES_ENABLED";
-
-        /// <summary>
         /// Configuration key for whether the tracer should be initialized by the profiler or not.
         /// </summary>
         public const string LoadTracerAtStartup = "OTEL_DOTNET_AUTO_LOAD_TRACER_AT_STARTUP";
@@ -109,12 +102,6 @@ public class ConfigurationKeys
     /// </summary>
     public static class Metrics
     {
-        /// <summary>
-        /// Configuration key for enabling or disabling the Meter.
-        /// Default is value is true (enabled).
-        /// </summary>
-        public const string Enabled = "OTEL_DOTNET_AUTO_METRICS_ENABLED";
-
         /// <summary>
         /// Configuration key for whether the meter should be initialized by the profiler or not.
         /// </summary>

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/MetricSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/MetricSettings.cs
@@ -60,16 +60,8 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration
             }
 
             MetricExportInterval = source.GetInt32(ConfigurationKeys.Metrics.ExportInterval);
-            MetricsEnabled = source.GetBool(ConfigurationKeys.Metrics.Enabled) ?? true;
             LoadMetricsAtStartup = source.GetBool(ConfigurationKeys.Metrics.LoadMeterAtStartup) ?? true;
         }
-
-        /// <summary>
-        /// Gets a value indicating whether metrics is enabled.
-        /// Default is <c>true</c>.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.Metrics.Enabled"/>
-        public bool MetricsEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the metrics should be loaded by the profiler. Default is true.

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
@@ -69,16 +69,8 @@ public class TracerSettings : Settings
             }
         }
 
-        TraceEnabled = source.GetBool(ConfigurationKeys.Traces.Enabled) ?? true;
         LoadTracerAtStartup = source.GetBool(ConfigurationKeys.Traces.LoadTracerAtStartup) ?? true;
     }
-
-    /// <summary>
-    /// Gets a value indicating whether tracing is enabled.
-    /// Default is <c>true</c>.
-    /// </summary>
-    /// <seealso cref="ConfigurationKeys.Traces.Enabled"/>
-    public bool TraceEnabled { get; }
 
     /// <summary>
     /// Gets a value indicating whether the tracer should be loaded by the profiler. Default is true.

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -51,7 +51,6 @@ public class SettingsTests : IDisposable
 
         using (new AssertionScope())
         {
-            settings.TraceEnabled.Should().BeTrue();
             settings.LoadTracerAtStartup.Should().BeTrue();
             settings.TracesExporter.Should().Be(TracesExporter.Otlp);
             settings.OtlpExportProtocol.Should().Be(OtlpExportProtocol.HttpProtobuf);
@@ -72,7 +71,6 @@ public class SettingsTests : IDisposable
 
         using (new AssertionScope())
         {
-            settings.MetricsEnabled.Should().BeTrue();
             settings.LoadMetricsAtStartup.Should().BeTrue();
             settings.MetricExporter.Should().Be(MetricsExporter.Otlp);
             settings.OtlpExportProtocol.Should().Be(OtlpExportProtocol.HttpProtobuf);


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #1080 and #1081

## What

Remove unused env. variables
`OTEL_DOTNET_AUTO_METRICS_ENABLED` and `OTEL_DOTNET_AUTO_TRACES_ENABLED`

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
