### PR TITLE
Support for B3 Single propagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   is set.
 - Add ILogger logging instrumentation for .NET Core 3.1+.  
 - Add [telemetry resource attributes](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.13.0/specification/resource/semantic_conventions#telemetry-sdk).
+- Add support for the `b3` propagator.
 
 ### Changed
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -78,8 +78,8 @@ Propagators allow applications to share context. See [the OpenTelemetry specific
 for more details.
 
 | Environment variable | Description                                                                                                                                                                                                                                                                                         | Default value          |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| `OTEL_PROPAGATORS`   | Comma-separated list of propagators. Supported options: `tracecontext`, `baggage`, `b3multi`, `b3`. See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration) for more details. | `tracecontext,baggage` |
+|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `OTEL_PROPAGATORS`   | Comma-separated list of propagators. Supported options: `tracecontext`, `baggage`, `b3multi`, `b3`. See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/sdk-environment-variables.md#general-sdk-configuration) for more details. | `tracecontext,baggage` |
 
 ## Exporters
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -78,8 +78,8 @@ Propagators allow applications to share context. See [the OpenTelemetry specific
 for more details.
 
 | Environment variable | Description                                                                                                                                                                                                                                                                                         | Default value          |
-|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| `OTEL_PROPAGATORS`   | Comma-separated list of propagators. Supported options: `tracecontext`, `baggage`, `b3multi`. See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration) for more details. | `tracecontext,baggage` |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
+| `OTEL_PROPAGATORS`   | Comma-separated list of propagators. Supported options: `tracecontext`, `baggage`, `b3multi`, `b3`. See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration) for more details. | `tracecontext,baggage` |
 
 ## Exporters
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationSdkHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationSdkHelper.cs
@@ -66,6 +66,8 @@ internal static class EnvironmentConfigurationSdkHelper
                 return new BaggagePropagator();
             case Propagator.B3Multi:
                 return new Extensions.Propagators.B3Propagator(singleHeader: false);
+            case Propagator.B3Single:
+                return new Extensions.Propagators.B3Propagator(singleHeader: true);
         }
 
         throw new ArgumentOutOfRangeException(nameof(propagator), propagator, "Propagator has an unexpected value.");

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/Propagator.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/Propagator.cs
@@ -32,8 +32,12 @@ internal enum Propagator
     W3CBaggage,
 
     /// <summary>
-    /// Prometheus exporter.
     /// B3 multi propagator.
     /// </summary>
-    B3Multi
+    B3Multi,
+
+    /// <summary>
+    /// B3 single propagator.
+    /// </summary>
+    B3Single
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/SdkSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/SdkSettings.cs
@@ -67,6 +67,8 @@ internal class SdkSettings
                 return Propagator.W3CBaggage;
             case Constants.ConfigurationValues.Propagators.B3Multi:
                 return Propagator.B3Multi;
+            case Constants.ConfigurationValues.Propagators.B3Single:
+                return Propagator.B3Single;
             default:
                 throw new FormatException($"Propagator '{propagator}' is not supported");
         }

--- a/src/OpenTelemetry.AutoInstrumentation/Constants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Constants.cs
@@ -53,6 +53,7 @@ internal static class Constants
             public const string W3CTraceContext = "tracecontext";
             public const string W3CBaggage = "baggage";
             public const string B3Multi = "b3multi";
+            public const string B3Single = "b3";
         }
     }
 }

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -38,6 +38,7 @@ public class HttpTests : TestHelper
     [Theory]
     [InlineData("")] // equivalent of default value
     [InlineData("b3multi")]
+    [InlineData("b3")]
     [Trait("Category", "EndToEnd")]
     public async Task SubmitTraces(string propagators)
     {

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -160,7 +160,8 @@ public class SettingsTests : IDisposable
     [InlineData("tracecontext", new[] { Propagator.W3CTraceContext })]
     [InlineData("baggage", new[] { Propagator.W3CBaggage })]
     [InlineData("b3multi", new[] { Propagator.B3Multi })]
-    [InlineData("tracecontext,baggage,b3multi", new[] { Propagator.W3CTraceContext, Propagator.W3CBaggage, Propagator.B3Multi })]
+    [InlineData("b3", new[] { Propagator.B3Single })]
+    [InlineData("tracecontext,baggage,b3multi,b3", new[] { Propagator.W3CTraceContext, Propagator.W3CBaggage, Propagator.B3Multi, Propagator.B3Single })]
     internal void Propagators_SupportedValues(string propagators, Propagator[] expectedPropagators)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, propagators);


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->
OpenTelemetry Operator for most cases is using B3 Single propagator.

Fixes N/A

## What

Support for B3 Single propagator.
`b3` is defined in https://github.com/open-telemetry/opentelemetry-specification/blob/0ff1c36708af773f1ed8b978946959471ffa6234/specification/sdk-environment-variables.md#general-sdk-configuration

## Tests

New tests added.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
