### PR TITLE
Rename TestProjectFilter build parameter to TestProject

### DIFF
--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -4,7 +4,7 @@ name: verify-test
 on:
   workflow_dispatch:
     inputs:
-      testProjectFilter:
+      testProject:
         description: String that partially matches test projects to run. Defaults to all test projects.
         required: false
       testName:
@@ -34,7 +34,7 @@ jobs:
           dotnet-version: | 
             3.1.x
             6.0.x
-      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project-filter "${{ github.event.inputs.testProjectFilter }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}
+      - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project "${{ github.event.inputs.testProject }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.0
         if: always()

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -295,10 +295,10 @@ partial class Build
                 Solution.GetProject(Projects.Tests.AutoInstrumentationTests)
             };
 
-            if (!string.IsNullOrWhiteSpace(TestProjectFilter))
+            if (!string.IsNullOrWhiteSpace(TestProject))
             {
                 unitTestProjects = unitTestProjects
-                    .Where(p => p.Name.Contains(TestProjectFilter, StringComparison.OrdinalIgnoreCase))
+                    .Where(p => p.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
                     .ToArray();
                 if (unitTestProjects.Length == 0)
                 {
@@ -326,7 +326,7 @@ partial class Build
         .Executes(() =>
         {
             var project = Solution.GetProject("IntegrationTests");
-            if (!string.IsNullOrWhiteSpace(TestProjectFilter) && !project.Name.Contains(TestProjectFilter, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(TestProject) && !project.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -429,7 +429,7 @@ partial class Build
     private void RunBootstrappingTests()
     {
         var project = Solution.GetProject(Projects.Tests.AutoInstrumentationBootstrappingTests);
-        if (!string.IsNullOrWhiteSpace(TestProjectFilter) && !project.Name.Contains(TestProjectFilter, StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrWhiteSpace(TestProject) && !project.Name.Contains(TestProject, StringComparison.OrdinalIgnoreCase))
         {
             // Test project was not selected.
             return;

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -26,7 +26,7 @@ partial class Build : NukeBuild
     const string ContainersWindows = "windows";
 
     [Parameter("Test projects to be run. Optional, default matches all test projects. The project will be selected if the string is part of its name.")]
-    readonly string TestProjectFilter = "";
+    readonly string TestProject = "";
 
     [Parameter("Test name to be run. Optional")]
     readonly string TestName;


### PR DESCRIPTION
## Why

Less typing when running

```
nuke ManagedTests --test-project Integration --test-name SmokeTests
```
```


## What

Rename TestProjectFilter build parameter to TestProject
