### PR TITLE
Add waiting for server in WCF tests

### DIFF
--- a/test/IntegrationTests/WcfTestsBase.cs
+++ b/test/IntegrationTests/WcfTestsBase.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -41,6 +42,7 @@ public abstract class WcfTestsBase : TestHelper, IDisposable
 
         var serverHelper = new WcfServerTestHelper(Output);
         _serverProcess = serverHelper.RunWcfServer(agent.Port);
+        await WaitForServer();
 
         RunTestApplication(agent.Port);
 
@@ -71,5 +73,26 @@ public abstract class WcfTestsBase : TestHelper, IDisposable
         Output.WriteLine($"ProcessId: " + _serverProcess.Process.Id);
         Output.WriteLine($"Exit Code: " + _serverProcess.Process.ExitCode);
         Output.WriteResult(_serverProcess);
+    }
+
+    private async Task WaitForServer()
+    {
+        using var tcpClient = new TcpClient();
+        const int tcpPort = 9090;
+
+        while (true)
+        {
+            try
+            {
+                await tcpClient.ConnectAsync("127.0.0.1", tcpPort);
+                Output.WriteLine("WCF Server is running.");
+                return;
+            }
+            catch (Exception)
+            {
+                Output.WriteLine("Waiting for WCF Server to open ports.");
+                await Task.Delay(500);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why

WCF tests fail randomly.

## What

Wait for WCF Server to open TCP port before starting test application.

## Tests

N/A

## Checklist

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
