### PR TITLE
Stabilize SdkSelfDiagnosticsEventListenerTests

### DIFF
--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Diagnostics/SdkSelfDiagnosticsEventListenerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Diagnostics/SdkSelfDiagnosticsEventListenerTests.cs
@@ -32,7 +32,7 @@ public class SdkSelfDiagnosticsEventListenerTests
     {
         var testSink = new TestSink();
         var logger = new Logger(testSink);
-        var listener = new SdkSelfDiagnosticsEventListener(EventLevel.Error, logger);
+        using var listener = new SdkSelfDiagnosticsEventListener(EventLevel.Error, logger);
 
         // Emitting a Verbose event. Or any EventSource event with lower severity than Error.
         AspNetTelemetryEventSource.Log.ActivityRestored("123");
@@ -46,7 +46,7 @@ public class SdkSelfDiagnosticsEventListenerTests
     {
         var testSink = new TestSink();
         var logger = new Logger(testSink);
-        var listener = new SdkSelfDiagnosticsEventListener(EventLevel.Verbose, logger);
+        using var listener = new SdkSelfDiagnosticsEventListener(EventLevel.Verbose, logger);
 
         // Emitting a Verbose event. Or any EventSource event with lower severity than Error.
         AspNetTelemetryEventSource.Log.ActivityRestored("123");


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #1154 

`SdkSelfDiagnosticsEventListenerTests` are flaky.

Issue occurs because two instances of EventSource with the same guid was created.
One of them was in the test code based, the second one from the https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.3.1/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs#L31

Guids are calculated based on the event source name if not defined manually.

## What

Change event source names used in our tests.


## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
