### PR TITLE
Revert "Bump Pipelines.Sockets.Unofficial from 2.1.16 to 2.2.2 in /test/IntegrationTests"

### DIFF
--- a/src/CommonExcludedAssets.props
+++ b/src/CommonExcludedAssets.props
@@ -3,7 +3,7 @@
     <!-- StackExchange.Redis is required by OpenTelemetry.Instrumentation.StackExchangeRedis. ExcludeAssets="all" prevents copying it to the output -->
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" ExcludeAssets="all" />
     <!-- Pipelines.Sockets.Unofficial is tranistive dependency required by OpenTelemetry.Instrumentation.StackExchangeRedis. ExcludeAssets="all" prevents copying it to the output -->
-    <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.2.2" ExcludeAssets="all" />
+    <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.1.16" ExcludeAssets="all" />
     <!-- MySql.Data is required by OpenTelemetry.Instrumentation.MySqlData. ExcludeAssets="all" prevents copying it to the output -->
     <PackageReference Include="MySql.Data" Version="6.10.7" ExcludeAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-dotnet-instrumentation#1160