### PR TITLE
Update to ICorProfilerInfo7

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.cpp
@@ -13,7 +13,7 @@
 namespace trace
 {
 
-RuntimeInformation GetRuntimeInformation(ICorProfilerInfo4* info)
+RuntimeInformation GetRuntimeInformation(ICorProfilerInfo7* info)
 {
     COR_PRF_RUNTIME_TYPE runtime_type;
     USHORT major_version;
@@ -31,7 +31,7 @@ RuntimeInformation GetRuntimeInformation(ICorProfilerInfo4* info)
     return {runtime_type, major_version, minor_version, build_version, qfe_version};
 }
 
-AssemblyInfo GetAssemblyInfo(ICorProfilerInfo4* info, const AssemblyID& assembly_id)
+AssemblyInfo GetAssemblyInfo(ICorProfilerInfo7* info, const AssemblyID& assembly_id)
 {
     WCHAR assembly_name[kNameMaxSize];
     DWORD assembly_name_len = 0;
@@ -188,7 +188,7 @@ FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import, co
             FunctionMethodSignature(raw_signature, raw_signature_len)};
 }
 
-ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id)
+ModuleInfo GetModuleInfo(ICorProfilerInfo7* info, const ModuleID& module_id)
 {
     const DWORD module_path_size = 260;
     WCHAR module_path[module_path_size]{};

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.h
@@ -486,9 +486,9 @@ struct FunctionInfo
     }
 };
 
-RuntimeInformation GetRuntimeInformation(ICorProfilerInfo4* info);
+RuntimeInformation GetRuntimeInformation(ICorProfilerInfo7* info);
 
-AssemblyInfo GetAssemblyInfo(ICorProfilerInfo4* info, const AssemblyID& assembly_id);
+AssemblyInfo GetAssemblyInfo(ICorProfilerInfo7* info, const AssemblyID& assembly_id);
 
 AssemblyMetadata GetAssemblyImportMetadata(const ComPtr<IMetaDataAssemblyImport>& assembly_import);
 
@@ -497,7 +497,7 @@ AssemblyMetadata GetReferencedAssemblyMetadata(const ComPtr<IMetaDataAssemblyImp
 
 FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token);
 
-ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id);
+ModuleInfo GetModuleInfo(ICorProfilerInfo7* info, const ModuleID& module_id);
 
 TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token);
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -94,11 +94,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         return E_FAIL;
     }
 
-    // get Profiler interface
-    HRESULT hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo4), (void**) &this->info_);
+    // get ICorProfilerInfo7 interface for .NET Framework >= 4.6.1 and any .NET (Core) 
+    HRESULT hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo7), (void**) &this->info_);
     if (FAILED(hr))
     {
-        Logger::Warn("OpenTelemetry TRACER DIAGNOSTICS - Failed to attach profiler: interface ICorProfilerInfo4 not found.");
+        Logger::Warn("OpenTelemetry TRACER DIAGNOSTICS - Failed to attach profiler: interface ICorProfilerInfo7 not found.");
         return E_FAIL;
     }
 
@@ -107,17 +107,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     if (process_name == WStr("w3wp.exe") || process_name == WStr("iisexpress.exe"))
     {
         is_desktop_iis = runtime_information_.is_desktop();
-    }
-
-    // get ICorProfilerInfo6 for net46+
-    ICorProfilerInfo6* info6;
-    hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo6), (void**)&info6);
-
-    // Fail if net46+ not detected
-    // TODO: Update this to ICorProfilerInfo7 which corresponds to net462 and make CorProfilerBase.info_ have type ICorProfilerInfo7*
-    if (FAILED(hr)) {
-        Logger::Warn("OpenTelemetry TRACER DIAGNOSTICS - Failed to attach profiler: interface ICorProfilerInfo6 not found.");
-        return E_FAIL;
     }
 
     // get ICorProfilerInfo10 for >= .NET Core 3.0
@@ -132,10 +121,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         // and the necessary dependencies are not available yet.
         use_dotnet_startuphook_bootstrapper = true;
     }
-    else
-    {
-        info10 = nullptr;
-    }
+    info10 = nullptr;
 
     Logger::Info("Environment variables:");
     for (auto&& env_var : env_vars_to_display)
@@ -189,7 +175,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         return this->CallTarget_RewriterCallback(mod, method);
     };
 
-    rejit_handler = new RejitHandler(info6, callback);
+    rejit_handler = new RejitHandler(this->info_, callback);
 
     // load all integrations from JSON files
     LoadIntegrationsFromEnvironment(integration_methods_, GetEnvironmentValues(environment::disabled_integrations));
@@ -230,7 +216,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     }
 
     // set event mask to subscribe to events and disable NGEN images
-    hr = info6->SetEventMask2(event_mask, COR_PRF_HIGH_ADD_ASSEMBLY_REFERENCES);
+    hr = this->info_->SetEventMask2(event_mask, COR_PRF_HIGH_ADD_ASSEMBLY_REFERENCES);
     if (FAILED(hr))
     {
         Logger::Warn("OpenTelemetry TRACER DIAGNOSTICS - Failed to attach profiler: unable to set event mask.");

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler_base.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler_base.h
@@ -14,7 +14,7 @@ private:
     std::atomic<int> ref_count_;
 
 protected:
-    ICorProfilerInfo4* info_;
+    ICorProfilerInfo7* info_;
 
 public:
     CorProfilerBase();

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
@@ -74,7 +74,7 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
     ModuleID currentModuleId = m_module->GetModuleId();
     mdMethodDef currentMethodDef = m_methodDef;
     RejitHandler* handler = m_module->GetHandler();
-    ICorProfilerInfo6* pInfo = handler->GetCorProfilerInfo6();
+    ICorProfilerInfo7* pInfo = handler->GetCorProfilerInfo7();
 
     if (pInfo != nullptr)
     {
@@ -216,10 +216,10 @@ void RejitHandler::RequestRejitForInlinersInModule(ModuleID moduleId)
     }
 }
 
-RejitHandler::RejitHandler(ICorProfilerInfo6* pInfo,
+RejitHandler::RejitHandler(ICorProfilerInfo7* pInfo,
                            std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> rewriteCallback)
 {
-    m_profilerInfo6 = pInfo;
+    m_profilerInfo7 = pInfo;
     m_rewriteCallback = rewriteCallback;
 }
 
@@ -280,7 +280,7 @@ void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector, std::vecto
     // Instead of using RequestReJITWithInliners to handle inlined methods that are targeted
     // for instrumentation the code uses the ICorProfilerCallback::JITInlining callback instead.
     // On the callback the profiler blocks the inlining of any method targeted for instrumentation.
-    HRESULT hr = m_profilerInfo6->RequestReJIT((ULONG) length, modulesVector.data(), modulesMethodDef.data());
+    HRESULT hr = m_profilerInfo7->RequestReJIT((ULONG) length, modulesVector.data(), modulesMethodDef.data());
     if (SUCCEEDED(hr))
     {
         Logger::Info("Request ReJIT done for ", length, " methods");
@@ -294,7 +294,7 @@ void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector, std::vecto
 void RejitHandler::Shutdown()
 {
     m_modules.clear();
-    m_profilerInfo6 = nullptr;
+    m_profilerInfo7 = nullptr;
     m_rewriteCallback = nullptr;
 }
 
@@ -363,14 +363,14 @@ HRESULT RejitHandler::NotifyReJITCompilationStarted(FunctionID functionId, ReJIT
     return S_OK;
 }
 
-ICorProfilerInfo6* RejitHandler::GetCorProfilerInfo6()
+ICorProfilerInfo7* RejitHandler::GetCorProfilerInfo7()
 {
-    return m_profilerInfo6;
+    return m_profilerInfo7;
 }
 
 void RejitHandler::RequestRejitForNGenInliners()
 {
-    if (m_profilerInfo6 != nullptr)
+    if (m_profilerInfo7 != nullptr)
     {
         std::lock_guard<std::mutex> guard(m_ngenModules_lock);
         for (const auto& mod : m_ngenModules)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.h
@@ -88,7 +88,7 @@ private:
     std::mutex m_modules_lock;
     std::unordered_map<ModuleID, std::unique_ptr<RejitHandlerModule>> m_modules;
 
-    ICorProfilerInfo6* m_profilerInfo6;
+    ICorProfilerInfo7* m_profilerInfo7;
 
     std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> m_rewriteCallback;
 
@@ -98,7 +98,7 @@ private:
     void RequestRejitForInlinersInModule(ModuleID moduleId);
 
 public:
-    RejitHandler(ICorProfilerInfo6* pInfo,
+    RejitHandler(ICorProfilerInfo7* pInfo,
                  std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> rewriteCallback);
 
     RejitHandlerModule* GetOrAddModule(ModuleID moduleId);
@@ -116,7 +116,7 @@ public:
                                   ICorProfilerFunctionControl* pFunctionControl, ModuleMetadata* metadata);
     HRESULT NotifyReJITCompilationStarted(FunctionID functionId, ReJITID rejitId);
 
-    ICorProfilerInfo6* GetCorProfilerInfo6();
+    ICorProfilerInfo7* GetCorProfilerInfo7();
 
     void RequestRejitForNGenInliners();
 };


### PR DESCRIPTION
## Why

Simplify code, ensure that we are using the highest available interface.

Fixes #1288 

## What

Update to ICorProfilerInfo7. It is available since .NET 4.6.1.
Replaces usages of older interfaces in our/upstream code.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
