### PR TITLE
Refactor ICorProfilerInfo usage in RejitHandler

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -189,9 +189,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         return this->CallTarget_RewriterCallback(mod, method);
     };
 
-    rejit_handler =
-        info10 != nullptr ? new RejitHandler(info10, callback)
-                          : new RejitHandler(info6, callback);
+    rejit_handler = new RejitHandler(info6, callback);
 
     // load all integrations from JSON files
     LoadIntegrationsFromEnvironment(integration_methods_, GetEnvironmentValues(environment::disabled_integrations));

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
@@ -88,9 +88,8 @@ private:
     std::mutex m_modules_lock;
     std::unordered_map<ModuleID, std::unique_ptr<RejitHandlerModule>> m_modules;
 
-    ICorProfilerInfo4* m_profilerInfo;
     ICorProfilerInfo6* m_profilerInfo6;
-    ICorProfilerInfo10* m_profilerInfo10;
+
     std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> m_rewriteCallback;
 
     std::mutex m_ngenModules_lock;
@@ -99,11 +98,7 @@ private:
     void RequestRejitForInlinersInModule(ModuleID moduleId);
 
 public:
-    RejitHandler(ICorProfilerInfo4* pInfo,
-                 std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> rewriteCallback);
     RejitHandler(ICorProfilerInfo6* pInfo,
-                 std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> rewriteCallback);
-    RejitHandler(ICorProfilerInfo10* pInfo,
                  std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> rewriteCallback);
 
     RejitHandlerModule* GetOrAddModule(ModuleID moduleId);
@@ -121,7 +116,6 @@ public:
                                   ICorProfilerFunctionControl* pFunctionControl, ModuleMetadata* metadata);
     HRESULT NotifyReJITCompilationStarted(FunctionID functionId, ReJITID rejitId);
 
-    ICorProfilerInfo4* GetCorProfilerInfo();
     ICorProfilerInfo6* GetCorProfilerInfo6();
 
     void RequestRejitForNGenInliners();


### PR DESCRIPTION
## Why

Refactor RejitHandler to remove unnecessary code. Follow-up to PR #1279, see comment https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1279#pullrequestreview-1121253655

## What

- Remove code in RejitHandler used to handle versions prior to ICorProfilerInfo6 the minimum required by current implementation. 
- Removes the code for using ICorProfilerInfo10 to deal with ReJIT of methods targeted for instrumentation that were inlined in NGEN modules.

## Tests

No special tests added for this, opened #1284 as a future test addition.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
