### PR TITLE
Increase timeout in tests

### DIFF
--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -31,7 +31,7 @@ namespace IntegrationTests.Helpers;
 
 public class MockLogsCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromSeconds(30);
 
     private readonly object _syncRoot = new object();
     private readonly ITestOutputHelper _output;

--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -31,7 +31,7 @@ namespace IntegrationTests.Helpers;
 
 public class MockLogsCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
 
     private readonly object _syncRoot = new object();
     private readonly ITestOutputHelper _output;

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -31,7 +31,7 @@ namespace IntegrationTests.Helpers;
 
 public class MockMetricsCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
 
     private readonly object _syncRoot = new object();
     private readonly ITestOutputHelper _output;

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -31,7 +31,7 @@ namespace IntegrationTests.Helpers;
 
 public class MockMetricsCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromSeconds(30);
 
     private readonly object _syncRoot = new object();
     private readonly ITestOutputHelper _output;

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -32,7 +32,7 @@ namespace IntegrationTests.Helpers;
 
 public class MockZipkinCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultSpanWaitTimeout = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan DefaultSpanWaitTimeout = TimeSpan.FromSeconds(30);
 
     private readonly object _syncRoot = new object();
     private readonly ITestOutputHelper _output;

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -32,7 +32,7 @@ namespace IntegrationTests.Helpers;
 
 public class MockZipkinCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultSpanWaitTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultSpanWaitTimeout = TimeSpan.FromMinutes(1);
 
     private readonly object _syncRoot = new object();
     private readonly ITestOutputHelper _output;

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -178,8 +178,8 @@ public class SmokeTests : TestHelper
                 content.Should().Contain("TYPE ", "should export any metric");
             };
             await assert.Should().NotThrowAfterAsync(
-                waitTime: 30.Seconds(),
-                pollInterval: 1.Seconds());
+                waitTime: 1.Minutes(),
+                pollInterval: 3.Seconds());
         }
         finally
         {


### PR DESCRIPTION
## Why

I think this is caused b/c the machines on GH Actions are not that powerful and also because the Prometheus exporter caches the returned metrics for 10 seconds.

Fixes #1260

## What

Increase timeout in tests to give more chances to succeed.

## Tests

`verify-test` GH workflows for `PrometheusExporter` test:
- https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3104812761
- https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3104815626
- https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3104842753

and CI workflow 

`GraphQLTests` , `LogTests` still fails from time to time . I want to look at it tomorrow.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] ~~Documentation is updated.~~
- [x] ~~New features are covered by tests.~~
