### PR TITLE
Stabilize and speedup LogTests

### DIFF
--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -100,7 +100,7 @@ public abstract class TestHelper
     /// RunTestApplication starts the test application, wait up to DefaultProcessTimeout.
     /// Assertion exceptions are thrown if it timed out or the exit code is non-zero.
     /// </summary>
-    public void RunTestApplication(int traceAgentPort = 0, int metricsAgentPort = 0, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool enableStartupHook = true, bool enableClrProfiler = true)
+    public void RunTestApplication(int traceAgentPort = 0, int metricsAgentPort = 0, int logsAgentPort = 0, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool enableStartupHook = true, bool enableClrProfiler = true)
     {
         var testSettings = new TestSettings
         {
@@ -120,6 +120,11 @@ public abstract class TestHelper
         if (metricsAgentPort != 0)
         {
             testSettings.MetricsSettings = new() { Port = metricsAgentPort };
+        }
+
+        if (logsAgentPort != 0)
+        {
+            testSettings.LogSettings = new() { Port = logsAgentPort };
         }
 
         RunTestApplication(testSettings);

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -15,13 +15,11 @@
 // </copyright>
 
 #if !NETFRAMEWORK
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using IntegrationTests.Helpers;
-using OpenTelemetry.Proto.Common.V1;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/IntegrationTests/LogTests.cs
+++ b/test/IntegrationTests/LogTests.cs
@@ -17,10 +17,7 @@
 #if !NETFRAMEWORK
 
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/test-applications/integrations/TestApplication.Logs/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Logs/Program.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Net.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
@@ -23,13 +24,19 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        CreateHostBuilder(args).Build().Run();
+        var port = IntegrationTests.Helpers.TcpPortProvider.GetOpenPort();
+        using var host = CreateHostBuilder(args, port).Build();
+        host.Start();
+
+        using var httpClient = new HttpClient();
+        httpClient.GetAsync($"http://localhost:{port}/test").Wait();
     }
 
-    public static IHostBuilder CreateHostBuilder(string[] args) =>
+    public static IHostBuilder CreateHostBuilder(string[] args, int port) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseStartup<Startup>();
+                webBuilder.UseUrls($"http://localhost:{port}");
             });
 }

--- a/test/test-applications/integrations/TestApplication.Logs/TestApplication.Logs.csproj
+++ b/test/test-applications/integrations/TestApplication.Logs/TestApplication.Logs.csproj
@@ -4,4 +4,8 @@
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\..\IntegrationTests\Helpers\TcpPortProvider.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Why

The tests sometimes failed. I think that the pattern used in `HttpTests` seems to be more stable (and faster). Also, it makes the test code simpler.

## What

Change the `TestApplication.Logs` to call itself and exit.

## Tests

CI