### PR TITLE
Dependabot - Ignore updates for main projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "MySql.Data"
+      - dependency-name: "StackExchange.Redis"
 
   - package-ecosystem: nuget
     directory: /src/OpenTelemetry.AutoInstrumentation.AdditionalDeps


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #971

## What

Dependabot - Ignore updates for main projects
 - MySql.Data
 - StackExchange.Redis

 It will be updated for the testing applications only.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
