### PR TITLE
Remove company info for emeritus

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -199,11 +199,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):
 
-- [Colin Higgins](https://github.com/colin-higgins), Datadog
-- [Greg Paperin](https://github.com/macrogreg), Datadog
-- [Kevin Gosse](https://github.com/kevingosse), Datadog
-- [Lucas Pimentel-Ordyna](https://github.com/lucaspimentel), Datadog
-- [Mike Goldsmith](https://github.com/MikeGoldsmith), HoneyComb
-- [Tony Redondo](https://github.com/tonyredondo), Datadog
+- [Colin Higgins](https://github.com/colin-higgins)
+- [Greg Paperin](https://github.com/macrogreg)
+- [Kevin Gosse](https://github.com/kevingosse)
+- [Lucas Pimentel-Ordyna](https://github.com/lucaspimentel)
+- [Mike Goldsmith](https://github.com/MikeGoldsmith)
+- [Tony Redondo](https://github.com/tonyredondo)
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).


### PR DESCRIPTION
I think the general practice is to avoid putting company name/info in the emeritus section since people will move and nobody is committed to keep tracking these.