### PR TITLE
Use PackageReference with ExcludeAssets instead of PackageDownload

### DIFF
--- a/build/nuke/_build.csproj
+++ b/build/nuke/_build.csproj
@@ -12,10 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="6.2.1" />
+    <PackageReference Include="Nuget.CommandLine" Version="6.2.1" ExcludeAssets="all" />
   </ItemGroup>
   
-  <ItemGroup>
-    <PackageDownload Include="Nuget.CommandLine" Version="[6.2.1]" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION

## Why

<!-- Explain why the changes are needed.  -->

Fixes #1130 

## What

Use PackageReference with ExcludeAssets instead of PackageDownload to leverage Dependabot.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
