### PR TITLE
Add test project filter to verify test workflow

### DIFF
--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -34,7 +34,7 @@ jobs:
           dotnet-version: | 
             3.1.x
             6.0.x
-      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project-filter "${{ github.event.inputs.testProjectFilter }}"--test-name "${{ github.event.inputs.testName }}" --test-count ${{ github.event.inputs.count }}
+      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project-filter "${{ github.event.inputs.testProjectFilter }}" --test-name "${{ github.event.inputs.testName }}" --test-count ${{ github.event.inputs.count }}
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.0
         if: always()

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -4,11 +4,14 @@ name: verify-test
 on:
   workflow_dispatch:
     inputs:
+      testProjectFilter:
+        description: String that partially matches test projects to run. Defaults to all test projects.
+        required: false
       testName:
-        description: 'Test name'     
+        description: 'String that partially matches the tests to run'
         required: true
       count:
-        description: 'Test execution count'     
+        description: 'Test execution count'
         default: '20'
 
 jobs:
@@ -31,7 +34,7 @@ jobs:
           dotnet-version: | 
             3.1.x
             6.0.x
-      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-name "${{ github.event.inputs.testName }}" --test-count ${{ github.event.inputs.count }}
+      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project-filter "${{ github.event.inputs.testProjectFilter }}"--test-name "${{ github.event.inputs.testName }}" --test-count ${{ github.event.inputs.count }}
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.0
         if: always()

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -295,10 +295,10 @@ partial class Build
                 Solution.GetProject(Projects.Tests.AutoInstrumentationTests)
             };
 
-            if (!string.IsNullOrWhiteSpace(TestProject))
+            if (!string.IsNullOrWhiteSpace(TestProjectFilter))
             {
                 unitTestProjects = unitTestProjects
-                    .Where(p => p.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
+                    .Where(p => p.Name.Contains(TestProjectFilter, StringComparison.OrdinalIgnoreCase))
                     .ToArray();
                 if (unitTestProjects.Length == 0)
                 {
@@ -326,7 +326,7 @@ partial class Build
         .Executes(() =>
         {
             var project = Solution.GetProject("IntegrationTests");
-            if (!string.IsNullOrWhiteSpace(TestProject) && !project.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(TestProjectFilter) && !project.Name.Contains(TestProjectFilter, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -429,7 +429,7 @@ partial class Build
     private void RunBootstrappingTests()
     {
         var project = Solution.GetProject(Projects.Tests.AutoInstrumentationBootstrappingTests);
-        if (!string.IsNullOrWhiteSpace(TestProject) && !project.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrWhiteSpace(TestProjectFilter) && !project.Name.Contains(TestProjectFilter, StringComparison.OrdinalIgnoreCase))
         {
             // Test project was not selected.
             return;

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -295,6 +295,17 @@ partial class Build
                 Solution.GetProject(Projects.Tests.AutoInstrumentationTests)
             };
 
+            if (!string.IsNullOrWhiteSpace(TestProject))
+            {
+                unitTestProjects = unitTestProjects
+                    .Where(p => p.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+                if (unitTestProjects.Length == 0)
+                {
+                    return;
+                }
+            }
+
             for (int i = 0; i < TestCount; i++)
             {
                 DotNetTest(config => config
@@ -315,6 +326,10 @@ partial class Build
         .Executes(() =>
         {
             var project = Solution.GetProject("IntegrationTests");
+            if (!string.IsNullOrWhiteSpace(TestProject) && !project.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
 
             IEnumerable<TargetFramework> frameworks = IsWin ? TestFrameworks : TestFrameworks.ExceptNetFramework();
 
@@ -414,6 +429,11 @@ partial class Build
     private void RunBootstrappingTests()
     {
         var project = Solution.GetProject(Projects.Tests.AutoInstrumentationBootstrappingTests);
+        if (!string.IsNullOrWhiteSpace(TestProject) && !project.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
+        {
+            // Test project was not selected.
+            return;
+        }
 
         const string testPrefix = "OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests.InstrumentationTests";
         var testNames = new[] {

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -25,6 +25,9 @@ partial class Build : NukeBuild
     const string ContainersLinux = "linux";
     const string ContainersWindows = "windows";
 
+    [Parameter("Test project to be run. Optional, default matches all test projects. The project will be selected if the string is part of its name.")]
+    readonly string TestProject = "";
+
     [Parameter("Test name to be run. Optional")]
     readonly string TestName;
 

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -25,8 +25,8 @@ partial class Build : NukeBuild
     const string ContainersLinux = "linux";
     const string ContainersWindows = "windows";
 
-    [Parameter("Test project to be run. Optional, default matches all test projects. The project will be selected if the string is part of its name.")]
-    readonly string TestProject = "";
+    [Parameter("Test projects to be run. Optional, default matches all test projects. The project will be selected if the string is part of its name.")]
+    readonly string TestProjectFilter = "";
 
     [Parameter("Test name to be run. Optional")]
     readonly string TestName;

--- a/test/test-applications/integrations/TestApplication.Smoke/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Smoke/Program.cs
@@ -29,31 +29,22 @@ public class Program
 
     public static void Main(string[] args)
     {
-        try
-        {
-            ConsoleHelper.WriteSplashScreen(args);
+        ConsoleHelper.WriteSplashScreen(args);
 
-            EmitTraces();
-            EmitMetrics();
+        EmitTraces();
+        EmitMetrics();
 
-            // The "LONG_RUNNING" environment variable is used by tests that access/receive
-            // data that takes time to be produced.
-            var longRunning = Environment.GetEnvironmentVariable("LONG_RUNNING");
-            if (longRunning == "true")
-            {
-                // In this case it is necessary to ensure that the test has a chance to read the
-                // expected data, only by keeping the application alive for some time that can
-                // be ensured. Anyway, tests that set "LONG_RUNNING" env var to true are expected
-                // to kill the process directly.
-                Console.WriteLine($"[{DateTime.Now}] LONG_RUNNING is true, waiting for process to be killed...");
-                Process.GetCurrentProcess().WaitForExit();
-                Console.WriteLine($"[{DateTime.Now}] exiting...");
-            }
-        }
-        catch (Exception ex)
+        // The "LONG_RUNNING" environment variable is used by tests that access/receive
+        // data that takes time to be produced.
+        var longRunning = Environment.GetEnvironmentVariable("LONG_RUNNING");
+        if (longRunning == "true")
         {
-            Console.WriteLine($"Main Exception: [{DateTime.Now}] {ex}");
-            throw;
+            // In this case it is necessary to ensure that the test has a chance to read the
+            // expected data, only by keeping the application alive for some time that can
+            // be ensured. Anyway, tests that set "LONG_RUNNING" env var to true are expected
+            // to kill the process directly.
+            Console.WriteLine("LONG_RUNNING is true, waiting for process to be killed...");
+            Process.GetCurrentProcess().WaitForExit();
         }
     }
 
@@ -72,29 +63,18 @@ public class Program
         try
         {
             client.GetStringAsync("http://httpstat.us/200").Wait();
-            Console.WriteLine($"EmitTraces: [{DateTime.Now}] GetStringAsync completed");
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"EmitTraces Exception: [{DateTime.Now}] {ex}");
-            throw;
+            Console.WriteLine(ex);
         }
     }
 
     private static void EmitMetrics()
     {
-        try
-        {
-            var myMeter = new Meter(SourceName, "1.0");
-            var myFruitCounter = myMeter.CreateCounter<int>("MyFruitCounter");
+        var myMeter = new Meter(SourceName, "1.0");
+        var myFruitCounter = myMeter.CreateCounter<int>("MyFruitCounter");
 
-            myFruitCounter.Add(1, new KeyValuePair<string, object>("name", "apple"));
-            Console.WriteLine("EmitMetrics: [{DateTime.Now}] Counter.Add completed");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"EmitMetrics Exception: [{DateTime.Now}] {ex}");
-            throw;
-        }
+        myFruitCounter.Add(1, new KeyValuePair<string, object>("name", "apple"));
     }
 }

--- a/test/test-applications/integrations/TestApplication.Smoke/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Smoke/Program.cs
@@ -29,22 +29,31 @@ public class Program
 
     public static void Main(string[] args)
     {
-        ConsoleHelper.WriteSplashScreen(args);
-
-        EmitTraces();
-        EmitMetrics();
-
-        // The "LONG_RUNNING" environment variable is used by tests that access/receive
-        // data that takes time to be produced.
-        var longRunning = Environment.GetEnvironmentVariable("LONG_RUNNING");
-        if (longRunning == "true")
+        try
         {
-            // In this case it is necessary to ensure that the test has a chance to read the
-            // expected data, only by keeping the application alive for some time that can
-            // be ensured. Anyway, tests that set "LONG_RUNNING" env var to true are expected
-            // to kill the process directly.
-            Console.WriteLine("LONG_RUNNING is true, waiting for process to be killed...");
-            Process.GetCurrentProcess().WaitForExit();
+            ConsoleHelper.WriteSplashScreen(args);
+
+            EmitTraces();
+            EmitMetrics();
+
+            // The "LONG_RUNNING" environment variable is used by tests that access/receive
+            // data that takes time to be produced.
+            var longRunning = Environment.GetEnvironmentVariable("LONG_RUNNING");
+            if (longRunning == "true")
+            {
+                // In this case it is necessary to ensure that the test has a chance to read the
+                // expected data, only by keeping the application alive for some time that can
+                // be ensured. Anyway, tests that set "LONG_RUNNING" env var to true are expected
+                // to kill the process directly.
+                Console.WriteLine($"[{DateTime.Now}] LONG_RUNNING is true, waiting for process to be killed...");
+                Process.GetCurrentProcess().WaitForExit();
+                Console.WriteLine($"[{DateTime.Now}] exiting...");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Main Exception: [{DateTime.Now}] {ex}");
+            throw;
         }
     }
 
@@ -63,18 +72,29 @@ public class Program
         try
         {
             client.GetStringAsync("http://httpstat.us/200").Wait();
+            Console.WriteLine($"EmitTraces: [{DateTime.Now}] GetStringAsync completed");
         }
         catch (Exception ex)
         {
-            Console.WriteLine(ex);
+            Console.WriteLine($"EmitTraces Exception: [{DateTime.Now}] {ex}");
+            throw;
         }
     }
 
     private static void EmitMetrics()
     {
-        var myMeter = new Meter(SourceName, "1.0");
-        var myFruitCounter = myMeter.CreateCounter<int>("MyFruitCounter");
+        try
+        {
+            var myMeter = new Meter(SourceName, "1.0");
+            var myFruitCounter = myMeter.CreateCounter<int>("MyFruitCounter");
 
-        myFruitCounter.Add(1, new KeyValuePair<string, object>("name", "apple"));
+            myFruitCounter.Add(1, new KeyValuePair<string, object>("name", "apple"));
+            Console.WriteLine("EmitMetrics: [{DateTime.Now}] Counter.Add completed");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"EmitMetrics Exception: [{DateTime.Now}] {ex}");
+            throw;
+        }
     }
 }


### PR DESCRIPTION
## Why

The test filter and counter added in #1229 are a great but a "verify" pass loses time on projects that don't match the actual intended test. 

## What

Add a test project filter to complement #1229, 
![image](https://user-images.githubusercontent.com/5600755/191113709-91167100-4d41-4c70-844e-86a4a853fe66.png)

Compare the Windows a run without the change taking [34min](https://github.com/pjanotti/opentelemetry-dotnet-instrumentation/actions/runs/3070813155) and one with it taking [15min](https://github.com/pjanotti/opentelemetry-dotnet-instrumentation/actions/runs/3085911611/jobs/4989727362).

## Tests

[<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->](https://github.com/pjanotti/opentelemetry-dotnet-instrumentation/actions/runs/3085493815)

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
