### PR TITLE
Add GH job for testing the Shell scripts on Alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
             os_type: linux-musl
     runs-on: ubuntu-20.04
     steps:
+    - uses: actions/checkout@v3.1.0
     - name: Test the Shell scripts from README.md in Docker container
       run: |
         set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           dotnet help
             test "$(ls -A '${{ matrix.log-dir }}' )"
 
- shell-scripts-container:
+  shell-scripts-container:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,11 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3.1.0
-    - name: Build Docker image
-      run: |
-        docker build \
-          --tag otel-dotnet-autoinstrumentation/${{ matrix.base-image }} \
-          --file "./docker/${{ matrix.base-image }}.dockerfile" \
-          ./build
     - name: Build in Docker container
       run: |
-        docker run --rm \
-          --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project \
-          otel-dotnet-autoinstrumentation/${{ matrix.base-image }} \
+        set -e
+        docker build -t mybuildimage -f "./docker/${{ matrix.base-image }}.dockerfile" .
+        docker run --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
           ./build.sh Workflow --containers none
     - name: Publish Linux build
       uses: actions/upload-artifact@v3.1.0
@@ -106,3 +100,28 @@ jobs:
           . ./instrument.sh
           dotnet help
             test "$(ls -A '${{ matrix.log-dir }}' )"
+
+ shell-scripts-container:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - base-image: alpine
+            os_type: linux-musl
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Test the Shell scripts from README.md in Docker container
+      run: |
+        set -e
+        docker build -t mybuildimage -f "./docker/${{ matrix.base-image }}.dockerfile" .
+        docker run --rm mybuildimage /bin/sh -c '
+          set -e
+          export OS_TYPE=${{ matrix.os_type }}
+          curl -sSfL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/download.sh -O
+          sh ./download.sh
+            test "$(ls -A "$HOME/.otel-dotnet-auto")"
+          curl -sSfL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/instrument.sh -O
+          . ./instrument.sh
+          dotnet help
+            test "$(ls -A /var/log/opentelemetry/dotnet )"
+        '

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -12,11 +12,10 @@ RUN apk update \
         protobuf-dev \
         grpc
 
-ENV IsAlpine=true
 ENV PROTOBUF_PROTOC=/usr/bin/protoc
 ENV gRPC_PluginFullPath=/usr/bin/grpc_csharp_plugin
 
-# Install older sdks using the install script
+# Install older .NET SDKs using the install script
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -c 3.1 --install-dir /usr/share/dotnet --no-path \


### PR DESCRIPTION
## Why

Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1373

## What

Add GH job for testing the Shell scripts on Alpine 

Opportunistic cleanup

## Tests

CI (see [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/3225465699/jobs/5277807493)) and locally running the same commands in WSL (Git bash does some strange things and it does not work there).