### PR TITLE
Fix permissions for assign reviews

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -5,6 +5,10 @@ on:
   # the github token will not have sufficient permission to update the PR.
   pull_request_target:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   assign:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Fix permissions for assign reviews, follow up to #1275

## What

<!-- Describe changes proposed in this pull request. -->

## Tests

Teste on my fork with lower permissions for `GITHUB_TOKEN`

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
