### PR TITLE
Add diagnostic messages and hang dumps for IntegrationTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,5 +302,8 @@ src/OpenTelemetry.AutoInstrumentation.Native/cmake_install.cmake
 # ignore verify .received files
 *.received.*
 
+# profiler and test logs
+/build_data
+
 # install.sh downloaded artifacts
 /otel-dotnet-auto/

--- a/build/nuke/Build.Steps.cs
+++ b/build/nuke/Build.Steps.cs
@@ -339,6 +339,7 @@ partial class Build
                     .SetConfiguration(BuildConfiguration)
                     .SetTargetPlatform(Platform)
                     .SetFilter(AndFilter(TestNameFilter(), ContainersFilter()))
+                    .SetBlameHangTimeout("3m")
                     .EnableTrxLogOutput(GetResultsDirectory(project))
                     .SetProjectFile(project)
                     .EnableNoRestore()

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.21.6" />
-    <PackageReference Include="Grpc.Tools" Version="2.49.0" PrivateAssets="all" />
+    <PackageReference Include="Grpc.Tools" Version="2.49.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StrongNamer" Version="0.2.5" Condition="$(TargetFramework.StartsWith('net4'))" />

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTelemetry.AutoInstrumentation\OpenTelemetry.AutoInstrumentation.csproj" />
   </ItemGroup>
 

--- a/test/IntegrationTests/VerboseTestFramework.cs
+++ b/test/IntegrationTests/VerboseTestFramework.cs
@@ -1,0 +1,138 @@
+// <copyright file="VerboseTestFramework.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("IntegrationTests.Helpers.VerboseTestFramework", "IntegrationTests")]
+
+namespace IntegrationTests.Helpers;
+
+public class VerboseTestFramework : XunitTestFramework
+{
+    public VerboseTestFramework(IMessageSink messageSink)
+        : base(messageSink)
+    {
+    }
+
+    protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+    {
+        return new VerboseTestExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+    }
+
+    private class VerboseTestExecutor : XunitTestFrameworkExecutor
+    {
+        public VerboseTestExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink)
+            : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
+        {
+        }
+
+        protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+        {
+            using (var assemblyRunner = new VerboseTestAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+            {
+                await assemblyRunner.RunAsync();
+            }
+        }
+    }
+
+    private class VerboseTestAssemblyRunner : XunitTestAssemblyRunner
+    {
+        public VerboseTestAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+            : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+        {
+        }
+
+        protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
+        {
+            return new VerboseTestCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), cancellationTokenSource).RunAsync();
+        }
+    }
+
+    private class VerboseTestCollectionRunner : XunitTestCollectionRunner
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public VerboseTestCollectionRunner(ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+        {
+            return new VerboseTestClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, CollectionFixtureMappings)
+               .RunAsync();
+        }
+    }
+
+    private class VerboseTestClassRunner : XunitTestClassRunner
+    {
+        public VerboseTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings)
+            : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+        {
+        }
+
+        protected override Task<RunSummary> RunTestMethodAsync(ITestMethod testMethod, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, object[] constructorArguments)
+        {
+            return new VerboseTestMethodRunner(testMethod, this.Class, method, testCases, this.DiagnosticMessageSink, this.MessageBus, new ExceptionAggregator(this.Aggregator), this.CancellationTokenSource, constructorArguments)
+               .RunAsync();
+        }
+    }
+
+    private class VerboseTestMethodRunner : XunitTestMethodRunner
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public VerboseTestMethodRunner(ITestMethod testMethod, IReflectionTypeInfo @class, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments)
+            : base(testMethod, @class, method, testCases, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource, constructorArguments)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
+        {
+            var parameters = string.Empty;
+            if (testCase.TestMethodArguments != null)
+            {
+                parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString() ?? "null"));
+            }
+
+            var test = $"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}({parameters})";
+            _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"=== RUN   {test}"));
+
+            try
+            {
+                var result = await base.RunTestCaseAsync(testCase);
+                var status = result.Failed > 0 ? "FAIL" : "PASS";
+                _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"--- {status}: {test} ({result.Time:0.00}s)"));
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"--- EXPT: {test} ({ex.Message})"));
+                throw;
+            }
+        }
+    }
+}

--- a/test/IntegrationTests/xunit.runner.json
+++ b/test/IntegrationTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true
+}

--- a/test/IntegrationTests/xunit.runner.json
+++ b/test/IntegrationTests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "diagnosticMessages": true
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": true
 }

--- a/test/IntegrationTests/xunit.runner.json
+++ b/test/IntegrationTests/xunit.runner.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "diagnosticMessages": true,
-  "internalDiagnosticMessages": true
+  "longRunningTestSeconds": 60,
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
## Why

Add more verbose output when running integration tests so that we can have more info when troubleshooting e.g. deadlocks in tests. Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1296

## What

Applies for `IntegrationTests`

- Add diagnostic messages when starting and finishing the test (output inspired by `go test`)
- Add diagnostics messages if a single test is taking longer than 1 minute (a message is printed each 1 minute)
- Crash and dump if a single test is taking more than 3 minutes. The dumps are stored under `build_data\results\IntegrationTests` and are stored as artifacts in `ci` GH workflow
- Configure xunit to run sequentially (more readable output, should be more pleasant for GH runners) - may take a little longer (~ 3 minutes right now)  - **I CAN REVERT THIS CHANGE**

Sample output: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/3147118594/jobs/5116310304#step:4:2635

References:
- https://github.com/dotnet/docs/blob/main/docs/core/tools/dotnet-test.md
- https://xunit.net/docs/configuration-files#diagnosticMessages
- https://andrewlock.net/tracking-down-a-hanging-xunit-test-in-ci-building-a-custom-test-framework/
