### PR TITLE
Stabilize LogTests

### DIFF
--- a/test/IntegrationTests/LogTests.cs
+++ b/test/IntegrationTests/LogTests.cs
@@ -118,7 +118,10 @@ public class LogTests : TestHelper
 
     private void SubmitRequest(int aspNetCorePort)
     {
-        using var client = new HttpClient();
+        using var client = new HttpClient
+        {
+            Timeout = 3.Seconds()
+        };
         var request = new HttpRequestMessage
         {
             Method = HttpMethod.Get,

--- a/test/IntegrationTests/LogTests.cs
+++ b/test/IntegrationTests/LogTests.cs
@@ -105,7 +105,7 @@ public class LogTests : TestHelper
             // Send a request to server (retry to avoid flakyness)
             var sendRequest = () => SubmitRequest(aspNetCorePort);
             sendRequest.Should().NotThrowAfter(
-                waitTime: 15.Seconds(),
+                waitTime: 30.Seconds(),
                 pollInterval: 0.5.Seconds());
 
             collector.AssertExpectations();


### PR DESCRIPTION
## Why

Try to fix
```log
Error: [xUnit.net 00:00:16.93]     IntegrationTests.LogTests.SubmitLogs(enableClrProfiler: True, parseStateValues: False, includeFormattedMessage: True) [FAIL]
  07:00:58 [ERR] [xUnit.net 00:00:16.93]     IntegrationTests.LogTests.SubmitLogs(enableClrProfiler: True, parseStateValues: False, includeFormattedMessage: True) [FAIL]
  07:00:58 [DBG]   Failed IntegrationTests.LogTests.SubmitLogs(enableClrProfiler: True, parseStateValues: False, includeFormattedMessage: True) [15 s]
  07:00:58 [DBG]   Error Message:
  07:00:58 [DBG]    Did not expect any exceptions after 15s, but found System.Net.Http.HttpRequestException with message "Response status code does not indicate success: 501 (Not Implemented)."
  07:00:58 [DBG]      at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
  07:00:58 [DBG]      at IntegrationTests.LogTests.SubmitRequest(Int32 aspNetCorePort) in /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/test/IntegrationTests/LogTests.cs:line 129
  07:00:58 [DBG]      at IntegrationTests.LogTests.<>c__DisplayClass1_0.<SubmitLogs>b__2() in /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/test/IntegrationTests/LogTests.cs:line 75
  07:00:58 [DBG]      at FluentAssertions.Specialized.ActionAssertions.InvokeSubject()
  07:00:58 [DBG]      at FluentAssertions.Specialized.DelegateAssertions`2.InvokeSubjectWithInterception()
  07:00:58 [DBG] .
  07:00:58 [DBG]   Stack Trace:
  07:00:58 [DBG]      at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
  07:00:58 [DBG]    at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
  07:00:58 [DBG]    at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
  07:00:58 [DBG]    at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
  07:00:58 [DBG]    at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
  07:00:58 [DBG]    at FluentAssertions.Specialized.DelegateAssertions`2.NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, String because, Object[] becauseArgs)
  07:00:58 [DBG]    at IntegrationTests.LogTests.SubmitLogs(Boolean enableClrProfiler, Boolean parseStateValues, Boolean includeFormattedMessage) in /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/test/IntegrationTests/LogTests.cs:line 76
  07:00:58 [DBG] --- End of stack trace from previous location ---
  07:00:58 [DBG]   Standard Output Messages:
  07:00:58 [DBG]  Platform: X64
  07:00:58 [DBG]  Configuration: Release
  07:00:58 [DBG]  TargetFramework: net6.0
  07:00:58 [DBG]  .NET Core: True
  07:00:58 [DBG]  Found profiler at /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/bin/tracer-home/OpenTelemetry.AutoInstrumentation.Native.so.
  07:00:58 [DBG]  Profiler DLL: /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/bin/tracer-home/OpenTelemetry.AutoInstrumentation.Native.so
  07:00:58 [DBG]  [TestHttpListener]: Listening on 'http://localhost:42359/'
  07:00:58 [DBG]  MockLogsCollector healthz endpoint: http://localhost:42359//healthz
  07:00:58 [DBG]  Starting Application: /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/test/test-applications/integrations/TestApplication.Logs/bin/x64/Release/net6.0/TestApplication.Logs.dll
  07:00:58 [DBG]  Found integrations at /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/bin/tracer-home/OpenTelemetry.AutoInstrumentation.Native.so.
  07:00:58 [DBG]  [MockLogsCollector]: Shutting down. Total logs requests received: '4'
  07:00:58 [DBG]  [TestHttpListener]: Listener is shutting down.
  07:00:58 [DBG] 
  07:00:58 [DBG] 
  07:03:28 [DBG] Results File: /home/runner/work/opentelemetry-dotnet-instrumentation/opentelemetry-dotnet-instrumentation/build_data/results/IntegrationTests/_fv-az451-748_2022-09-28_07_00_58.t
```

## What

Extend retry timeout and decrease HTTP request timeout.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
