### PR TITLE
Stabilize SqlClient tests

### DIFF
--- a/test/IntegrationTests/Helpers/TestContainers/UntilAsyncOperationIsSucceeded.cs
+++ b/test/IntegrationTests/Helpers/TestContainers/UntilAsyncOperationIsSucceeded.cs
@@ -21,6 +21,7 @@ using DotNet.Testcontainers.Containers;
 using Microsoft.Extensions.Logging;
 
 namespace IntegrationTests.Helpers.TestContainers;
+
 internal class UntilAsyncOperationIsSucceeded : IWaitUntil
 {
     private readonly int _maxCallCount;

--- a/test/IntegrationTests/Helpers/TestContainers/UntilAsyncOperationIsSucceeded.cs
+++ b/test/IntegrationTests/Helpers/TestContainers/UntilAsyncOperationIsSucceeded.cs
@@ -1,0 +1,45 @@
+// <copyright file="UntilAsyncOperationIsSucceeded.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Microsoft.Extensions.Logging;
+
+namespace IntegrationTests.Helpers.TestContainers;
+internal class UntilAsyncOperationIsSucceeded : IWaitUntil
+{
+    private readonly int _maxCallCount;
+    private readonly Func<Task<bool>> _operation;
+    private int _tryCount;
+
+    public UntilAsyncOperationIsSucceeded(Func<Task<bool>> operation, int maxCallCount)
+    {
+        _operation = operation;
+        _maxCallCount = maxCallCount;
+    }
+
+    public async Task<bool> Until(ITestcontainersContainer testcontainers, ILogger logger)
+    {
+        if (++_tryCount > _maxCallCount)
+        {
+            throw new TimeoutException($"Number of failed operations exceeded max count ({_maxCallCount}).");
+        }
+
+        return await _operation();
+    }
+}

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -4,6 +4,7 @@
 
     <PackageReference Include="Google.Protobuf" Version="3.21.5" />
     <PackageReference Include="Grpc.Tools" Version="2.48.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/test/IntegrationTests/SqlServerCollection.cs
+++ b/test/IntegrationTests/SqlServerCollection.cs
@@ -87,7 +87,8 @@ public class SqlServerFixture : IAsyncLifetime
     {
         try
         {
-            using (var connection = new SqlConnection(GetConnectionString()))
+            string connectionString = $"Server=127.0.0.1,{Port};User=sa;Password={Password};TrustServerCertificate=True;";
+            using (var connection = new SqlConnection(connectionString))
             {
                 connection.Open();
                 return true;
@@ -100,10 +101,5 @@ public class SqlServerFixture : IAsyncLifetime
 
             return false;
         }
-    }
-
-    private string GetConnectionString()
-    {
-        return $"Server=127.0.0.1,{Port};User=sa;Password={Password};TrustServerCertificate=True;";
     }
 }

--- a/test/IntegrationTests/SqlServerCollection.cs
+++ b/test/IntegrationTests/SqlServerCollection.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -94,6 +95,9 @@ public class SqlServerFixture : IAsyncLifetime
         }
         catch
         {
+            // Slow down next connection attempt
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+
             return false;
         }
     }


### PR DESCRIPTION
## Why

Fixes #970

## What

Stabilizes tests by waiting for first successful connection.