### PR TITLE
Bump OTel Core Components to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.3.0-beta.1...HEAD)
 
+This release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
+
+- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
+  [`1.3.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.1)
+- `System.Diagnostics.DiagnosticSource`: [`6.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/6.0.0)
+
 ### Added
 
 - Add support for Alpine.
@@ -16,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Extend StackExchange.Redis traces instrumentation for versions 2.6.66+.
+- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
+  [`1.3.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.1)
 
 ## [0.3.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.3.0-beta.1)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ OpenTelemetry .NET Automatic Instrumentation is built on top of
 [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
-[`1.3.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.0)
+[`1.3.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.1)
 - `System.Diagnostics.DiagnosticSource`: [`6.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/6.0.0)
   referencing `System.Runtime.CompilerServices.Unsafe`: [`6.0.0`](https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/6.0.0)
 

--- a/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
+++ b/examples/AspNetCoreMvc/Examples.AspNetCoreMvc.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
+++ b/examples/ConsoleApp.SelfBootstrap/Examples.ConsoleApp.SelfBootstrap.csproj
@@ -10,14 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.5" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.4" Condition="'$(TargetFramework)' != 'net462'" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Shims.OpenTracing" Version="1.0.0-rc9.4" />
   </ItemGroup>
   

--- a/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
+++ b/examples/Vendor.Distro/Examples.Vendor.Distro.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.3.0-rc.2" />
   </ItemGroup>
   

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Propagators" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.0.0" />

--- a/test/test-applications/integrations/TestApplication.Plugins/TestApplication.Plugins.csproj
+++ b/test/test-applications/integrations/TestApplication.Plugins/TestApplication.Plugins.csproj
@@ -4,7 +4,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Keep in sync with OTel SDK releases.

## What

Bump OTel Core Components to 1.3.1

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
