### PR TITLE
[Tiny]: Support multiple test names on verify workflow

### DIFF
--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -34,7 +34,7 @@ jobs:
           dotnet-version: | 
             3.1.x
             6.0.x
-      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project-filter "${{ github.event.inputs.testProjectFilter }}" --test-name "${{ github.event.inputs.testName }}" --test-count ${{ github.event.inputs.count }}
+      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project-filter "${{ github.event.inputs.testProjectFilter }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.0
         if: always()


### PR DESCRIPTION
## Why

To allow the test name filter to work on Windows runs

## What

The pipe character causes problems on PowerShell. Make the test-name parameter wrapped by a literal string. This works for PowerShell and the bash shell.

## Tests

See https://github.com/pjanotti/opentelemetry-dotnet-instrumentation/actions/runs/3101453559

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
