### PR TITLE
Prometheus exporter cache duration set to 300ms

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
@@ -74,7 +74,11 @@ internal static class EnvironmentConfigurationMetricHelper
         switch (settings.MetricExporter)
         {
             case MetricsExporter.Prometheus:
-                builder.AddPrometheusExporter(options => { options.StartHttpListener = true; });
+                builder.AddPrometheusExporter(options =>
+                {
+                    options.StartHttpListener = true;
+                    options.ScrapeResponseCacheDurationMilliseconds = 300;
+                });
                 break;
             case MetricsExporter.Otlp:
 #if NETCOREAPP3_1

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -179,7 +179,7 @@ public class SmokeTests : TestHelper
             };
             await assert.Should().NotThrowAfterAsync(
                 waitTime: 1.Minutes(),
-                pollInterval: 3.Seconds());
+                pollInterval: 1.Seconds());
         }
         finally
         {


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Include settings value from: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3522
 * same settings as the newest version of OTel SDK.
 * It should improve CI stability.

## What

Prometheus exporter cache duration set to 300ms
it is backport from OTel SDK 1.4.0

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
