### PR TITLE
Refine MockMetricsCollector and metrics tests

### DIFF
--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -83,6 +83,7 @@ public class AspNetTests : TestHelper
         // the endpoint to all network interfaces. In order to do that it is necessary to open the port
         // on the firewall.
         using var collector = await MockMetricsCollector.Start(Output, host: "*");
+        collector.Expect("OpenTelemetry.Instrumentation.Http");
         collector.Expect("OpenTelemetry.Instrumentation.AspNet");
 
         // Helps to reduce noise by enabling only AspNet metrics.

--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -83,7 +83,6 @@ public class AspNetTests : TestHelper
         // the endpoint to all network interfaces. In order to do that it is necessary to open the port
         // on the firewall.
         using var collector = await MockMetricsCollector.Start(Output, host: "*");
-        collector.Expect("OpenTelemetry.Instrumentation.Http");
         collector.Expect("OpenTelemetry.Instrumentation.AspNet");
 
         // Helps to reduce noise by enabling only AspNet metrics.

--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -70,9 +70,9 @@ public class MockLogsCollector : IDisposable
 
     public void Dispose()
     {
-        _listener.Dispose();
         WriteOutput($"Shutting down. Total logs requests received: '{_logs.Count}'");
         _logs.Dispose();
+        _listener.Dispose();
     }
 
     public void Expect(Func<global::OpenTelemetry.Proto.Logs.V1.LogRecord, bool> predicate, string description = null)

--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -102,7 +102,7 @@ public class MockLogsCollector : IDisposable
             foreach (var logRecord in _logs.GetConsumingEnumerable(cts.Token))
             {
                 bool found = false;
-                for (int i = 0; i < missingExpectations.Count; i++)
+                for (int i = missingExpectations.Count - 1; i >= 0; i--)
                 {
                     if (!missingExpectations[i].Predicate(logRecord))
                     {

--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -112,6 +112,7 @@ public class MockLogsCollector : IDisposable
                     expectationsMet.Add(logRecord);
                     missingExpectations.RemoveAt(i);
                     found = true;
+                    break;
                 }
 
                 if (!found)

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -138,12 +138,12 @@ public class MockMetricsCollector : IDisposable
                             expectationsMet.Add(colleted);
                             missingExpectations.RemoveAt(i);
                             found = true;
+                            break;
                         }
 
                         if (!found)
                         {
                             additionalEntries.Add(colleted);
-                            continue;
                         }
                     }
                 }

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -80,7 +80,7 @@ public class MockMetricsCollector : IDisposable
     public void Expect(string instrumentationScopeName, Func<global::OpenTelemetry.Proto.Metrics.V1.Metric, bool> predicate = null, string description = null)
     {
         predicate ??= x => true;
-        description ??= "<no description>";
+        description ??= instrumentationScopeName;
 
         _expectations.Add(new Expectation { InstrumentationScopeName = instrumentationScopeName, Predicate = predicate, Description = description });
     }

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -106,7 +106,7 @@ public class MockMetricsCollector : IDisposable
             // loop until expectations met or timeout
             while (true)
             {
-                var resourceMetrics = _metrics.Take(cts.Token); // get the latest metrics
+                var resourceMetrics = _metrics.Take(cts.Token); // get the metrics snapshot
 
                 missingExpectations = new List<Expectation>(_expectations);
                 expectationsMet = new List<Collected>();

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -72,9 +72,9 @@ public class MockMetricsCollector : IDisposable
 
     public void Dispose()
     {
-        _listener.Dispose();
         WriteOutput($"Shutting down.");
         _metrics.Dispose();
+        _listener.Dispose();
     }
 
     public void Expect(string instrumentationScopeName, Func<global::OpenTelemetry.Proto.Metrics.V1.Metric, bool> predicate = null, string description = null)

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -108,6 +108,10 @@ public class MockMetricsCollector : IDisposable
             {
                 var resourceMetrics = _metrics.Take(cts.Token); // get the latest metrics
 
+                missingExpectations = new List<Expectation>(_expectations);
+                expectationsMet = new List<Collected>();
+                additionalEntries = new List<Collected>();
+
                 foreach (var scopeMetrics in resourceMetrics.ScopeMetrics)
                 {
                     foreach (var metric in scopeMetrics.Metrics)

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -15,17 +15,17 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Protobuf;
-using IntegrationTests.Helpers.Models;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
@@ -34,9 +34,10 @@ public class MockMetricsCollector : IDisposable
 {
     private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
 
-    private readonly object _syncRoot = new object();
     private readonly ITestOutputHelper _output;
     private readonly TestHttpListener _listener;
+    private readonly BlockingCollection<global::OpenTelemetry.Proto.Metrics.V1.ResourceMetrics> _metrics = new(10); // bounded to avoid memory leak
+    private readonly List<Expectation> _expectations = new();
 
     private MockMetricsCollector(ITestOutputHelper output, string host = "localhost")
     {
@@ -44,28 +45,15 @@ public class MockMetricsCollector : IDisposable
         _listener = new(output, HandleHttpRequests, host);
     }
 
-    public event EventHandler<EventArgs<HttpListenerContext>> RequestReceived;
-
-    public event EventHandler<EventArgs<ExportMetricsServiceRequest>> RequestDeserialized;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to skip deserialization of metrics.
-    /// </summary>
-    public bool ShouldDeserializeMetrics { get; set; } = true;
-
     /// <summary>
     /// Gets the TCP port that this collector is listening on.
     /// </summary>
     public int Port { get => _listener.Port; }
 
     /// <summary>
-    /// Gets the filters used to filter out metrics we don't want to look at for a test.
+    /// IsStrict defines if all entries must be expected.
     /// </summary>
-    public List<Func<ExportMetricsServiceRequest, bool>> MetricFilters { get; private set; } = new List<Func<ExportMetricsServiceRequest, bool>>();
-
-    private IImmutableList<ExportMetricsServiceRequest> MetricsMessages { get; set; } = ImmutableList<ExportMetricsServiceRequest>.Empty;
-
-    private IImmutableList<NameValueCollection> RequestHeaders { get; set; } = ImmutableList<NameValueCollection>.Empty;
+    public bool IsStrict { get; set; }
 
     public static async Task<MockMetricsCollector> Start(ITestOutputHelper output, string host = "localhost")
     {
@@ -82,77 +70,136 @@ public class MockMetricsCollector : IDisposable
         return collector;
     }
 
-    /// <summary>
-    /// Wait for the given number of metric requests to appear.
-    /// </summary>
-    /// <param name="count">The expected number of metric requests.</param>
-    /// <param name="timeout">The timeout</param>
-    /// <returns>The list of metric requests.</returns>
-    public IImmutableList<ExportMetricsServiceRequest> WaitForMetrics(
-        int count,
-        TimeSpan? timeout = null)
-    {
-        timeout ??= DefaultWaitTimeout;
-        var deadline = DateTime.Now.Add(timeout.Value);
-
-        IImmutableList<ExportMetricsServiceRequest> relevantMetricRequests = ImmutableList<ExportMetricsServiceRequest>.Empty;
-
-        while (DateTime.Now < deadline)
-        {
-            lock (_syncRoot)
-            {
-                relevantMetricRequests =
-                    MetricsMessages
-                        .Where(m => MetricFilters.All(shouldReturn => shouldReturn(m)))
-                        .ToImmutableList();
-            }
-
-            if (relevantMetricRequests.Count >= count)
-            {
-                break;
-            }
-
-            Thread.Sleep(500);
-        }
-
-        return relevantMetricRequests;
-    }
-
     public void Dispose()
     {
-        lock (_syncRoot)
+        _listener.Dispose();
+        WriteOutput($"Shutting down.");
+        _metrics.Dispose();
+    }
+
+    public void Expect(string instrumentationScopeName, Func<global::OpenTelemetry.Proto.Metrics.V1.Metric, bool> predicate = null, string description = null)
+    {
+        predicate ??= x => true;
+        description ??= "<no description>";
+
+        _expectations.Add(new Expectation { InstrumentationScopeName = instrumentationScopeName, Predicate = predicate, Description = description });
+    }
+
+    public void AssertExpectations(TimeSpan? timeout = null)
+    {
+        if (_expectations.Count == 0)
         {
-            WriteOutput($"Shutting down. Total metric requests received: '{MetricsMessages.Count}'");
+            throw new InvalidOperationException("Expectations were not set");
         }
 
-        _listener.Dispose();
+        var missingExpectations = new List<Expectation>(_expectations);
+        var expectationsMet = new List<global::OpenTelemetry.Proto.Metrics.V1.Metric>();
+        var additionalEntries = new List<global::OpenTelemetry.Proto.Metrics.V1.Metric>();
+
+        timeout ??= DefaultWaitTimeout;
+        var cts = new CancellationTokenSource();
+
+        try
+        {
+            cts.CancelAfter(timeout.Value);
+
+            // loop until expectations met or timeout
+            while (true)
+            {
+                var resourceMetrics = _metrics.Take(cts.Token); // get the latest metrics
+
+                foreach (var scopeMetrics in resourceMetrics.ScopeMetrics)
+                {
+                    foreach (var metric in scopeMetrics.Metrics)
+                    {
+                        bool found = false;
+                        for (int i = 0; i < missingExpectations.Count; i++)
+                        {
+                            if (metric.Name == missingExpectations[i].InstrumentationScopeName)
+                            {
+                                continue;
+                            }
+
+                            if (!missingExpectations[i].Predicate(metric))
+                            {
+                                continue;
+                            }
+
+                            expectationsMet.Add(metric);
+                            missingExpectations.RemoveAt(i);
+                            found = true;
+                        }
+
+                        if (!found)
+                        {
+                            additionalEntries.Add(metric);
+                            continue;
+                        }
+
+                        if (missingExpectations.Count == 0)
+                        {
+                            if (IsStrict && additionalEntries.Count > 0)
+                            {
+                                FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+                            }
+
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // CancelAfter called with non-positive value
+            FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+        }
+        catch (OperationCanceledException)
+        {
+            // timeout
+            FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+        }
     }
 
-    protected virtual void OnRequestReceived(HttpListenerContext context)
+    private static void FailExpectations(
+        List<Expectation> missingExpectations,
+        List<global::OpenTelemetry.Proto.Metrics.V1.Metric> expectationsMet,
+        List<global::OpenTelemetry.Proto.Metrics.V1.Metric> additionalEntries)
     {
-        RequestReceived?.Invoke(this, new EventArgs<HttpListenerContext>(context));
-    }
+        var message = new StringBuilder();
+        message.AppendLine();
 
-    protected virtual void OnRequestDeserialized(ExportMetricsServiceRequest metricsRequest)
-    {
-        RequestDeserialized?.Invoke(this, new EventArgs<ExportMetricsServiceRequest>(metricsRequest));
+        message.AppendLine("Missing expectations:");
+        foreach (var logline in missingExpectations)
+        {
+            message.AppendLine($"  - \"{logline.Description}\"");
+        }
+
+        message.AppendLine("Entries meeting expectations:");
+        foreach (var logline in expectationsMet)
+        {
+            message.AppendLine($"    \"{logline}\"");
+        }
+
+        message.AppendLine("Additional entries:");
+        foreach (var logline in additionalEntries)
+        {
+            message.AppendLine($"  + \"{logline}\"");
+        }
+
+        Assert.Fail(message.ToString());
     }
 
     private void HandleHttpRequests(HttpListenerContext ctx)
     {
-        OnRequestReceived(ctx);
-
         if (ctx.Request.RawUrl.Equals("/v1/metrics", StringComparison.OrdinalIgnoreCase))
         {
-            if (ShouldDeserializeMetrics)
+            var metricsMessage = ExportMetricsServiceRequest.Parser.ParseFrom(ctx.Request.InputStream);
+            if (metricsMessage.ResourceMetrics != null)
             {
-                var metricsMessage = ExportMetricsServiceRequest.Parser.ParseFrom(ctx.Request.InputStream);
-                OnRequestDeserialized(metricsMessage);
-
-                lock (_syncRoot)
+                foreach (var metrics in metricsMessage.ResourceMetrics)
                 {
-                    MetricsMessages = MetricsMessages.Add(metricsMessage);
-                    RequestHeaders = RequestHeaders.Add(new NameValueCollection(ctx.Request.Headers));
+                    _metrics.Add(metrics);
                 }
             }
 
@@ -176,5 +223,14 @@ public class MockMetricsCollector : IDisposable
     {
         const string name = nameof(MockMetricsCollector);
         _output.WriteLine($"[{name}]: {msg}");
+    }
+
+    private class Expectation
+    {
+        public string InstrumentationScopeName { get; set; }
+
+        public Func<global::OpenTelemetry.Proto.Metrics.V1.Metric, bool> Predicate { get; set; }
+
+        public string Description { get; set; }
     }
 }

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -112,7 +112,7 @@ public class MockMetricsCollector : IDisposable
                 {
                     foreach (var metric in scopeMetrics.Metrics)
                     {
-                        var colleted =  new Collected
+                        var colleted = new Collected
                         {
                             InstrumentationScopeName = scopeMetrics.Scope.Name,
                             Metric = metric

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -145,17 +145,17 @@ public class MockMetricsCollector : IDisposable
                             additionalEntries.Add(colleted);
                             continue;
                         }
-
-                        if (missingExpectations.Count == 0)
-                        {
-                            if (IsStrict && additionalEntries.Count > 0)
-                            {
-                                FailExpectations(missingExpectations, expectationsMet, additionalEntries);
-                            }
-
-                            return;
-                        }
                     }
+                }
+
+                if (missingExpectations.Count == 0)
+                {
+                    if (IsStrict && additionalEntries.Count > 0)
+                    {
+                        FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+                    }
+
+                    return;
                 }
             }
         }

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -123,7 +123,7 @@ public class MockMetricsCollector : IDisposable
                         };
 
                         bool found = false;
-                        for (int i = 0; i < missingExpectations.Count; i++)
+                        for (int i = missingExpectations.Count - 1; i >= 0; i--)
                         {
                             if (colleted.InstrumentationScopeName != missingExpectations[i].InstrumentationScopeName)
                             {

--- a/test/IntegrationTests/Helpers/TestHttpListener.cs
+++ b/test/IntegrationTests/Helpers/TestHttpListener.cs
@@ -126,6 +126,12 @@ public class TestHttpListener : IDisposable
             {
                 // we don't care about any exception when listener is stopped
             }
+            catch (Exception ex)
+            {
+                // somethig unexpected happened
+                // log instead of crashing the thread
+                WriteOutput(ex.ToString());
+            }
         }
     }
 

--- a/test/IntegrationTests/PluginsTests.cs
+++ b/test/IntegrationTests/PluginsTests.cs
@@ -48,13 +48,12 @@ public class PluginsTests : TestHelper
     [Trait("Category", "EndToEnd")]
     public async Task SubmitMetrics()
     {
-        SetEnvironmentVariable("OTEL_DOTNET_AUTO_PLUGINS", "TestApplication.Plugins.Plugin, TestApplication.Plugins, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
-
         using var collector = await MockMetricsCollector.Start(Output);
-        RunTestApplication(metricsAgentPort: collector.Port);
-        var metricRequests = collector.WaitForMetrics(1);
+        collector.Expect("MyCompany.MyProduct.MyLibrary");
 
-        var metrics = metricRequests.Should().NotBeEmpty().And.Subject.First().ResourceMetrics.Should().ContainSingle().Subject.ScopeMetrics;
-        metrics.Should().Contain(x => x.Scope.Name == "MyCompany.MyProduct.MyLibrary");
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_PLUGINS", "TestApplication.Plugins.Plugin, TestApplication.Plugins, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+        RunTestApplication(metricsAgentPort: collector.Port);
+
+        collector.AssertExpectations();
     }
 }

--- a/test/IntegrationTests/PluginsTests.cs
+++ b/test/IntegrationTests/PluginsTests.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using IntegrationTests.Helpers;

--- a/test/IntegrationTests/RuntimeTests.cs
+++ b/test/IntegrationTests/RuntimeTests.cs
@@ -14,11 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -22,12 +21,10 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using IntegrationTests.Helpers;
 using IntegrationTests.Helpers.Mocks;
 using IntegrationTests.Helpers.Models;
-using OpenTelemetry.Proto.Common.V1;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
## Why

Follow-up #1269

Part of  addressing #915 and #1232. 

## What

- Refactor the `MockMetricsCollector` to use similar pattern like lin `MockLogsCollector`
  - It is a little different as OTLP exporter always send the snapshot so we we do not accumulate the results
- Remove some assertions - I feel a lot of tests were overspecified
  - The only drawback is that we do not assert the resource attributes (like `service.name`) - I want to address it in a seperate PR to avoid scope creeping (the PR is complex enough)
- Some minior refactorings (mainly connected with `AspNetTests`)
- Do not crash the thread started in `TestHttpListener` in case some unexpected happens

Sample failure message (I modified the test to check it):

```
[xUnit.net 00:01:04.24]     IntegrationTests.SmokeTests.SubmitMetrics [FAIL]
  Failed IntegrationTests.SmokeTests.SubmitMetrics [1 m 2 s]
  Error Message:
   Assert.Fail():
Missing expectations:
  - "MyCompany.MyProduct.MyLibrary123"
Entries meeting expectations:
    "InstrumentationScopeName = MyCompany.MyProduct.MyLibrary, Metric = { "name": "MyFruitCounter", "sum": { "dataPoints": [ { "startTimeUnixNano": "1664187023139052000", "timeUnixNano": "1664187023299085800", "asInt": "1", "attributes": [ { "key": "name", "value": { "stringValue": "apple" } } ] } ], "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE", "isMonotonic": true } }"
Additional entries:
  + "InstrumentationScopeName = OpenTelemetry.Instrumentation.Runtime, Metric = { "name": "process.runtime.dotnet.gc.collections.count", "description": "Number of garbage collections that have occurred since process start.", "sum": { "dataPoints": [ { "startTimeUnixNano": "1664187022378291000", "timeUnixNano": "1664187023299085800", "asInt": "0", "attributes": [ { "key": "generation", "value": { 
"gen2" } } ] }, { "startTimeUnixNano": "1664187022378291000", "timeUnixNano": "1664187023299085800", "asInt": "0", "attributes": [ { "key": "generation", "value": { "stringValue": "gen1" } } ] }, { "startTimeUnixNano": "1664187022378291000", "timeUnixNano": "1664187023299085800", "asInt": "0", "attributes": [ { "key": "generation", "value": { "stringValue": "gen0" } } ] } ], "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE", "isMonotonic": true } }"
  + "InstrumentationScopeName = OpenTelemetry.Instrumentation.Runtime, Metric = { "name": "process.runtime.dotnet.assemblies.count", "description": "The number of .NET assemblies that are currently loaded.", "gauge": { "dataPoints": [ { "startTimeUnixNano": "1664187022378291000", "timeUnixNano": "1664187023299085800", "asInt": "35" } ] } }"
  + "InstrumentationScopeName = OpenTelemetry.Instrumentation.Runtime, Metric = { "name": "process.runtime.dotnet.exceptions.count", "description": "Count of exceptions that have been thrown in managed code, since the observation started. The value will be unavailable until an exception has been thrown after OpenTelemetry.Instrumentation.Runtime initialization.", "sum": { "dataPoints": [ { "startTimeUnixNano": "1664187022379295100", "timeUnixNano": "1664187023299085800", "asInt": "1" } ], "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE", "isMonotonic": true } }"
```

## Tests

- CI (I will run it a few times before merging to make sure the builds are stable)
- `verify-test` all integration tests 5 times: https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3130065402
## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] ~~Documentation is updated.~~
- [x] ~~New features are covered by tests.~~
