### PR TITLE
Calulate default OS_TYPE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
           name: bin-${{ matrix.machine }}
           path: bin/tracer-home
 
-  container-build:
-    name: Container Build 
+  build-container:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,10 @@ jobs:
       matrix:
         include:
           - machine: windows-2022
-            os_type: windows
             log-dir: "/c/ProgramData/OpenTelemetry .NET AutoInstrumentation/logs"
           - machine: ubuntu-20.04
-            os_type: linux-glibc
             log-dir: "/var/log/opentelemetry/dotnet"
           - machine: macos-11
-            os_type: macos
             log-dir: "/var/log/opentelemetry/dotnet"
     runs-on: ${{ matrix.machine }}
     steps:
@@ -98,7 +95,6 @@ jobs:
         shell: bash
         run: |
           set -e
-          export OS_TYPE=${{ matrix.os_type }} 
           curl -sSfL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/download.sh -O
           sh ./download.sh
             test "$(ls -A "$HOME/.otel-dotnet-auto")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - base-image: alpine
-            os_type: linux-musl
+        base-image: [ alpine ]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3.1.0
@@ -113,7 +111,6 @@ jobs:
         docker build -t mybuildimage -f "./docker/${{ matrix.base-image }}.dockerfile" .
         docker run --rm mybuildimage /bin/sh -c '
           set -e
-          export OS_TYPE=${{ matrix.os_type }}
           curl -sSfL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/download.sh -O
           sh ./download.sh
             test "$(ls -A "$HOME/.otel-dotnet-auto")"

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,6 @@ and instrument your .NET application using the provided Shell scripts.
 Example usage:
 
 ```sh
-export OS_TYPE=linux-glibc
 curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/main/download.sh -O
 sh ./download.sh
 curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/main/instrument.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,20 +138,20 @@ OTEL_SERVICE_NAME=myapp OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging,
 
 [download.sh](../download.sh) script uses environment variables as parameters:
 
-| Parameter               | Description                                                      | Required | Default value             |
-|-------------------------|------------------------------------------------------------------|----------|---------------------------|
-| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
-| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | Yes      |                           |
-| `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `v0.3.1-beta.1`           |
+| Parameter               | Description                                                      | Required             | Default value             |
+|-------------------------|------------------------------------------------------------------|----------------------|---------------------------|
+| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No                   | `$HOME/.otel-dotnet-auto` |
+| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No (but Recommended) | *Calculated*              |
+| `TMPDIR`                | Temporary directory used when downloading the files              | No                   | `$(mktemp -d)`            |
+| `VERSION`               | Version to download                                              | No                   | `v0.3.1-beta.1`           |
 
 [instrument.sh](../instrument.sh) script uses environment variables as parameters:
 
-| Parameter               | Description                                                            | Required | Default value             |
-|-------------------------|------------------------------------------------------------------------|----------|---------------------------|
-| `ENABLE_PROFILING`      | Whether to set the .NET CLR Profiler, possible values: `true`, `false` | No       | `true`                    |
-| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                            | No       | `$HOME/.otel-dotnet-auto` |
-| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows`       | Yes      |                           |
+| Parameter               | Description                                                            | Required             | Default value             |
+|-------------------------|------------------------------------------------------------------------|----------------------|---------------------------|
+| `ENABLE_PROFILING`      | Whether to set the .NET CLR Profiler, possible values: `true`, `false` | No                   | `true`                    |
+| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                            | No                   | `$HOME/.otel-dotnet-auto` |
+| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows`       | No (but Recommended) | *Calculated*              |
 
 > On macOS [`coreutils`](https://formulae.brew.sh/formula/coreutils) is required.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,20 +138,20 @@ OTEL_SERVICE_NAME=myapp OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging,
 
 [download.sh](../download.sh) script uses environment variables as parameters:
 
-| Parameter               | Description                                                      | Required             | Default value             |
-|-------------------------|------------------------------------------------------------------|----------------------|---------------------------|
-| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No                   | `$HOME/.otel-dotnet-auto` |
-| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No (but Recommended) | *Calculated*              |
-| `TMPDIR`                | Temporary directory used when downloading the files              | No                   | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No                   | `v0.3.1-beta.1`           |
+| Parameter               | Description                                                      | Required | Default value             |
+|-------------------------|------------------------------------------------------------------|----------|---------------------------|
+| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
+| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
+| `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
+| `VERSION`               | Version to download                                              | No       | `v0.3.1-beta.1`           |
 
 [instrument.sh](../instrument.sh) script uses environment variables as parameters:
 
-| Parameter               | Description                                                            | Required             | Default value             |
-|-------------------------|------------------------------------------------------------------------|----------------------|---------------------------|
-| `ENABLE_PROFILING`      | Whether to set the .NET CLR Profiler, possible values: `true`, `false` | No                   | `true`                    |
-| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                            | No                   | `$HOME/.otel-dotnet-auto` |
-| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows`       | No (but Recommended) | *Calculated*              |
+| Parameter               | Description                                                            | Required | Default value             |
+|-------------------------|------------------------------------------------------------------------|----------|---------------------------|
+| `ENABLE_PROFILING`      | Whether to set the .NET CLR Profiler, possible values: `true`, `false` | No       | `true`                    |
+| `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                            | No       | `$HOME/.otel-dotnet-auto` |
+| `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows`       | No       | *Calculated*              |
 
 > On macOS [`coreutils`](https://formulae.brew.sh/formula/coreutils) is required.
 

--- a/download.sh
+++ b/download.sh
@@ -1,6 +1,25 @@
 #!/bin/sh
 set -e
 
+# guess OS_TYPE if not provided
+if [ -z "$OS_TYPE" ]; then
+  case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    cygwin_nt*|mingw*|msys_nt*)
+      OS_TYPE="windows"
+      ;;
+    linux*)
+      if [ -z "$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)" ]; then
+        OS_TYPE="linux-glibc"
+      else
+        OS_TYPE="linux-musl"
+      fi
+      ;;
+    darwin*)
+      OS_TYPE="macos"
+      ;;
+  esac
+fi
+
 case "$OS_TYPE" in
   "linux-glibc"|"linux-musl"|"macos"|"windows")
     ;;

--- a/download.sh
+++ b/download.sh
@@ -8,10 +8,10 @@ if [ -z "$OS_TYPE" ]; then
       OS_TYPE="windows"
       ;;
     linux*)
-      if [ -z "$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)" ]; then
-        OS_TYPE="linux-glibc"
-      else
+      if [ "$(ldd /bin/ls | grep -m1 'musl')" ]; then
         OS_TYPE="linux-musl"
+      else
+        OS_TYPE="linux-glibc"
       fi
       ;;
     darwin*)

--- a/instrument.sh
+++ b/instrument.sh
@@ -1,5 +1,24 @@
 #!/bin/sh
 
+# guess OS_TYPE if not provided
+if [ -z "$OS_TYPE" ]; then
+  case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+    cygwin_nt*|mingw*|msys_nt*)
+      OS_TYPE="windows"
+      ;;
+    linux*)
+      if [ -z "$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)" ]; then
+        OS_TYPE="linux-glibc"
+      else
+        OS_TYPE="linux-musl"
+      fi
+      ;;
+    darwin*)
+      OS_TYPE="macos"
+      ;;
+  esac
+fi
+
 # validate input
 case "$OS_TYPE" in
   "linux-glibc"|"linux-musl"|"macos"|"windows")

--- a/instrument.sh
+++ b/instrument.sh
@@ -7,10 +7,10 @@ if [ -z "$OS_TYPE" ]; then
       OS_TYPE="windows"
       ;;
     linux*)
-      if [ -z "$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)" ]; then
-        OS_TYPE="linux-glibc"
-      else
+      if [ "$(ldd /bin/ls | grep -m1 'musl')" ]; then
         OS_TYPE="linux-musl"
+      else
+        OS_TYPE="linux-glibc"
       fi
       ;;
     darwin*)


### PR DESCRIPTION
## Why

Better UX. No need to provide `OS_TYPE`

Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1373

## What

Calculate `OS_TYPE` using `uname -s` and  `ldd /bin/ls`

## Tests

CI and locally

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] ~~Documentation is updated.~~
- [x] New features are covered by tests.
