### PR TITLE
Remove LoggingBuilder instrumentation from .NET Framework

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -102,8 +102,6 @@ OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.OperationTypeProxy
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.OperationTypeProxy.Mutation = 1 -> OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.OperationTypeProxy
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.OperationTypeProxy.Query = 0 -> OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.OperationTypeProxy
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.OperationTypeProxy.Subscription = 2 -> OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.OperationTypeProxy
-OpenTelemetry.AutoInstrumentation.Instrumentations.Logger.LoggingBuilderIntegration
-OpenTelemetry.AutoInstrumentation.Instrumentations.Logger.LoggingBuilderIntegration.LoggingBuilderIntegration() -> void
 OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration
 OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration.MongoClientIntegration() -> void
 OpenTelemetry.AutoInstrumentation.Instrumentations.Validations.StrongNamedValidation

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Logger/LoggingBuilderIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Logger/LoggingBuilderIntegration.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#if !NETFRAMEWORK
+
 using System;
 using OpenTelemetry.AutoInstrumentation.CallTarget;
 
@@ -43,15 +45,14 @@ public class LoggingBuilderIntegration
     /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
     internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
     {
-#if !NETFRAMEWORK
         if (instance is not null)
         {
             var logBuilderExtensionsType = Type.GetType("OpenTelemetry.AutoInstrumentation.Logger.LogBuilderExtensions, OpenTelemetry.AutoInstrumentation");
             var methodInfo = logBuilderExtensionsType?.GetMethod("AddOpenTelemetryLogs");
             methodInfo?.Invoke(null, new[] { (object)instance });
         }
-#endif
 
         return CallTargetReturn.GetDefault();
     }
 }
+#endif


### PR DESCRIPTION

## Why

<!-- Explain why the changes are needed.  -->

Fixes N/A

## What

Remove LoggingBuilder instrumentation from .NET Framework
It does not have any impact on execution and we can avoid one bytecode operation.

We have the same approach for StackExchange.Redis and others.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
