### PR TITLE
Dependabot for /src/Directory.Build.props

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,12 @@ updates:
     open-pull-requests-limit: 20
 
   - package-ecosystem: nuget
+    directory: /src
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20
+
+  - package-ecosystem: nuget
     directory: /src/OpenTelemetry.AutoInstrumentation
     schedule:
       interval: "daily"

--- a/src/Empty.csproj
+++ b/src/Empty.csproj
@@ -1,0 +1,6 @@
+<!-- This is an empty *.csproj so that dependabot can bump dependencies in Directory.Build.props. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DefaultItemExcludes>**</DefaultItemExcludes>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1312

## What

Dependabot for /src/Directory.Build.props

## Tests

None. I believe it should fix the issue or at least not harm. Same pattern is used for /test/Directory.Build.props
