### PR TITLE
Reduce smoke tests duration

### DIFF
--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -104,7 +104,10 @@ public class MockZipkinCollector : IDisposable
 
         IImmutableList<IMockSpan> relevantSpans = ImmutableList<IMockSpan>.Empty;
 
-        while (DateTime.Now < deadline)
+        // Use a do-while to ensure at least one attempt at reading the data already
+        // received. This is helpful for negative tests, ie.: no spans generated, when
+        // the process emitting the spans already finished.
+        do
         {
             lock (_syncRoot)
             {
@@ -122,6 +125,7 @@ public class MockZipkinCollector : IDisposable
 
             await Task.Delay(500);
         }
+        while (DateTime.Now < deadline);
 
         if (!returnAllOperations)
         {

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -241,6 +241,8 @@ public class SmokeTests : TestHelper
         using var agent = await MockZipkinCollector.Start(Output);
         RunTestApplication(agent.Port, enableStartupHook: enableStartupHook);
 
-        return await agent.WaitForSpansAsync(2);
+        // The process emitting the spans already finished by this time, there is no need to wait more,
+        // just get the spans received so far.
+        return await agent.WaitForSpansAsync(count: 2, timeout: TimeSpan.Zero);
     }
 }


### PR DESCRIPTION
## Why

Reduce smoke tests by 2 minutes.

## What

Negative tests are waiting 2 minutes without the need for that. This change simply leverages the fact that for the smoke tests the instrumented app is already finished when calling WaitForSpans.

## Tests

- Multiple runs of smoke tests: https://github.com/pjanotti/opentelemetry-dotnet-instrumentation/actions/runs/3178622774
- Clean CI pass: https://github.com/pjanotti/opentelemetry-dotnet-instrumentation/actions/runs/3178579056

## Checklist

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
