### PR TITLE
Add ASPNETCORE_HOSTINGSTARTUPASSEMBLIES to instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,7 @@ sudo chmod a+rwx /var/log/opentelemetry/dotnet
 Before running your application, set the following environment variables:
 
 ```env
+ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper
 COR_ENABLE_PROFILING=1
 COR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
 CORECLR_ENABLE_PROFILING=1


### PR DESCRIPTION
## Why

Followup  #1214 

## What

Add info to set `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES`  in the getting started instructions.

## Tests

Manual. I think I had also to set `OTEL_DOTNET_AUTO_LOGS_PARSE_STATE_VALUES` or/and `OTEL_DOTNET_AUTO_LOGS_INCLUDE_FORMATTED_MESSAGE` to `true`. So that it works with OTel Collector. _I am going to double-check it tomorrow, but I do not think it is a blocker_

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
