### PR TITLE
Refine MockLogsCollector and LogTests

### DIFF
--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -15,16 +15,14 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Collections.Specialized;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
 using Google.Protobuf;
-using IntegrationTests.Helpers.Models;
 using OpenTelemetry.Proto.Collector.Logs.V1;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
@@ -33,7 +31,7 @@ public class MockLogsCollector : IDisposable
 {
     private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
 
-    private readonly object _syncRoot = new object();
+    private readonly BlockingCollection<string> _logs = new(100); // bounded to avoid memory leak
     private readonly ITestOutputHelper _output;
     private readonly TestHttpListener _listener;
 
@@ -43,89 +41,99 @@ public class MockLogsCollector : IDisposable
         _listener = new(output, HandleHttpRequests, host);
     }
 
-    public event EventHandler<EventArgs<HttpListenerContext>> RequestReceived;
-
-    public event EventHandler<EventArgs<ExportLogsServiceRequest>> RequestDeserialized;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to skip deserialization of logs.
-    /// </summary>
-    public bool ShouldDeserializeLogs { get; set; } = true;
-
     /// <summary>
     /// Gets the TCP port that this collector is listening on.
     /// </summary>
     public int Port { get => _listener.Port; }
 
-    /// <summary>
-    /// Gets the filters used to filter out logs we don't want to look at for a test.
-    /// </summary>
-    public List<Func<ExportLogsServiceRequest, bool>> LogFilters { get; private set; } = new List<Func<ExportLogsServiceRequest, bool>>();
+    public bool IsStrict { get; set; }
 
-    private IImmutableList<ExportLogsServiceRequest> LogMessages { get; set; } = ImmutableList<ExportLogsServiceRequest>.Empty;
-
-    private IImmutableList<NameValueCollection> RequestHeaders { get; set; } = ImmutableList<NameValueCollection>.Empty;
-
-    /// <summary>
-    /// Wait for the given number of logs to appear.
-    /// </summary>
-    /// <param name="count">The expected number of logs.</param>
-    /// <param name="timeout">The timeout</param>
-    /// <returns>The list of logs.</returns>
-    public IImmutableList<ExportLogsServiceRequest> WaitForLogs(
-        int count,
-        TimeSpan? timeout = null)
-    {
-        timeout ??= DefaultWaitTimeout;
-        var deadline = DateTime.Now.Add(timeout.Value);
-
-        IImmutableList<ExportLogsServiceRequest> relevantLogs = ImmutableList<ExportLogsServiceRequest>.Empty;
-
-        while (DateTime.Now < deadline)
-        {
-            lock (_syncRoot)
-            {
-                relevantLogs =
-                    LogMessages
-                        .Where(m => LogFilters.All(shouldReturn => shouldReturn(m)))
-                        .ToImmutableList();
-            }
-
-            if (relevantLogs.Count >= count)
-            {
-                break;
-            }
-
-            Thread.Sleep(500);
-        }
-
-        return relevantLogs;
-    }
+    public List<string> Expectations { get; set; } = new List<string>();
 
     public void Dispose()
     {
-        lock (_syncRoot)
+        _listener.Dispose();
+        WriteOutput($"Shutting down. Total logs requests received: '{_logs.Count}'");
+        _logs.Dispose();
+    }
+
+    public void AssertExpectations(TimeSpan? timeout = null)
+    {
+        if (Expectations.Count == 0)
         {
-            WriteOutput($"Shutting down. Total logs requests received: '{LogMessages.Count}'");
+            throw new InvalidOperationException("Expectations were not set");
         }
 
-        _listener.Dispose();
-    }
+        var missingExpectations = new List<string>(Expectations);
+        var expectationsMet = new List<string>();
+        var additionalEntries = new List<string>();
+        var fail = () =>
+        {
+            var message = new StringBuilder();
 
-    protected virtual void OnRequestReceived(HttpListenerContext context)
-    {
-        RequestReceived?.Invoke(this, new EventArgs<HttpListenerContext>(context));
-    }
+            message.AppendLine("Missing expectations:");
+            foreach (var logline in missingExpectations)
+            {
+                message.AppendLine($"  - \"{logline}\"");
+            }
 
-    protected virtual void OnRequestDeserialized(ExportLogsServiceRequest logsRequest)
-    {
-        RequestDeserialized?.Invoke(this, new EventArgs<ExportLogsServiceRequest>(logsRequest));
+            message.AppendLine("Expectations met:");
+            foreach (var logline in expectationsMet)
+            {
+                message.AppendLine($"    \"{logline}\"");
+            }
+
+            message.AppendLine("Additional entries:");
+            foreach (var logline in additionalEntries)
+            {
+                message.AppendLine($"  + \"{logline}\"");
+            }
+
+            Assert.Fail(message.ToString());
+        };
+
+        timeout ??= DefaultWaitTimeout;
+        var cts = new CancellationTokenSource();
+
+        try
+        {
+            cts.CancelAfter(timeout.Value);
+            foreach (var logline in _logs.GetConsumingEnumerable(cts.Token))
+            {
+                if (missingExpectations.Remove(logline))
+                {
+                    expectationsMet.Add(logline);
+                }
+                else
+                {
+                    additionalEntries.Add(logline);
+                }
+
+                if (missingExpectations.Count == 0)
+                {
+                    if (IsStrict && additionalEntries.Count > 0)
+                    {
+                        fail();
+                    }
+
+                    return;
+                }
+            }
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // CancelAfter for negative value
+            fail();
+        }
+        catch (OperationCanceledException)
+        {
+            // timeout
+            fail();
+        }
     }
 
     private void HandleHttpRequests(HttpListenerContext ctx)
     {
-        OnRequestReceived(ctx);
-
         if (ctx.Request.RawUrl.Equals("/healthz", StringComparison.OrdinalIgnoreCase))
         {
             CreateHealthResponse(ctx);
@@ -134,15 +142,15 @@ public class MockLogsCollector : IDisposable
 
         if (ctx.Request.RawUrl.Equals("/v1/logs", StringComparison.OrdinalIgnoreCase))
         {
-            if (ShouldDeserializeLogs)
+            var logsMessage = ExportLogsServiceRequest.Parser.ParseFrom(ctx.Request.InputStream);
+            foreach (var rLogs in logsMessage.ResourceLogs)
             {
-                var logsMessage = ExportLogsServiceRequest.Parser.ParseFrom(ctx.Request.InputStream);
-                OnRequestDeserialized(logsMessage);
-
-                lock (_syncRoot)
+                foreach (var sLogs in rLogs.ScopeLogs)
                 {
-                    LogMessages = LogMessages.Add(logsMessage);
-                    RequestHeaders = RequestHeaders.Add(new NameValueCollection(ctx.Request.Headers));
+                    foreach (var logRecord in sLogs.LogRecords)
+                    {
+                        _logs.Add(logRecord.Body.ToString());
+                    }
                 }
             }
 

--- a/test/IntegrationTests/LogTests.cs
+++ b/test/IntegrationTests/LogTests.cs
@@ -17,10 +17,7 @@
 #if !NETFRAMEWORK
 
 using System;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Threading;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using IntegrationTests.Helpers;
@@ -38,70 +35,28 @@ public class LogTests : TestHelper
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
+    [InlineData(true, true, "{ \"stringValue\": \"Information from Test App.\" }")]
+    [InlineData(true, false, "{ \"stringValue\": \"Information from Test App.\" }")]
+    [InlineData(false, true, "{ \"stringValue\": \"Information from Test App.\" }")]
+    [InlineData(false, false, "TestApplication.Logs.Controllers.TestController")] // When parseStateValues and includeFormattedMessage are set to false, LogRecord is not parsed and body will not have data. This is a collector behavior.
     [Trait("Category", "EndToEnd")]
-    public void SubmitLogs(bool parseStateValues, bool includeFormattedMessage)
+    public void SubmitLogs(bool parseStateValues, bool includeFormattedMessage, string expectedLog)
     {
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_LOGS_PARSE_STATE_VALUES", parseStateValues.ToString());
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_LOGS_INCLUDE_FORMATTED_MESSAGE", includeFormattedMessage.ToString());
 
         int aspNetCorePort = TcpPortProvider.GetOpenPort();
-        using var collector = new MockLogsCollector(Output);
+        using var collector = new MockLogsCollector(Output) { Expectations = new() { expectedLog } };
         using var process = StartTestApplication(logsAgentPort: collector.Port, aspNetCorePort: aspNetCorePort, enableClrProfiler: !IsCoreClr());
-
-        var maxMillisecondsToWait = 15_000;
-        var intervalMilliseconds = 500;
-        var intervals = maxMillisecondsToWait / intervalMilliseconds;
-        var success = false;
-
-        // Send a request to server.
-        while (intervals-- > 0)
-        {
-            try
-            {
-                success = SubmitRequest(aspNetCorePort) == HttpStatusCode.OK;
-            }
-            catch
-            {
-                // ignore
-            }
-
-            if (success)
-            {
-                Output.WriteLine("Received response from server.");
-                break;
-            }
-
-            Thread.Sleep(intervalMilliseconds);
-        }
-
         try
         {
-            success.Should().BeTrue();
-            var assert = () =>
-            {
-                var logRequests = collector.WaitForLogs(1);
-                var logs = logRequests.SelectMany(r => r.ResourceLogs).Where(s => s.ScopeLogs.Count > 0).FirstOrDefault();
-                var logRecords = logs.ScopeLogs.FirstOrDefault().LogRecords;
-                if (parseStateValues || includeFormattedMessage)
-                {
-                    logRecords.Should().ContainSingle(x => Convert.ToString(x.Body) == "{ \"stringValue\": \"Information from Test App.\" }");
-                }
-                else
-                {
-                    // When parseStateValues and includeFormattedMessage are set to false
-                    // LogRecord is not parsed and body will not have data.
-                    // This is a collector behavior.
-                    logRecords.Should().ContainSingle(x => Convert.ToString(x).Contains("TestApplication.Logs.Controllers.TestController"));
-                }
-            };
+            // Send a request to server (retry to avoid flakyness).
+            var sendRequest = () => SubmitRequest(aspNetCorePort);
+            sendRequest.Should().NotThrowAfter(
+                waitTime: 15.Seconds(),
+                pollInterval: 0.5.Seconds());
 
-            assert.Should().NotThrowAfter(
-                waitTime: 30.Seconds(),
-                pollInterval: 1.Seconds());
+            collector.AssertExpectations();
         }
         finally
         {
@@ -109,28 +64,17 @@ public class LogTests : TestHelper
         }
     }
 
-    private HttpStatusCode SubmitRequest(int aspNetCorePort)
+    private void SubmitRequest(int aspNetCorePort)
     {
-        try
+        using var client = new HttpClient();
+        var request = new HttpRequestMessage
         {
-            using var client = new HttpClient();
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-                RequestUri = new Uri($"http://localhost:{aspNetCorePort}/test"),
-            };
+            Method = HttpMethod.Get,
+            RequestUri = new Uri($"http://localhost:{aspNetCorePort}/test"),
+        };
 
-            var response = client.SendAsync(request).Result;
-            response.EnsureSuccessStatusCode();
-
-            return response.StatusCode;
-        }
-        catch (Exception ex)
-        {
-            Output.WriteLine($"Exception: {ex}");
-        }
-
-        return HttpStatusCode.BadRequest;
+        var response = client.SendAsync(request).Result;
+        response.EnsureSuccessStatusCode();
     }
 }
 #endif


### PR DESCRIPTION
## Why

An idea of how to address both https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/915 and https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1232. I took logs as an example because it has only one test class.

I think this might lead to more readable and maintainable code in the tests (the test code is simpler). Also, I think it will result in better test failure messages.

## What

Refine MockLogsCollector and LogTest. When the test fails it prints the missing expectations (user-defined messages) and what was collected. I was inspired by @RassK "expectations" in `GraphQLTests`.

If you like it then the same pattern could be used for other signals.

Also, it should be "faster" as we are not using `Thread.Sleep` nor `Task.Delay`. Here we are using a `BlockingCollection` for synchronization.
