### PR TITLE
Change INSTALL_DIR to OTEL_DOTNET_AUTO_HOME in scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           export OS_TYPE=${{ matrix.os_type }} 
           curl -sSfL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/download.sh -O
           sh ./download.sh
-            test "$(ls -A ./otel-dotnet-auto)"
+            test "$(ls -A "$HOME/.otel-dotnet-auto")"
           curl -sSfL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/instrument.sh -O
           . ./instrument.sh
           dotnet help

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,23 +101,23 @@ When running your application, make sure to:
 1. Set the [resources](config.md#resources).
 1. Set the environment variables from the table below.
 
-| Environment variable                 | .NET version           | Value                                                                               |
-|--------------------------------------|------------------------|-------------------------------------------------------------------------------------|
-| `COR_ENABLE_PROFILING`               | .NET Framework         | `1`                                                                                 |
-| `COR_PROFILER`                       | .NET Framework         | `{918728DD-259F-4A6A-AC2B-B85E1B658318}`                                            |
-| `COR_PROFILER_PATH_32`               | .NET Framework         | `$INSTALL_DIR/win-x86/OpenTelemetry.AutoInstrumentation.Native.dll`                 |
-| `COR_PROFILER_PATH_64`               | .NET Framework         | `$INSTALL_DIR/win-x64/OpenTelemetry.AutoInstrumentation.Native.dll`                 |
-| `CORECLR_ENABLE_PROFILING`           | .NET (Core)            | `1`                                                                                 |
-| `CORECLR_PROFILER`                   | .NET (Core)            | `{918728DD-259F-4A6A-AC2B-B85E1B658318}`                                            |
-| `CORECLR_PROFILER_PATH`              | .NET (Core) on Linux   | `$INSTALL_DIR/OpenTelemetry.AutoInstrumentation.Native.so`    |
-| `CORECLR_PROFILER_PATH`              | .NET (Core) on macOS   | `$INSTALL_DIR/OpenTelemetry.AutoInstrumentation.Native.dylib` |
-| `CORECLR_PROFILER_PATH_32`           | .NET (Core) on Windows | `$INSTALL_DIR/win-x86/OpenTelemetry.AutoInstrumentation.Native.dll`                 |
-| `CORECLR_PROFILER_PATH_64`           | .NET (Core) on Windows | `$INSTALL_DIR/win-x64/OpenTelemetry.AutoInstrumentation.Native.dll`                 |
-| `DOTNET_ADDITIONAL_DEPS`             | .NET (Core)            | `$INSTALL_DIR/AdditionalDeps`                                                       |
-| `DOTNET_SHARED_STORE`                | .NET (Core)            | `$INSTALL_DIR/store`                                                                |
-| `DOTNET_STARTUP_HOOKS`               | .NET (Core)            | `$INSTALL_DIR/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll`      |
-| `OTEL_DOTNET_AUTO_HOME`              | All versions           | `$INSTALL_DIR`                                                                      |
-| `OTEL_DOTNET_AUTO_INTEGRATIONS_FILE` | All versions           | `$INSTALL_DIR/integrations.json`                                                    |
+| Environment variable                 | .NET version           | Value                                                                          |
+|--------------------------------------|------------------------|--------------------------------------------------------------------------------|
+| `COR_ENABLE_PROFILING`               | .NET Framework         | `1`                                                                            |
+| `COR_PROFILER`                       | .NET Framework         | `{918728DD-259F-4A6A-AC2B-B85E1B658318}`                                       |
+| `COR_PROFILER_PATH_32`               | .NET Framework         | `$INSTALL_DIR/win-x86/OpenTelemetry.AutoInstrumentation.Native.dll`            |
+| `COR_PROFILER_PATH_64`               | .NET Framework         | `$INSTALL_DIR/win-x64/OpenTelemetry.AutoInstrumentation.Native.dll`            |
+| `CORECLR_ENABLE_PROFILING`           | .NET (Core)            | `1`                                                                            |
+| `CORECLR_PROFILER`                   | .NET (Core)            | `{918728DD-259F-4A6A-AC2B-B85E1B658318}`                                       |
+| `CORECLR_PROFILER_PATH`              | .NET (Core) on Linux   | `$INSTALL_DIR/OpenTelemetry.AutoInstrumentation.Native.so`                     |
+| `CORECLR_PROFILER_PATH`              | .NET (Core) on macOS   | `$INSTALL_DIR/OpenTelemetry.AutoInstrumentation.Native.dylib`                  |
+| `CORECLR_PROFILER_PATH_32`           | .NET (Core) on Windows | `$INSTALL_DIR/win-x86/OpenTelemetry.AutoInstrumentation.Native.dll`            |
+| `CORECLR_PROFILER_PATH_64`           | .NET (Core) on Windows | `$INSTALL_DIR/win-x64/OpenTelemetry.AutoInstrumentation.Native.dll`            |
+| `DOTNET_ADDITIONAL_DEPS`             | .NET (Core)            | `$INSTALL_DIR/AdditionalDeps`                                                  |
+| `DOTNET_SHARED_STORE`                | .NET (Core)            | `$INSTALL_DIR/store`                                                           |
+| `DOTNET_STARTUP_HOOKS`               | .NET (Core)            | `$INSTALL_DIR/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll` |
+| `OTEL_DOTNET_AUTO_HOME`              | All versions           | `$INSTALL_DIR`                                                                 |
+| `OTEL_DOTNET_AUTO_INTEGRATIONS_FILE` | All versions           | `$INSTALL_DIR/integrations.json`                                               |
 
 > Some settings can be omitted on .NET (Core). For more information, see [config.md](config.md#net-clr-profiler).
 
@@ -138,21 +138,20 @@ OTEL_SERVICE_NAME=myapp OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging,
 
 [download.sh](../download.sh) script uses environment variables as parameters:
 
-| Parameter      | Description                                                      | Required | Default value                                                                     |
-|----------------|------------------------------------------------------------------|----------|-----------------------------------------------------------------------------------|
-| `INSTALL_DIR`  | Location where binaries are to be installed                      | No       | `./otel-dotnet-auto`                                                              |
-| `OS_TYPE`      | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | Yes      |                                                                                   |
-| `RELEASES_URL` | GitHub releases URL                                              | No       | `https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases` |
-| `TMPDIR`       | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`                                                                    |
-| `VERSION`      | Version to download                                              | No       | `v0.3.1-beta.1`                                                                   |
+| Parameter               | Description                                                      | Required | Default value             |
+|-------------------------|------------------------------------------------------------------|----------|---------------------------|
+| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
+| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | Yes      |                           |
+| `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
+| `VERSION`               | Version to download                                              | No       | `v0.3.1-beta.1`           |
 
 [instrument.sh](../instrument.sh) script uses environment variables as parameters:
 
-| Parameter          | Description                                                            | Required | Default value        |
-|--------------------|------------------------------------------------------------------------|----------|----------------------|
-| `ENABLE_PROFILING` | Whether to set the .NET CLR Profiler, possible values: `true`, `false` | No       | `true`               |
-| `INSTALL_DIR`      | Location where binaries are to be installed                            | No       | `./otel-dotnet-auto` |
-| `OS_TYPE`          | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows`       | Yes      |                      |
+| Parameter               | Description                                                            | Required | Default value             |
+|-------------------------|------------------------------------------------------------------------|----------|---------------------------|
+| `ENABLE_PROFILING`      | Whether to set the .NET CLR Profiler, possible values: `true`, `false` | No       | `true`                    |
+| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                            | No       | `$HOME/.otel-dotnet-auto` |
+| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows`       | Yes      |                           |
 
 > On macOS [`coreutils`](https://formulae.brew.sh/formula/coreutils) is required.
 

--- a/download.sh
+++ b/download.sh
@@ -10,19 +10,18 @@ case "$OS_TYPE" in
     ;;
 esac
 
-test -z "$INSTALL_DIR" && INSTALL_DIR="./otel-dotnet-auto"
-test -z "$RELEASES_URL" && RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
+test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
 test -z "$VERSION" && VERSION="v0.3.1-beta.1"
 
+RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
 ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"
-TMPFILE="$TMPDIR/$ARCHIVE"
 
+TMPFILE="$TMPDIR/$ARCHIVE"
 (
   cd "$TMPDIR"
   echo "Downloading $VERSION for $OS_TYPE..."
   curl -sSfLo "$TMPFILE" "$RELEASES_URL/download/$VERSION/$ARCHIVE"
 )
-
-rm -rf "$INSTALL_DIR"
-unzip -q "$TMPFILE" -d "$INSTALL_DIR" 
+rm -rf "$OTEL_DOTNET_AUTO_HOME"
+unzip -q "$TMPFILE" -d "$OTEL_DOTNET_AUTO_HOME" 

--- a/instrument.sh
+++ b/instrument.sh
@@ -23,27 +23,42 @@ case "$ENABLE_PROFILING" in
 esac
 
 # set defaults
-test -z "$INSTALL_DIR" && INSTALL_DIR="./otel-dotnet-auto"
+test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 
 
-# check $INSTALL_DIR and use it to set the absolute path $OTEL_DIR 
-if [ -z "$(ls -A $INSTALL_DIR)" ]; then
-  echo "There are no files under the location specified via INSTALL_DIR."
+# check $OTEL_DOTNET_AUTO_HOME and change it to an absolute path
+if [ -z "$(ls -A $OTEL_DOTNET_AUTO_HOME)" ]; then
+  echo "There are no files under the location specified via OTEL_DOTNET_AUTO_HOME."
   return 1
 fi
+# get absulute path
 if [ "$OS_TYPE" == "macos" ]; then
-  OTEL_DIR=$(greadlink -fn $INSTALL_DIR)
+  OTEL_DOTNET_AUTO_HOME=$(greadlink -fn $OTEL_DOTNET_AUTO_HOME)
 else
-  OTEL_DIR=$(readlink -fn $INSTALL_DIR)
+  OTEL_DOTNET_AUTO_HOME=$(readlink -fn $OTEL_DOTNET_AUTO_HOME)
 fi
+if [ -z "$OTEL_DOTNET_AUTO_HOME" ]; then
+  echo "Failed to get OTEL_DOTNET_AUTO_HOME absolute path."
+  return 1
+fi
+# on Windows change to Windows path format
 if [ "$OS_TYPE" == "windows" ]; then
-  OTEL_DIR=$(cygpath -w $OTEL_DIR)
+  OTEL_DOTNET_AUTO_HOME=$(cygpath -w $OTEL_DOTNET_AUTO_HOME)
 fi
-if [ -z "$OTEL_DIR" ]; then
-  echo "Failed to get INSTALL_DIR absolute path. "
+if [ -z "$OTEL_DOTNET_AUTO_HOME" ]; then
+  echo "Failed to get OTEL_DOTNET_AUTO_HOME absolute Windows path."
   return 1
 fi
 
+# Configure OpenTelemetry .NET Auto-Instrumentation
+export OTEL_DOTNET_AUTO_HOME
+
+# Configure .NET Core Runtime
+export DOTNET_ADDITIONAL_DEPS="$OTEL_DOTNET_AUTO_HOME/AdditionalDeps"
+export DOTNET_SHARED_STORE="$OTEL_DOTNET_AUTO_HOME/store"
+export DOTNET_STARTUP_HOOKS="$OTEL_DOTNET_AUTO_HOME/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll"
+
+# Configure .NET CLR Profiler
 if [ "$ENABLE_PROFILING" = "true" ]; then
   # Set the .NET CLR Profiler file sufix
   case "$OS_TYPE" in
@@ -68,8 +83,8 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
     export COR_ENABLE_PROFILING="1"
     export COR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
     # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
-    export COR_PROFILER_PATH_64="$OTEL_DIR/win-x64/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
-    export COR_PROFILER_PATH_32="$OTEL_DIR/win-x86/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
+    export COR_PROFILER_PATH_64="$OTEL_DOTNET_AUTO_HOME/win-x64/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
+    export COR_PROFILER_PATH_32="$OTEL_DOTNET_AUTO_HOME/win-x86/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
   fi
 
   # Enable .NET Core Profiling API
@@ -78,20 +93,12 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
   if [ "$OS_TYPE" == "windows" ]
   then
     # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
-    export CORECLR_PROFILER_PATH_64="$OTEL_DIR/win-x64/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
-    export CORECLR_PROFILER_PATH_32="$OTEL_DIR/win-x86/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
+    export CORECLR_PROFILER_PATH_64="$OTEL_DOTNET_AUTO_HOME/win-x64/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
+    export CORECLR_PROFILER_PATH_32="$OTEL_DOTNET_AUTO_HOME/win-x86/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
   else
-    export CORECLR_PROFILER_PATH="$OTEL_DIR/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
+    export CORECLR_PROFILER_PATH="$OTEL_DOTNET_AUTO_HOME/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"
   fi
 
   # Configure the bytecode instrumentation configuration file
-  export OTEL_DOTNET_AUTO_INTEGRATIONS_FILE="$OTEL_DIR/integrations.json"
+  export OTEL_DOTNET_AUTO_INTEGRATIONS_FILE="$OTEL_DOTNET_AUTO_HOME/integrations.json"
 fi
-
-# Configure .NET Core Runtime
-export DOTNET_ADDITIONAL_DEPS="$OTEL_DIR/AdditionalDeps"
-export DOTNET_SHARED_STORE="$OTEL_DIR/store"
-export DOTNET_STARTUP_HOOKS="$OTEL_DIR/netcoreapp3.1/OpenTelemetry.AutoInstrumentation.StartupHook.dll"
-
-# Configure OpenTelemetry .NET Auto-Instrumentation
-export OTEL_DOTNET_AUTO_HOME="$OTEL_DIR"


### PR DESCRIPTION
## Why

Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1373

1. User can define a global machine-wide (or user-wide) `OTEL_DOTNET_AUTO_HOME` so that `INSTALL_DIR` (which is not a unique name) does not have to be provided when a custom installation path is used
   1. At some point `install.sh` could even set OTEL_DOTNET_AUTO_HOME as a global env var to facilitate using `./instrument.sh`. Not now for sure - personally I want to postpone setting global env vars until we see that it is beneficial)
1. Takes advantage of existing env var name which is required anyway

Also, change the default so that, by default, the `./instrument.sh` could be used from a different location.

## What

- Change `INSTALL_DIR` env var script param to `OTEL_DOTNET_AUTO_HOME`
- Change the default installation path to `$HOME/.otel-auto-dotnet`
  - Based on what `dotnet-install.sh`
  - It is not dependent on `$PWD`
  - Does not require admin rights
- Remove `RELEASES_URL` script param (YAGNI)

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- [x] New features are covered by tests.
