### PR TITLE
Facilitate flaky test resolution

### DIFF
--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -16,7 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: [ windows-2022, ubuntu-20.04, macos-11 ]
+        include:
+          - machine: windows-2022
+            containers: windows
+          - machine: ubuntu-20.04
+            containers: linux
+          - machine: macos-11
+            containers: none
     runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v3.0.2
@@ -25,45 +31,7 @@ jobs:
           dotnet-version: | 
             3.1.x
             6.0.x
-
-      - name: Windows - build and test ${{ github.event.inputs.testName }} ${{ github.event.inputs.count }} times
-        run: |
-          ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
-          if ($global:LASTEXITCODE -ne 0) { 
-            exit $global:LASTEXITCODE
-          }
-          
-          for ($i=1; $i -le ${{ github.event.inputs.count }}; $i++) {
-            Write-Host "Execution count: $i"
-            ./build.cmd RunManagedTests --containers windows --test-name "${{ github.event.inputs.testName }}"
-            if ($global:LASTEXITCODE -ne 0) { 
-              exit $global:LASTEXITCODE
-            }
-          }
-        if: ${{ runner.os == 'Windows' }}
-
-      - name: Linux - build and test ${{ github.event.inputs.testName }} ${{ github.event.inputs.count }} times
-        run: |
-          set -e
-          ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
-          
-          for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
-            echo "Execution count: $i"
-            ./build.cmd RunManagedTests --containers linux --test-name "${{ github.event.inputs.testName }}"
-          done
-        if: ${{ runner.os == 'Linux' }}
-      
-      - name: macOS - build and test ${{ github.event.inputs.testName }} ${{ github.event.inputs.count }} times
-        run: |
-          set -e
-          ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
-          
-          for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
-            echo "Execution count: $i"
-            ./build.cmd RunManagedTests --containers none --test-name "${{ github.event.inputs.testName }}"
-          done
-        if: ${{ runner.os == 'macOS' }}
-
+      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-name "${{ github.event.inputs.testName }}" --test-count ${{ github.event.inputs.count }}
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.0
         if: always()

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -1,0 +1,57 @@
+# this workflow can be used to check if given integration test is flaky
+name: verify-test
+
+on:
+  workflow_dispatch:
+    inputs:
+      testName:
+        description: 'Test name'     
+        required: true
+      count:
+        description: 'Test execution count'     
+        default: '20'
+
+jobs:
+  verify-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: [ windows-2022, ubuntu-20.04, macos-11 ]
+    runs-on: ${{ matrix.machine }}
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-dotnet@v2.1.0
+        with:
+          dotnet-version: | 
+            3.1.x
+            6.0.x
+
+      - run: ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
+
+      - run: |
+          for ($i=1; $i -le ${{ github.event.inputs.count }}; $i++) {
+            Write-Host "Execution count: $i"
+            ./build.cmd RunManagedTests --containers windows --test-name ${{ github.event.inputs.testName }}"
+          }
+        if: ${{ runner.os == 'Windows' }}
+
+      - run: |
+          for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
+            echo "Execution count: $i"
+            ./build.cmd RunManagedTests --containers linux --test-name ${{ github.event.inputs.testName }}"
+          done
+        if: ${{ runner.os == 'Linux' }}
+      
+      - run: |
+          for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
+            echo "Execution count: $i"
+            ./build.cmd RunManagedTests --containers none --test-name ${{ github.event.inputs.testName }}"
+          done
+        if: ${{ runner.os == 'macOS' }}
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v3.1.0
+        if: always()
+        with:
+          name: logs-${{ matrix.machine }}
+          path: build_data/profiler-logs/

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -26,7 +26,7 @@ jobs:
             3.1.x
             6.0.x
 
-      - name: Windows - build and test ${{ github.event.inputs.testName }} {{ github.event.inputs.count }} times
+      - name: Windows - build and test ${{ github.event.inputs.testName }} ${{ github.event.inputs.count }} times
         run: |
           ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
           if ($global:LASTEXITCODE -ne 0) { 
@@ -42,7 +42,7 @@ jobs:
           }
         if: ${{ runner.os == 'Windows' }}
 
-      - name: Linux - build and test ${{ github.event.inputs.testName }} {{ github.event.inputs.count }} times
+      - name: Linux - build and test ${{ github.event.inputs.testName }} ${{ github.event.inputs.count }} times
         run: |
           set -e
           ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
@@ -53,7 +53,7 @@ jobs:
           done
         if: ${{ runner.os == 'Linux' }}
       
-      - name: macOS - build and test ${{ github.event.inputs.testName }} {{ github.event.inputs.count }} times
+      - name: macOS - build and test ${{ github.event.inputs.testName }} ${{ github.event.inputs.count }} times
         run: |
           set -e
           ./build.cmd BuildTracer ManagedTests --skip RunManagedTests

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -31,21 +31,21 @@ jobs:
       - run: |
           for ($i=1; $i -le ${{ github.event.inputs.count }}; $i++) {
             Write-Host "Execution count: $i"
-            ./build.cmd RunManagedTests --containers windows --test-name ${{ github.event.inputs.testName }}"
+            ./build.cmd RunManagedTests --containers windows --test-name "${{ github.event.inputs.testName }}"
           }
         if: ${{ runner.os == 'Windows' }}
 
       - run: |
           for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
             echo "Execution count: $i"
-            ./build.cmd RunManagedTests --containers linux --test-name ${{ github.event.inputs.testName }}"
+            ./build.cmd RunManagedTests --containers linux --test-name "${{ github.event.inputs.testName }}"
           done
         if: ${{ runner.os == 'Linux' }}
       
       - run: |
           for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
             echo "Execution count: $i"
-            ./build.cmd RunManagedTests --containers none --test-name ${{ github.event.inputs.testName }}"
+            ./build.cmd RunManagedTests --containers none --test-name "${{ github.event.inputs.testName }}"
           done
         if: ${{ runner.os == 'macOS' }}
 

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -26,23 +26,38 @@ jobs:
             3.1.x
             6.0.x
 
-      - run: ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
-
-      - run: |
+      - name: Windows - build and test ${{ github.event.inputs.testName }} {{ github.event.inputs.count }} times
+        run: |
+          ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
+          if ($global:LASTEXITCODE -ne 0) { 
+            exit $global:LASTEXITCODE
+          }
+          
           for ($i=1; $i -le ${{ github.event.inputs.count }}; $i++) {
             Write-Host "Execution count: $i"
             ./build.cmd RunManagedTests --containers windows --test-name "${{ github.event.inputs.testName }}"
+            if ($global:LASTEXITCODE -ne 0) { 
+              exit $global:LASTEXITCODE
+            }
           }
         if: ${{ runner.os == 'Windows' }}
 
-      - run: |
+      - name: Linux - build and test ${{ github.event.inputs.testName }} {{ github.event.inputs.count }} times
+        run: |
+          set -e
+          ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
+          
           for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
             echo "Execution count: $i"
             ./build.cmd RunManagedTests --containers linux --test-name "${{ github.event.inputs.testName }}"
           done
         if: ${{ runner.os == 'Linux' }}
       
-      - run: |
+      - name: macOS - build and test ${{ github.event.inputs.testName }} {{ github.event.inputs.count }} times
+        run: |
+          set -e
+          ./build.cmd BuildTracer ManagedTests --skip RunManagedTests
+          
           for (( i=1; i<=${{ github.event.inputs.count }}; i++ )); do
             echo "Execution count: $i"
             ./build.cmd RunManagedTests --containers none --test-name "${{ github.event.inputs.testName }}"

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -298,6 +298,7 @@ partial class Build
             DotNetTest(config => config
                 .SetConfiguration(BuildConfiguration)
                 .SetTargetPlatformAnyCPU()
+                .SetFilter(TestName)
                 .EnableNoRestore()
                 .EnableNoBuild()
                 .CombineWith(unitTestProjects, (s, project) => s
@@ -317,7 +318,7 @@ partial class Build
             DotNetTest(config => config
                 .SetConfiguration(BuildConfiguration)
                 .SetTargetPlatform(Platform)
-                .SetFilter(ContainersTestFilter())
+                .SetFilter(FilterExpression(TestName, ContainersTestFilter()))
                 .EnableTrxLogOutput(GetResultsDirectory(project))
                 .SetProjectFile(project)
                 .EnableNoRestore()
@@ -414,7 +415,7 @@ partial class Build
             "Initialize_WithDefaultFlag_CreatesTracerProvider",
             "Initialize_WithEnabledFlag_CreatesTracerProvider",
             "Initialize_WithPreviouslyCreatedTracerProvider_WorksCorrectly"
-        }.Select(name => $"{testPrefix}.{name}");
+        }.Select(name => $"FullyQualifiedName~{testPrefix}.{name}");
 
         foreach (var testName in testNames)
         {
@@ -425,7 +426,7 @@ partial class Build
                 .EnableNoBuild()
                 .EnableTrxLogOutput(GetResultsDirectory(project))
                 .SetProjectFile(project)
-                .SetFilter(testName)
+                .SetFilter(FilterExpression(TestName, testName))
                 .SetProcessEnvironmentVariable("BOOSTRAPPING_TESTS", "true"));
         }
     }

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -295,15 +295,18 @@ partial class Build
                 Solution.GetProject(Projects.Tests.AutoInstrumentationTests)
             };
 
-            DotNetTest(config => config
-                .SetConfiguration(BuildConfiguration)
-                .SetTargetPlatformAnyCPU()
-                .SetFilter(TestName)
-                .EnableNoRestore()
-                .EnableNoBuild()
-                .CombineWith(unitTestProjects, (s, project) => s
-                    .EnableTrxLogOutput(GetResultsDirectory(project))
-                    .SetProjectFile(project)), degreeOfParallelism: 4);
+            for (int i = 0; i < TestCount; i++)
+            {
+                DotNetTest(config => config
+                    .SetConfiguration(BuildConfiguration)
+                    .SetTargetPlatformAnyCPU()
+                    .SetFilter(TestNameFilter())
+                    .EnableNoRestore()
+                    .EnableNoBuild()
+                    .CombineWith(unitTestProjects, (s, project) => s
+                        .EnableTrxLogOutput(GetResultsDirectory(project))
+                        .SetProjectFile(project)), degreeOfParallelism: 4); 
+            }
         });
 
     Target RunManagedIntegrationTests => _ => _
@@ -315,17 +318,20 @@ partial class Build
 
             IEnumerable<TargetFramework> frameworks = IsWin ? TestFrameworks : TestFrameworks.ExceptNetFramework();
 
-            DotNetTest(config => config
-                .SetConfiguration(BuildConfiguration)
-                .SetTargetPlatform(Platform)
-                .SetFilter(FilterExpression(TestName, ContainersTestFilter()))
-                .EnableTrxLogOutput(GetResultsDirectory(project))
-                .SetProjectFile(project)
-                .EnableNoRestore()
-                .EnableNoBuild()
-                .CombineWith(frameworks, (s, fx) => s
-                    .SetFramework(fx)
-                ));
+            for (int i = 0; i < TestCount; i++)
+            {
+                DotNetTest(config => config
+                    .SetConfiguration(BuildConfiguration)
+                    .SetTargetPlatform(Platform)
+                    .SetFilter(AndFilter(TestNameFilter(), ContainersFilter()))
+                    .EnableTrxLogOutput(GetResultsDirectory(project))
+                    .SetProjectFile(project)
+                    .EnableNoRestore()
+                    .EnableNoBuild()
+                    .CombineWith(frameworks, (s, fx) => s
+                        .SetFramework(fx)
+                    ));
+            }
         });
 
     Target CopyAdditionalDeps => _ => _
@@ -417,17 +423,20 @@ partial class Build
             "Initialize_WithPreviouslyCreatedTracerProvider_WorksCorrectly"
         }.Select(name => $"FullyQualifiedName~{testPrefix}.{name}");
 
-        foreach (var testName in testNames)
+        for (int i = 0; i < TestCount; i++)
         {
-            DotNetTest(config => config
-                .SetConfiguration(BuildConfiguration)
-                .SetTargetPlatformAnyCPU()
-                .EnableNoRestore()
-                .EnableNoBuild()
-                .EnableTrxLogOutput(GetResultsDirectory(project))
-                .SetProjectFile(project)
-                .SetFilter(FilterExpression(TestName, testName))
-                .SetProcessEnvironmentVariable("BOOSTRAPPING_TESTS", "true"));
+            foreach (var testName in testNames)
+            {
+                DotNetTest(config => config
+                    .SetConfiguration(BuildConfiguration)
+                    .SetTargetPlatformAnyCPU()
+                    .EnableNoRestore()
+                    .EnableNoBuild()
+                    .EnableTrxLogOutput(GetResultsDirectory(project))
+                    .SetProjectFile(project)
+                    .SetFilter(AndFilter(TestNameFilter(), testName))
+                    .SetProcessEnvironmentVariable("BOOSTRAPPING_TESTS", "true"));
+            }
         }
     }
 }

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -305,7 +305,7 @@ partial class Build
                     .EnableNoBuild()
                     .CombineWith(unitTestProjects, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
-                        .SetProjectFile(project)), degreeOfParallelism: 4); 
+                        .SetProjectFile(project)), degreeOfParallelism: 4);
             }
         });
 

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -25,6 +25,8 @@ partial class Build : NukeBuild
     const string ContainersLinux = "linux";
     const string ContainersWindows = "windows";
 
+    [Parameter("Test name to be run. Optional.")]
+    readonly string TestName;
 
     [Parameter("Windows Server Core container version. Use it if your Windows does not support the default value. Default is 'ltsc2022'")]
     readonly string WindowsContainerVersion = "ltsc2022";
@@ -119,5 +121,30 @@ partial class Build : NukeBuild
             default:
                 throw new InvalidOperationException($"Container={Containers} is not supported");
         }
+    }
+
+    string FilterExpression(params string[] args)
+    {
+        var result = string.Empty;
+        var first = true;
+
+        foreach (var arg in args)
+        {
+            if (string.IsNullOrEmpty(arg))
+            {
+                continue;
+            }
+
+            if (first)
+            {
+                result = arg;
+                first = true;
+                continue;
+            }
+
+            result += "&" + arg;
+        }
+
+        return result;
     }
 }

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -133,7 +133,7 @@ partial class Build : NukeBuild
             return null;
         }
 
-        return "FullyQualifiedName~" + TestName; 
+        return "FullyQualifiedName~" + TestName;
     }
 
     string AndFilter(params string[] args)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -171,6 +171,10 @@ are used to test against higher library versions when they are released.
 > `TestApplication.AspNet` references the latest versions
 > of the ASP.NET packages.
 
+To verify that a test is not flaky,
+you can [manually trigger](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
+the [verify-test.yml](../.github/workflows/verify-test.yml) GitHub workflow.
+
 ## Debug the .NET runtime on Linux
 
 - [Requirements](https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/linux-requirements.md)


### PR DESCRIPTION
## Why

Checking if a test is flaky is not user-friendly.

## What

- Add `TestName` Nuke parameter to enable running a single .NET test (unit + integration)
- Add `TestCount` Nuke parameter to enable running .NET tests (unit + integration) multiple times
- Add `verify-test` GH workflow that can be used to check if a given test is flaky

## Tests

The new GH workflow:
- Linux - `SqlClientTests`: https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3059880715
- Windows - `AspNetTests`: https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3059881973
- All: - `SmokeTests`: https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3059882944

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
