### PR TITLE
Remove CallTargetType from InstrumentMethodAttribute

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/InstrumentMethodAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/InstrumentMethodAttribute.cs
@@ -101,9 +101,4 @@ internal class InstrumentMethodAttribute : Attribute
     /// Gets or sets the integration name. Allows to group several integration with a single integration name.
     /// </summary>
     public string IntegrationName { get; set; }
-
-    /// <summary>
-    /// Gets or sets the CallTarget Class used to instrument the method
-    /// </summary>
-    public Type CallTargetType { get; set; }
 }


### PR DESCRIPTION


## Why

Cleanup code.

Fixes #

## What

Remove `CallTargetType` from `InstrumentMethodAttribute`.
It is unused property.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
