### PR TITLE
[WIP | Experimental] Kestrel Mock Zipkin Collector

### DIFF
--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
## Why

Fun thing to try out to stabilize tests.
_Source issue discovered by @pellared  https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1363#issuecomment-1268412906_

## What

Switches `HttpListener` to AspNetCore Kestrel minimal server.

## Tests

Existing.
