### PR TITLE
Extended support for StackExchange.Redis v.2.6.66+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Extend StackExchange.Redis traces instrumentation for versions 2.6.66+.
+
 ## [0.3.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.3.0-beta.1)
 
 This release add various new instrumentations and more propagation options.

--- a/integrations.json
+++ b/integrations.json
@@ -187,6 +187,32 @@
         "target": {
           "assembly": "StackExchange.Redis",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
+          "method": "ConnectImpl",
+          "signature_types": [
+            "StackExchange.Redis.ConnectionMultiplexer",
+            "StackExchange.Redis.ConfigurationOptions",
+            "System.IO.TextWriter",
+            "System.Nullable`1[StackExchange.Redis.ServerType]",
+            "StackExchange.Redis.EndPointCollection"
+          ],
+          "minimum_major": 2,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 2,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "OpenTelemetry.AutoInstrumentation",
+          "type": "OpenTelemetry.AutoInstrumentation.Instrumentations.StackExchangeRedis.StackExchangeRedisIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "StackExchange.Redis",
+          "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ConnectImplAsync",
           "signature_types": [
             "System.Threading.Tasks.Task`1[StackExchange.Redis.ConnectionMultiplexer]",

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisConstants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisConstants.cs
@@ -30,7 +30,8 @@ internal static class StackExchangeRedisConstants
     public const string ConfigurationOptionsTypeName = "StackExchange.Redis.ConfigurationOptions";
     public const string TextWriterTypeName = "System.IO.TextWriter";
     public const string TaskConnectionMultiplexerTypeName = $"System.Threading.Tasks.Task`1[{ConnectionMultiplexerTypeName}]";
-    public const string NullableServerType = $"System.Nullable`1[{ServerTypeTypeName}]";
+    public const string NullableServerTypeTypeName = $"System.Nullable`1[{ServerTypeTypeName}]";
+    public const string EndPointCollectionTypeName = "StackExchange.Redis.EndPointCollection";
 
     public const string ConnectImplMethodName = "ConnectImpl";
     public const string ConnectImplAsyncMethodName = "ConnectImplAsync";

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisIntegration.cs
@@ -42,12 +42,21 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.StackExchangeRedis;
     MinimumVersion = StackExchangeRedisConstants.MinimumVersion,
     MaximumVersion = StackExchangeRedisConstants.MaximumVersion,
     IntegrationName = StackExchangeRedisConstants.IntegrationName)]
-[InstrumentMethod(// releases 2.5.61+
+[InstrumentMethod(// releases 2.5.61 - 2.6.48
     AssemblyName = StackExchangeRedisConstants.AssemblyName,
     TypeName = StackExchangeRedisConstants.ConnectionMultiplexerTypeName,
     MethodName = StackExchangeRedisConstants.ConnectImplMethodName,
     ReturnTypeName = StackExchangeRedisConstants.ConnectionMultiplexerTypeName,
-    ParameterTypeNames = new[] { StackExchangeRedisConstants.ConfigurationOptionsTypeName, StackExchangeRedisConstants.TextWriterTypeName, StackExchangeRedisConstants.NullableServerType },
+    ParameterTypeNames = new[] { StackExchangeRedisConstants.ConfigurationOptionsTypeName, StackExchangeRedisConstants.TextWriterTypeName, StackExchangeRedisConstants.NullableServerTypeTypeName },
+    MinimumVersion = StackExchangeRedisConstants.MinimumVersion,
+    MaximumVersion = StackExchangeRedisConstants.MaximumVersion,
+    IntegrationName = StackExchangeRedisConstants.IntegrationName)]
+[InstrumentMethod(// releases 2.6.66+
+    AssemblyName = StackExchangeRedisConstants.AssemblyName,
+    TypeName = StackExchangeRedisConstants.ConnectionMultiplexerTypeName,
+    MethodName = StackExchangeRedisConstants.ConnectImplMethodName,
+    ReturnTypeName = StackExchangeRedisConstants.ConnectionMultiplexerTypeName,
+    ParameterTypeNames = new[] { StackExchangeRedisConstants.ConfigurationOptionsTypeName, StackExchangeRedisConstants.TextWriterTypeName, StackExchangeRedisConstants.NullableServerTypeTypeName, StackExchangeRedisConstants.EndPointCollectionTypeName },
     MinimumVersion = StackExchangeRedisConstants.MinimumVersion,
     MaximumVersion = StackExchangeRedisConstants.MaximumVersion,
     IntegrationName = StackExchangeRedisConstants.IntegrationName)]

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisIntegrationAsync.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisIntegrationAsync.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.StackExchangeRedis;
     TypeName = StackExchangeRedisConstants.ConnectionMultiplexerTypeName,
     MethodName = StackExchangeRedisConstants.ConnectImplAsyncMethodName,
     ReturnTypeName = StackExchangeRedisConstants.TaskConnectionMultiplexerTypeName,
-    ParameterTypeNames = new[] { StackExchangeRedisConstants.ConfigurationOptionsTypeName, StackExchangeRedisConstants.TextWriterTypeName, StackExchangeRedisConstants.NullableServerType },
+    ParameterTypeNames = new[] { StackExchangeRedisConstants.ConfigurationOptionsTypeName, StackExchangeRedisConstants.TextWriterTypeName, StackExchangeRedisConstants.NullableServerTypeTypeName },
     MinimumVersion = StackExchangeRedisConstants.MinimumVersion,
     MaximumVersion = StackExchangeRedisConstants.MaximumVersion,
     IntegrationName = StackExchangeRedisConstants.IntegrationName)]


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #1172

Issue introduced by https://github.com/StackExchange/StackExchange.Redis/pull/2242

## What

Extended support for StackExchange.Redis v.2.6.66+ for `ConnectImpl` method.

## Tests

CI + local tests with version 2.6.66+
Tests will be executed also in scope of #1171 

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
