### PR TITLE
Add instrument.sh to build output

### DIFF
--- a/build/Build.Steps.cs
+++ b/build/Build.Steps.cs
@@ -232,8 +232,17 @@ partial class Build
         {
             var source = RootDirectory / "integrations.json";
             var dest = TracerHomeDirectory;
+            CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
+        });
 
-            Log.Information($"Copying '{source}' to '{dest}'");
+    Target CopyInstrumentScripts => _ => _
+        .Unlisted()
+        .After(Clean)
+        .After(CreateRequiredDirectories)
+        .Executes(() =>
+        {
+            var source = RootDirectory / "instrument.sh";
+            var dest = TracerHomeDirectory;
             CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
         });
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -91,7 +91,8 @@ partial class Build : NukeBuild
         .DependsOn(PublishManagedProfiler)
         .DependsOn(CompileNativeSrc)
         .DependsOn(PublishNativeProfiler)
-        .DependsOn(CopyIntegrationsJson);
+        .DependsOn(CopyIntegrationsJson)
+        .DependsOn(CopyInstrumentScripts);
 
     Target NativeTests => _ => _
         .Description("Builds the native unit tests and runs them")

--- a/test/IntegrationTests/BuildTests.DistributionStructure_linux.verified.txt
+++ b/test/IntegrationTests/BuildTests.DistributionStructure_linux.verified.txt
@@ -2,6 +2,7 @@
   /AdditionalDeps/shared/Microsoft.NETCore.App/3.1.0/OpenTelemetry.AutoInstrumentation.AdditionalDeps.deps.json,
   /AdditionalDeps/shared/Microsoft.NETCore.App/6.0.0/OpenTelemetry.AutoInstrumentation.AdditionalDeps.deps.json,
   /OpenTelemetry.AutoInstrumentation.Native.so,
+  /instrument.sh,
   /integrations.json,
   /netcoreapp3.1/Google.Protobuf.dll,
   /netcoreapp3.1/Grpc.Core.Api.dll,

--- a/test/IntegrationTests/BuildTests.DistributionStructure_osx.verified.txt
+++ b/test/IntegrationTests/BuildTests.DistributionStructure_osx.verified.txt
@@ -2,6 +2,7 @@
   /AdditionalDeps/shared/Microsoft.NETCore.App/3.1.0/OpenTelemetry.AutoInstrumentation.AdditionalDeps.deps.json,
   /AdditionalDeps/shared/Microsoft.NETCore.App/6.0.0/OpenTelemetry.AutoInstrumentation.AdditionalDeps.deps.json,
   /OpenTelemetry.AutoInstrumentation.Native.dylib,
+  /instrument.sh,
   /integrations.json,
   /netcoreapp3.1/Google.Protobuf.dll,
   /netcoreapp3.1/Grpc.Core.Api.dll,

--- a/test/IntegrationTests/BuildTests.DistributionStructure_windows.verified.txt
+++ b/test/IntegrationTests/BuildTests.DistributionStructure_windows.verified.txt
@@ -1,6 +1,7 @@
 ﻿[
   \AdditionalDeps\shared\Microsoft.NETCore.App\3.1.0\OpenTelemetry.AutoInstrumentation.AdditionalDeps.deps.json,
   \AdditionalDeps\shared\Microsoft.NETCore.App\6.0.0\OpenTelemetry.AutoInstrumentation.AdditionalDeps.deps.json,
+  \instrument.sh,
   \integrations.json,
   \net462\Google.Protobuf.dll,
   \net462\Grpc.Core.Api.dll,


### PR DESCRIPTION
## Why

Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1373

## What

Add `instrument.sh` to the artifacts so that we can simplify the script and not `curl` the `instrument.sh`.

## Tests

CI
