### PR TITLE
Ensure ./run-example.sh adds bytecode instr.

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "9090:9090"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.57.2
+    image: otel/opentelemetry-collector-contrib:0.61.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
     command: --config /etc/otel/config.yaml

--- a/dev/envvars.sh
+++ b/dev/envvars.sh
@@ -34,11 +34,11 @@ OS=$(uname_os)
 ENABLE_PROFILING=${ENABLE_PROFILING:-1}
 
 # Enable .NET Framework Profiling API
-export COR_ENABLE_PROFILING="${ENABLE_PROFILING}"
-export COR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
-export COR_PROFILER_PATH="${CURDIR}/bin/tracer-home/OpenTelemetry.AutoInstrumentation.Native.${SUFIX}"
 if [ "$OS" == "windows" ]
 then
+    export COR_ENABLE_PROFILING="${ENABLE_PROFILING}"
+    export COR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
+    export COR_PROFILER_PATH="${CURDIR}/bin/tracer-home/OpenTelemetry.AutoInstrumentation.Native.${SUFIX}"
     # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
     export COR_PROFILER_PATH_64="${CURDIR}/bin/tracer-home/win-x64/OpenTelemetry.AutoInstrumentation.Native.${SUFIX}"
     export COR_PROFILER_PATH_32="${CURDIR}/bin/tracer-home/win-x86/OpenTelemetry.AutoInstrumentation.Native.${SUFIX}"
@@ -65,8 +65,8 @@ export OTEL_DOTNET_AUTO_HOME="${CURDIR}/bin/tracer-home"
 export OTEL_DOTNET_AUTO_INTEGRATIONS_FILE="${CURDIR}/bin/tracer-home/integrations.json"
 export OTEL_DOTNET_AUTO_DEBUG="1"
 export OTEL_DOTNET_AUTO_DUMP_ILREWRITE_ENABLED="0"
-export OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES="dotnet.exe,dotnet"
+export OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES=${OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES:-dotnet.exe,dotnet}
 
 # Enable console exporters
-export OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED="true"
-export OTEL_DOTNET_AUTO_METRICS_CONSOLE_EXPORTER_ENABLED="true"
+export OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED=${OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED:-true}
+export OTEL_DOTNET_AUTO_METRICS_CONSOLE_EXPORTER_ENABLED=${OTEL_DOTNET_AUTO_METRICS_CONSOLE_EXPORTER_ENABLED:-true}

--- a/dev/otel-config.yaml
+++ b/dev/otel-config.yaml
@@ -39,4 +39,8 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [prometheus, logging]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]
   extensions: [health_check, zpages]

--- a/dev/otel-config.yaml
+++ b/dev/otel-config.yaml
@@ -8,13 +8,6 @@ receivers:
     protocols:
       grpc:
       http:
-  jaeger:
-    protocols:
-      grpc:
-      thrift_binary:
-      thrift_compact:
-      thrift_http:
-  zipkin:
 
 processors:
   batch:
@@ -32,7 +25,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [otlp, jaeger, zipkin]
+      receivers: [otlp]
       processors: [batch]
       exporters: [jaeger, logging]
     metrics:


### PR DESCRIPTION
## Why

Bytecode instrumentation is not available when running ./run-example.sh

## What

- Make 3 env vars from `dev/envvars.sh` configurable and prevent `dotnet.exe` and `dotnet` from being excluded when running ./run-example.sh
- Fixed `vendorPluginTargetFramework` on `./run-example.sh`
- Enabled logs on the collector config script, avoids errors being logged from processes exporting logs.

## Tests

Ran `./run-example.sh` manually.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
