### PR TITLE
MockMetricsCollector can assert resource attributes

### DIFF
--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -48,11 +48,6 @@ public class MockLogsCollector : IDisposable
     /// </summary>
     public int Port { get => _listener.Port; }
 
-    /// <summary>
-    /// IsStrict defines if all entries must be expected.
-    /// </summary>
-    public bool IsStrict { get; set; }
-
     public static async Task<MockLogsCollector> Start(ITestOutputHelper output, string host = "localhost")
     {
         var collector = new MockLogsCollector(output, host);
@@ -123,11 +118,6 @@ public class MockLogsCollector : IDisposable
 
                 if (missingExpectations.Count == 0)
                 {
-                    if (IsStrict && additionalEntries.Count > 0)
-                    {
-                        FailExpectations(missingExpectations, expectationsMet, additionalEntries);
-                    }
-
                     return;
                 }
             }

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -184,16 +184,15 @@ public class MockMetricsCollector : IDisposable
             throw new InvalidOperationException("Currently you can only assert for metrics or resouce attributes");
         }
 
-        var missingExpectations = new List<ResourceExpectation>(_resourceExpectations);
-
         timeout ??= DefaultWaitTimeout;
         var cts = new CancellationTokenSource();
 
         try
         {
             cts.CancelAfter(timeout.Value);
-            var resourceMetrics = _metrics.Take(cts.Token); // get the metrics snapshot
+            var resourceMetrics = _metrics.Take(cts.Token); // get the metrics snapshot, each contains the same resources 
 
+            var missingExpectations = new List<ResourceExpectation>(_resourceExpectations);
             foreach (var resourceAttribute in resourceMetrics.Resource.Attributes)
             {
                 for (int i = missingExpectations.Count - 1; i >= 0; i--)
@@ -221,12 +220,12 @@ public class MockMetricsCollector : IDisposable
         catch (ArgumentOutOfRangeException)
         {
             // CancelAfter called with non-positive value
-            FailResourceExpectations(missingExpectations, null);
+            FailResourceExpectations(_resourceExpectations, null);
         }
         catch (OperationCanceledException)
         {
             // timeout
-            FailResourceExpectations(missingExpectations, null);
+            FailResourceExpectations(_resourceExpectations, null);
         }
     }
 

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -129,6 +129,19 @@ public class SmokeTests : TestHelper
 
     [Fact]
     [Trait("Category", "EndToEnd")]
+    public async Task ResourceMetrics()
+    {
+        using var collector = await MockMetricsCollector.Start(Output);
+        collector.ExpectResourceAttribute("service.name", ServiceName);
+
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES", "MyCompany.MyProduct.MyLibrary");
+        RunTestApplication(metricsAgentPort: collector.Port);
+
+        collector.AssertResourceExpectations();
+    }
+
+    [Fact]
+    [Trait("Category", "EndToEnd")]
     public async Task PrometheusExporter()
     {
         SetEnvironmentVariable("LONG_RUNNING", "true");


### PR DESCRIPTION
## Why

Needed for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1274

## What

- Add `ExpectResourceAttribute` and `AssertResourceExpectations` to `MockMetricsCollector` for testing resource attributes.
- Remove `IsStrict`, because I think it will not be needed. It can always be added later.
- Add `SmokeTests.ResourceMetrics` which can be used in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1274

## Tests

CI

Here is a sample failure:

```
[xUnit.net 00:00:04.26]     IntegrationTests.SmokeTests.ResourceMetrics [FAIL]
  Failed IntegrationTests.SmokeTests.ResourceMetrics [2 s]
  Error Message:
   Assert.Fail():
Missing resource expectations:
  - "intentionally.missing=true"
Actual resource attributes:
  + "service.name=TestApplication.Smoke"
  + "deployment.environment=rpajak"
```

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] ~~Documentation is updated.~~
- [x] ~~New features are covered by tests.~~
