### PR TITLE
Use jaegertracing/all-in-one:1.38.1

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2"
 services:
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:1.38.1
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     ports:


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1392#discussion_r991254381

## What

Use jaegertracing/all-in-one:1.38.1
instead of jaegertracing/all-in-one:latest

## Tests

Manual

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
