### PR TITLE
Add support for OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add WCF traces instrumentation (server-side for .NET Framework, client-side
   for both .NET Core and .NET Framework).
-- Support for ASP.NET Core OpenTelemetry Log exporter related environment variables:
+- Support ASP.NET Core OpenTelemetry Log exporter related environment variables:
   - `OTEL_LOGS_EXPORTER`,
   - `OTEL_DOTNET_AUTO_LOGS_CONSOLE_EXPORTER_ENABLED`,
   - `OTEL_DOTNET_AUTO_LOGS_PARSE_STATE_VALUES`,
   - `OTEL_DOTNET_AUTO_LOGS_INCLUDE_FORMATTED_MESSAGE`,
+- Support `OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT` (default value: `false`)
+  environment variable which controls whether `graphql.document` attribute is set. 
 
 ### Changed
 
@@ -100,7 +102,7 @@ You can find all OpenTelemetry references in
 
 ### Added
 
-- Adds MongoDB instrumentation support from .NET Core 3.1+.
+- Add MongoDB instrumentation support from .NET Core 3.1+.
 - Support for OpenTelemetry metric exporter related environment variables:
   - `OTEL_DOTNET_AUTO_METRICS_ENABLED`,
   - `OTEL_DOTNET_AUTO_LOAD_METER_AT_STARTUP`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_DOTNET_AUTO_LOGS_PARSE_STATE_VALUES`,
   - `OTEL_DOTNET_AUTO_LOGS_INCLUDE_FORMATTED_MESSAGE`,
 - Support `OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT` (default value: `false`)
-  environment variable which controls whether `graphql.document` attribute is set. 
+  environment variable which controls whether `graphql.document` attribute
+  is set. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `OTEL_DOTNET_AUTO_LOGS_INCLUDE_FORMATTED_MESSAGE`,
 - Support `OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT` (default value: `false`)
   environment variable which controls whether `graphql.document` attribute
-  is set. 
+  is set.
 
 ### Changed
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -153,6 +153,12 @@ Important environment variables include:
 |-|-|-|
 | `OTEL_EXPORTER_ZIPKIN_ENDPOINT` | Zipkin URL. | `http://localhost:8126` |
 
+## Instrumentation options
+
+| Environment variable | Description | Default value |
+|-|-|-|
+| `OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT` | Whether GraphQL instrumentation can pass raw queries as `graphql.document` attribute. This may contain sensitive information and therefore is disabled by default. | `false` |
+
 ## Additional settings
 
 | Environment variable | Description | Default value |

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -107,7 +107,7 @@ public static class ConfigurationKeys
             /// Configuration key for GraphQL instrumentation to enable passing query as a document attribute.
             /// See <see cref="GraphQLTags.Document"/>.
             /// </summary>
-            public const string GraphQLEnableDocumentTag = "OTEL_DOTNET_AUTO_GRAPHQL_ENABLE_DOCUMENT_TAG";
+            public const string GraphQLSetDocument = "OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT";
         }
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -16,6 +16,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL;
 using OpenTelemetry.Logs;
 
 namespace OpenTelemetry.AutoInstrumentation.Configuration;
@@ -23,7 +24,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 /// <summary>
 /// Configuration keys
 /// </summary>
-public class ConfigurationKeys
+public static class ConfigurationKeys
 {
     /// <summary>
     /// Configuration key for the OTLP protocol to be used.
@@ -96,6 +97,18 @@ public class ConfigurationKeys
         /// Configuration key for legacy source names to be added to the tracer at the startup.
         /// </summary>
         public const string LegacySources = "OTEL_DOTNET_AUTO_LEGACY_SOURCES";
+
+        /// <summary>
+        /// Configuration keys for instrumentation options.
+        /// </summary>
+        public static class InstrumentationOptions
+        {
+            /// <summary>
+            /// Configuration key for GraphQL instrumentation to enable passing query as a document tag.
+            /// See <see cref="GraphQLTags.Document"/>.
+            /// </summary>
+            public const string GraphQLEnableDocumentTag = "OTEL_DOTNET_AUTO_GRAPHQL_ENABLE_DOCUMENT_TAG";
+        }
     }
 
     /// <summary>

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -104,7 +104,7 @@ public static class ConfigurationKeys
         public static class InstrumentationOptions
         {
             /// <summary>
-            /// Configuration key for GraphQL instrumentation to enable passing query as a document tag.
+            /// Configuration key for GraphQL instrumentation to enable passing query as a document attribute.
             /// See <see cref="GraphQLTags.Document"/>.
             /// </summary>
             public const string GraphQLEnableDocumentTag = "OTEL_DOTNET_AUTO_GRAPHQL_ENABLE_DOCUMENT_TAG";

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/InstrumentationOptions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/InstrumentationOptions.cs
@@ -1,0 +1,33 @@
+// <copyright file="InstrumentationOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.AutoInstrumentation.Configuration;
+
+/// <summary>
+/// Instrumentation options
+/// </summary>
+public class InstrumentationOptions
+{
+    internal InstrumentationOptions(IConfigurationSource source)
+    {
+        GraphQLEnableDocument = source.GetBool(ConfigurationKeys.Traces.InstrumentationOptions.GraphQLEnableDocumentTag) ?? false;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether GraphQL query can be passed as a Document tag.
+    /// </summary>
+    public bool GraphQLEnableDocument { get; }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/InstrumentationOptions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/InstrumentationOptions.cs
@@ -23,11 +23,11 @@ public class InstrumentationOptions
 {
     internal InstrumentationOptions(IConfigurationSource source)
     {
-        GraphQLEnableDocument = source.GetBool(ConfigurationKeys.Traces.InstrumentationOptions.GraphQLEnableDocumentTag) ?? false;
+        GraphQLSetDocument = source.GetBool(ConfigurationKeys.Traces.InstrumentationOptions.GraphQLSetDocument) ?? false;
     }
 
     /// <summary>
     /// Gets a value indicating whether GraphQL query can be passed as a Document tag.
     /// </summary>
-    public bool GraphQLEnableDocument { get; }
+    public bool GraphQLSetDocument { get; }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
@@ -61,6 +61,8 @@ public class TracerSettings : Settings
         }
 
         LoadTracerAtStartup = source.GetBool(ConfigurationKeys.Traces.LoadTracerAtStartup) ?? true;
+
+        InstrumentationOptions = new InstrumentationOptions(source);
     }
 
     /// <summary>
@@ -92,6 +94,11 @@ public class TracerSettings : Settings
     /// Gets the list of legacy sources to be added to the tracer at the startup.
     /// </summary>
     public IList<string> LegacySources { get; } = new List<string>();
+
+    /// <summary>
+    /// Gets the instrumentation options.
+    /// </summary>
+    public InstrumentationOptions InstrumentationOptions { get; private set; }
 
     internal static TracerSettings FromDefaultSources()
     {

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/GraphQLCommon.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/GraphQLCommon.cs
@@ -43,6 +43,7 @@ internal class GraphQLCommon
     internal static Activity CreateActivityFromExecuteAsync(IExecutionContext executionContext)
     {
         Activity activity = null;
+        InstrumentationOptions options = Instrumentation.TracerSettings.InstrumentationOptions;
 
         try
         {
@@ -52,9 +53,13 @@ internal class GraphQLCommon
             string operation = GetOperation(operationName, operationType);
 
             var tags = new GraphQLTags();
-            tags.Document = query; // TODO: Sanitization is recommended.
             tags.OperationName = operationName;
             tags.OperationType = operationType;
+
+            if (options.GraphQLEnableDocument)
+            {
+                tags.Document = query;
+            }
 
             activity = ActivitySource.StartActivityWithTags(operation, tags);
         }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/GraphQLCommon.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/GraphQLCommon.cs
@@ -56,7 +56,7 @@ internal class GraphQLCommon
             tags.OperationName = operationName;
             tags.OperationType = operationType;
 
-            if (options.GraphQLEnableDocument)
+            if (options.GraphQLSetDocument)
             {
                 tags.Document = query;
             }

--- a/test/IntegrationTests/GraphQLTests.cs
+++ b/test/IntegrationTests/GraphQLTests.cs
@@ -73,7 +73,7 @@ public class GraphQLTests : TestHelper
     public async Task SubmitsTraces()
     {
         SetEnvironmentVariable("OTEL_SERVICE_NAME", ServiceName);
-        SetEnvironmentVariable("OTEL_DOTNET_AUTO_GRAPHQL_ENABLE_DOCUMENT_TAG", bool.TrueString);
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT", bool.TrueString);
 
         int aspNetCorePort = TcpPortProvider.GetOpenPort();
         using var agent = new MockZipkinCollector(Output);

--- a/test/IntegrationTests/GraphQLTests.cs
+++ b/test/IntegrationTests/GraphQLTests.cs
@@ -73,6 +73,7 @@ public class GraphQLTests : TestHelper
     public async Task SubmitsTraces()
     {
         SetEnvironmentVariable("OTEL_SERVICE_NAME", ServiceName);
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_GRAPHQL_ENABLE_DOCUMENT_TAG", bool.TrueString);
 
         int aspNetCorePort = TcpPortProvider.GetOpenPort();
         using var agent = new MockZipkinCollector(Output);

--- a/test/IntegrationTests/GraphQLTests.cs
+++ b/test/IntegrationTests/GraphQLTests.cs
@@ -35,13 +35,15 @@ public class GraphQLTests : TestHelper
     private const string Library = "OpenTelemetry.AutoInstrumentation.GraphQL";
 
     private static readonly List<RequestInfo> _requests;
-    private static readonly List<WebServerSpanExpectation> _expectations;
+    private static readonly List<WebServerSpanExpectation> _expectationsAll; // Full expectations
+    private static readonly List<WebServerSpanExpectation> _expectationsSafe; // PII protected expectations
     private static int _expectedGraphQLExecuteSpanCount;
 
     static GraphQLTests()
     {
         _requests = new List<RequestInfo>(0);
-        _expectations = new List<WebServerSpanExpectation>();
+        _expectationsAll = new List<WebServerSpanExpectation>();
+        _expectationsSafe = new List<WebServerSpanExpectation>();
         _expectedGraphQLExecuteSpanCount = 0;
 
         // SUCCESS: query using GET
@@ -68,12 +70,14 @@ public class GraphQLTests : TestHelper
     {
     }
 
-    [Fact]
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     [Trait("Category", "EndToEnd")]
-    public async Task SubmitsTraces()
+    public async Task SubmitsTraces(bool setDocument)
     {
         SetEnvironmentVariable("OTEL_SERVICE_NAME", ServiceName);
-        SetEnvironmentVariable("OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT", bool.TrueString);
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT", setDocument.ToString());
 
         int aspNetCorePort = TcpPortProvider.GetOpenPort();
         using var agent = new MockZipkinCollector(Output);
@@ -156,7 +160,14 @@ public class GraphQLTests : TestHelper
             process.Kill();
         }
 
-        SpanTestHelpers.AssertExpectationsMet(_expectations, spans);
+        if (setDocument)
+        {
+            SpanTestHelpers.AssertExpectationsMet(_expectationsAll, spans);
+        }
+        else
+        {
+            SpanTestHelpers.AssertExpectationsMet(_expectationsSafe, spans);
+        }
     }
 
     private static void CreateGraphQLRequestsAndExpectations(
@@ -179,8 +190,7 @@ public class GraphQLTests : TestHelper
 
         if (failsValidation) { return; }
 
-        // Expect an 'execute' span
-        _expectations.Add(new GraphQLSpanExpectation(ServiceName, ServiceVersion, operationName)
+        _expectationsAll.Add(new GraphQLSpanExpectation(ServiceName, ServiceVersion, operationName)
         {
             OriginalUri = url,
             GraphQLRequestBody = graphQLRequestBody,
@@ -189,9 +199,18 @@ public class GraphQLTests : TestHelper
             GraphQLDocument = graphQLDocument,
             IsGraphQLError = failsExecution
         });
-        _expectedGraphQLExecuteSpanCount++;
 
-        if (failsExecution) { return; }
+        _expectationsSafe.Add(new GraphQLSpanExpectation(ServiceName, ServiceVersion, operationName)
+        {
+            OriginalUri = url,
+            GraphQLRequestBody = graphQLRequestBody,
+            GraphQLOperationType = graphQLOperationType,
+            GraphQLOperationName = graphQLOperationName,
+            GraphQLDocument = null,
+            IsGraphQLError = failsExecution
+        });
+
+        _expectedGraphQLExecuteSpanCount++;
     }
 
     private async Task SubmitRequestsAsync(HttpClient client, int aspNetCorePort)

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -65,7 +65,7 @@ public class SettingsTests : IDisposable
             settings.FlushOnUnhandledException.Should().BeFalse();
 
             // Instrumentation options tests
-            settings.InstrumentationOptions.GraphQLEnableDocument.Should().BeFalse();
+            settings.InstrumentationOptions.GraphQLSetDocument.Should().BeFalse();
         }
     }
 
@@ -312,7 +312,7 @@ public class SettingsTests : IDisposable
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Instrumentations, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.DisabledInstrumentations, null);
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.InstrumentationOptions.GraphQLEnableDocumentTag, null);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.InstrumentationOptions.GraphQLSetDocument, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Http2UnencryptedSupportEnabled, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.FlushOnUnhandledException, null);

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -63,6 +63,9 @@ public class SettingsTests : IDisposable
             settings.LegacySources.Should().BeEmpty();
             settings.Http2UnencryptedSupportEnabled.Should().BeFalse();
             settings.FlushOnUnhandledException.Should().BeFalse();
+
+            // Instrumentation options tests
+            settings.InstrumentationOptions.GraphQLEnableDocument.Should().BeFalse();
         }
     }
 
@@ -309,6 +312,7 @@ public class SettingsTests : IDisposable
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Instrumentations, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.DisabledInstrumentations, null);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.InstrumentationOptions.GraphQLEnableDocumentTag, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Http2UnencryptedSupportEnabled, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.FlushOnUnhandledException, null);


### PR DESCRIPTION
## Why

Fixes #1256 

## What

Does not send GraphQL Document tag (query) when disabled (the default behavior).

## Next

Proposing general key for PII protection to turn on or off all such's variables. `OTEL_DOTNET_AUTO_DISABLE_PII_PROTECTION`
While all subsets could be overridden separately, as all booleans are 3 state values.

## Tests

* Full tests (enabled).
* Safe tests (disabled).
* Default settings tests.

~Missing disabled integration tests. Not sure if we want to cover it now (to add second set of integration tests)?~

## Checklist

- [x] New features are covered by tests.
