### PR TITLE
Prometheus.Tests - log test app output

### DIFF
--- a/test/IntegrationTests/Helpers/OutputHelper.cs
+++ b/test/IntegrationTests/Helpers/OutputHelper.cs
@@ -25,16 +25,18 @@ public static class OutputHelper
     {
         processHelper.Drain();
 
-        string standardOutput = processHelper.StandardOutput;
+        var standardOutput = processHelper.StandardOutput;
         if (!string.IsNullOrWhiteSpace(standardOutput))
         {
-            outputHelper.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+            outputHelper.WriteLine("StandardOutput:");
+            outputHelper.WriteLine(standardOutput);
         }
 
-        string standardError = processHelper.ErrorOutput;
+        var standardError = processHelper.ErrorOutput;
         if (!string.IsNullOrWhiteSpace(standardError))
         {
-            outputHelper.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+            outputHelper.WriteLine("StandardError:");
+            outputHelper.WriteLine(standardError);
         }
     }
 }

--- a/test/IntegrationTests/Helpers/ProcessHelper.cs
+++ b/test/IntegrationTests/Helpers/ProcessHelper.cs
@@ -31,10 +31,10 @@ public class ProcessHelper : IDisposable
     private readonly ManualResetEventSlim _outputMutex = new();
     private readonly StringBuilder _outputBuffer = new();
     private readonly StringBuilder _errorBuffer = new();
+    private readonly object _outputLock = new();
 
     private bool _isStdOutputDrained;
     private bool _isErrOutputDrained;
-    private object _outputLock = new object();
 
     public ProcessHelper(Process process)
     {

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -220,8 +220,8 @@ public abstract class TestHelper
             process.Kill();
         }
 
-        Output.WriteLine($"ProcessId: " + process.Id);
-        Output.WriteLine($"Exit Code: " + process.ExitCode);
+        Output.WriteLine("ProcessId: " + process.Id);
+        Output.WriteLine("Exit Code: " + process.ExitCode);
         Output.WriteResult(helper);
 
         processTimeout.Should().BeFalse("Test application timed out");

--- a/test/IntegrationTests/WcfTestsBase.cs
+++ b/test/IntegrationTests/WcfTestsBase.cs
@@ -70,8 +70,8 @@ public abstract class WcfTestsBase : TestHelper, IDisposable
             _serverProcess.Process.Kill();
         }
 
-        Output.WriteLine($"ProcessId: " + _serverProcess.Process.Id);
-        Output.WriteLine($"Exit Code: " + _serverProcess.Process.ExitCode);
+        Output.WriteLine("ProcessId: " + _serverProcess.Process.Id);
+        Output.WriteLine("Exit Code: " + _serverProcess.Process.ExitCode);
         Output.WriteResult(_serverProcess);
     }
 

--- a/test/test-applications/integrations/TestApplication.Smoke/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Smoke/Program.cs
@@ -37,14 +37,14 @@ public class Program
         // The "LONG_RUNNING" environment variable is used by tests that access/receive
         // data that takes time to be produced.
         var longRunning = Environment.GetEnvironmentVariable("LONG_RUNNING");
-        while (longRunning == "true")
+        if (longRunning == "true")
         {
             // In this case it is necessary to ensure that the test has a chance to read the
             // expected data, only by keeping the application alive for some time that can
             // be ensured. Anyway, tests that set "LONG_RUNNING" env var to true are expected
             // to kill the process directly.
             Console.WriteLine("LONG_RUNNING is true, waiting for process to be killed...");
-            Console.ReadLine();
+            Process.GetCurrentProcess().WaitForExit();
         }
     }
 


### PR DESCRIPTION
## Why

To have better visibility what hapend on test app

Fixes #

## What

Log application test output to test output.
Wait for sigkill instead of looping in the while (it was producing a lot of logs while executing on GH).
Avoid additional allocation in the output helper. Together with previous issue it leads to OutOfMemoryException.

## Tests

Manual tests.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
