### PR TITLE
Pin the scripts version in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ environment variables as parameters:
 
 ```sh
 ( set -o pipefail
-curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/main/download.sh |
+curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.3.1-beta.1/download.sh |
   VERSION=v0.3.1-beta.1 DISTRIBUTION=linux-glibc bash -s )
 ```
 
@@ -186,7 +186,7 @@ environment variables as parameters:
 > On macOS [`coreutils`](https://formulae.brew.sh/formula/coreutils) is required.
 
 ```sh
-curl -fL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/main/instrument.sh -O
+curl -fL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.3.1-beta.1/instrument.sh -O
 DISTRIBUTION=linux-glibc source ./instrument.sh
 OTEL_SERVICE_NAME=myapp dotnet run
 ```


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1357

## What

Pin scripts to a tag.

## Tests

It does not work until we publish a new release. But I do not think it is that bad as at least we will not forget about it later and we have a "notice" in the beginning of the readme:

> The following documentation refers to the in-development version
of OpenTelemetry .NET Automatic Instrumentation

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] Documentation is updated.
- [ ] ~~New features are covered by tests.~~
