### PR TITLE
Separate logic used for asserting metrics and resource attributes

### DIFF
--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -186,7 +186,7 @@ public class MockMetricsCollector : IDisposable
         }
         catch (ArgumentOutOfRangeException)
         {
-            // CancelAfter called with non-positive value
+            // WaitOne called with non-positive value
             FailResourceMetrics(_resourceExpectations, null);
         }
     }

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -289,11 +289,11 @@ public class MockMetricsCollector : IDisposable
                         }
 
                         // process metrics snapshot
+                        var metricsSnapshot = new List<Collected>();
                         foreach (var sMetrics in rMetrics.ScopeMetrics)
                         {
                             if (sMetrics.Metrics != null)
                             {
-                                var metricsSnapshot = new List<Collected>(sMetrics.Metrics.Count);
                                 foreach (var metric in sMetrics.Metrics)
                                 {
                                     metricsSnapshot.Add(new Collected
@@ -302,10 +302,10 @@ public class MockMetricsCollector : IDisposable
                                         Metric = metric
                                     });
                                 }
-
-                                _metricsSnapshots.Add(metricsSnapshot);
                             }
                         }
+
+                        _metricsSnapshots.Add(metricsSnapshot);
                     }
                 }
             }


### PR DESCRIPTION
## Why

1. I want to add resource attribute tests to logs and spans. **The pattern from this PR can be easily reused in other MockCollectors.** _Which cannot be said for the currently used logic (before PR)._
2. I find it is cleaner to have the metrics/logs/spans test helper logic+structures separated. It can be even moved to separate classes (or methods), but I found it an overkill at this moment.
3. A good side effect is that it allows asserting for metrics and resource attributes in the same test (the assertion methods are not interfering)

## What

Separate the structures and logic used for asserting metrics and resource attributes.

## Tests

CI