### PR TITLE
Prometheus exporter is not stable on Linux and macOS

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -143,6 +143,10 @@ environment variables for the OTLP exporter:
 
 ### Prometheus
 
+> ⚠️ **Do NOT use in production.**
+>
+> Prometheus exporter uses [an unreliable, unmaintained legacy .NET component](https://github.com/dotnet/runtime/issues/28658#issuecomment-462062760).
+
 To enable the Prometheus exporter, set the `OTEL_METRICS_EXPORTER` environment
 variable to `prometheus`.
 


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1363

## What

- Run PrometheusExporter test only on Windows (.NET Framework). I think it is good enought and we do not need to run the test for .NET (Core). To do it we would need to create a custom `Fact` attribute that will skip tests on OSes other than Windows. I think it is not worth the effort.
- I also looked quickly add other smoke tests. Added comment and one missing test which I find quite important.

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
