### PR TITLE
Use TargetFrameworks instead of TargetFramework

### DIFF
--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION


## Why

This property is defined in Integrations.props so we should overwrite it.

Fixes #

## What

Use TargetFrameworks instead of TargetFramework

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
