### PR TITLE
Force ReJIT before 1st execution of a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Log folder structure is fully created on Linux.
 - Update GraphQL instrumentation to follow the [OpenTelemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.13.0/specification/trace/semantic_conventions/instrumentation/graphql.md).
+- Fixed the race between requesting ReJIT of methods targeted for bytecode
+ instrumentation and their first execution. The race allowed, in rare occasions,
+ for the first few executions of the method to not be instrumented.See
+ issue [#1242](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1242).
 
 ## [0.3.1-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.3.1-beta.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update GraphQL instrumentation to follow the [OpenTelemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.13.0/specification/trace/semantic_conventions/instrumentation/graphql.md).
 - Fixed the race between requesting ReJIT of methods targeted for bytecode
  instrumentation and their first execution. The race allowed, in rare occasions,
- for the first few executions of the method to not be instrumented.See
+ for the first few executions of the method to not be instrumented. See
  issue [#1242](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1242).
 
 ## [0.3.1-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.3.1-beta.1)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -2397,7 +2397,6 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
     // Request the ReJIT for all integrations found in the module.
     if (!vtMethodDefs.empty())
     {
-        // this->rejit_handler->EnqueueForRejit(vtModules, vtMethodDefs);
         this->rejit_handler->RequestRejit(vtModules, vtMethodDefs);
         this->rejit_handler->RequestRejitForNGenInliners();
     }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -2397,7 +2397,8 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
     // Request the ReJIT for all integrations found in the module.
     if (!vtMethodDefs.empty())
     {
-        this->rejit_handler->EnqueueForRejit(vtModules, vtMethodDefs);
+        // this->rejit_handler->EnqueueForRejit(vtModules, vtMethodDefs);
+        this->rejit_handler->RequestRejit(vtModules, vtMethodDefs);
         this->rejit_handler->RequestRejitForNGenInliners();
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
@@ -118,7 +118,6 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
             methodEnum = nullptr;
             if (total > 0)
             {
-                // handler->EnqueueForRejit(modules, methods);
                 handler->RequestRejit(modules, methods);
                 Logger::Info("NGEN:: Processed with ", total, " inliners [ModuleId=", currentModuleId,
                              ",MethodDef=", currentMethodDef, "]");
@@ -410,27 +409,6 @@ void RejitHandler::RequestRejit(const std::vector<ModuleID>& modulesVector, cons
     {
         Logger::Warn("Error requesting ReJIT for ", item->m_length, " methods");
     }
-}
-
-void RejitHandler::EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef)
-{
-    const size_t length = modulesMethodDef.size();
-
-    auto moduleIds = new ModuleID[length];
-    std::copy(modulesVector.begin(), modulesVector.end(), moduleIds);
-
-    auto mDefs = new mdMethodDef[length];
-    std::copy(modulesMethodDef.begin(), modulesMethodDef.end(), mDefs);
-
-    // Create module and methods metadata.
-    for (size_t i = 0; i < length; i++)
-    {
-        GetOrAddModule(moduleIds[i])->GetOrAddMethod(mDefs[i]);
-    }
-
-    // Enqueue rejit
-    m_rejit_queue->push(std::make_unique<RejitItem>((int) length, std::unique_ptr<ModuleID>(moduleIds),
-                                                    std::unique_ptr<mdMethodDef>(mDefs)));
 }
 
 void RejitHandler::Shutdown()

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
@@ -130,7 +130,6 @@ public:
 
     void RequestRejit(const std::vector<ModuleID>& modulesVector, const std::vector<mdMethodDef>& modulesMethodDef);
 
-    void EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef);
     void Shutdown();
 
     HRESULT NotifyReJITParameters(ModuleID moduleId, mdMethodDef methodId,

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
@@ -128,6 +128,8 @@ public:
 
     void AddNGenModule(ModuleID moduleId);
 
+    void RequestRejit(const std::vector<ModuleID>& modulesVector, const std::vector<mdMethodDef>& modulesMethodDef);
+
     void EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef);
     void Shutdown();
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
@@ -14,16 +14,6 @@
 namespace trace
 {
 
-struct RejitItem
-{
-    int m_length = 0;
-    std::unique_ptr<ModuleID> m_modulesId = nullptr;
-    std::unique_ptr<mdMethodDef> m_methodDefs = nullptr;
-
-    RejitItem(int length, std::unique_ptr<ModuleID>&& modulesId, std::unique_ptr<mdMethodDef>&& methodDefs);
-    static std::unique_ptr<RejitItem> CreateEndRejitThread();
-};
-
 // forward declarations...
 class RejitHandlerModule;
 class RejitHandler;
@@ -123,7 +113,7 @@ public:
 
     void AddNGenModule(ModuleID moduleId);
 
-    void RequestRejit(const std::vector<ModuleID>& modulesVector, const std::vector<mdMethodDef>& modulesMethodDef);
+    void RequestRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef);
 
     void Shutdown();
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
@@ -103,13 +103,8 @@ private:
     ICorProfilerInfo10* m_profilerInfo10;
     std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> m_rewriteCallback;
 
-    std::unique_ptr<UniqueBlockingQueue<RejitItem>> m_rejit_queue;
-    std::unique_ptr<std::thread> m_rejit_queue_thread;
-
     std::mutex m_ngenModules_lock;
     std::vector<ModuleID> m_ngenModules;
-
-    static void EnqueueThreadLoop(RejitHandler* handler);
 
     void RequestRejitForInlinersInModule(ModuleID moduleId);
 

--- a/test/IntegrationTests/StrongNamedTests.cs
+++ b/test/IntegrationTests/StrongNamedTests.cs
@@ -33,7 +33,7 @@ public class StrongNamedTests : TestHelper
     {
     }
 
-    [Fact(Skip = "Bug in product. See: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1242")]
+    [Fact]
     public async Task SubmitsTraces()
     {
         var assemblyPath = GetTestAssemblyPath();


### PR DESCRIPTION
## Why

Enqueueing requests to ReJIT can cause the first executions of a method targeted for bytecode instrumentation to not be instrumented.

Fixes #1242

## What

Make the request to ReJIT a method targeted for bytecode instrumentation to be made on the same thread finishing the module load targeted for instrumentation. This ensures that any execution of the targeted methods is going to use the ReJIT-ed version of the method. 

## Tests

Manual runs on mac and Windows without hitting the error - these errors have low frequency on more powerful machines but runs in ci and verify-test workflows were also good.

## Checklist

- [X] `CHANGELOG.md` is updated.
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
