### PR TITLE
Rename MockZipkinCollector to LegacyMockZipkinCollector

### DIFF
--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -47,7 +47,7 @@ public class AspNetTests : TestHelper
         // accessible to the Windows docker container where the test application is executed by binding
         // the endpoint to all network interfaces. In order to do that it is necessary to open the port
         // on the firewall.
-        using var agent = await MockZipkinCollector.Start(Output, host: "*");
+        using var agent = await LegacyMockZipkinCollector.Start(Output, host: "*");
         using var fwPort = FirewallHelper.OpenWinPort(agent.Port, Output);
         var testSettings = new TestSettings
         {

--- a/test/IntegrationTests/DomainNeutralTests.cs
+++ b/test/IntegrationTests/DomainNeutralTests.cs
@@ -58,7 +58,7 @@ public class DomainNeutralTests : TestHelper
 
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_INTEGRATIONS_FILE", integrationsFile);
 
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         RunTestApplication(agent.Port);
 

--- a/test/IntegrationTests/GraphQLTests.cs
+++ b/test/IntegrationTests/GraphQLTests.cs
@@ -81,7 +81,7 @@ public class GraphQLTests : TestHelper
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT", setDocument.ToString());
 
         int aspNetCorePort = TcpPortProvider.GetOpenPort();
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
         using var process = StartTestApplication(agent.Port, aspNetCorePort: aspNetCorePort);
         if (process.HasExited)
         {

--- a/test/IntegrationTests/GrpcNetClientTests.cs
+++ b/test/IntegrationTests/GrpcNetClientTests.cs
@@ -36,7 +36,7 @@ public class GrpcNetClientTests : TestHelper
     [Trait("Category", "EndToEnd")]
     public async Task SubmitsTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         // Grpc.Net.Client is using various version of http communication under the hood.
         // Disabling HttpClient instrumentation to have consistent set of spans.

--- a/test/IntegrationTests/Helpers/LegacyMockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/LegacyMockZipkinCollector.cs
@@ -1,4 +1,4 @@
-// <copyright file="MockZipkinCollector.cs" company="OpenTelemetry Authors">
+// <copyright file="LegacyMockZipkinCollector.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 
-public class MockZipkinCollector : IDisposable
+public class LegacyMockZipkinCollector : IDisposable
 {
     private static readonly TimeSpan DefaultSpanWaitTimeout = TimeSpan.FromMinutes(1);
 
@@ -38,7 +38,7 @@ public class MockZipkinCollector : IDisposable
     private readonly ITestOutputHelper _output;
     private readonly TestHttpListener _listener;
 
-    private MockZipkinCollector(ITestOutputHelper output, string host = "localhost")
+    private LegacyMockZipkinCollector(ITestOutputHelper output, string host = "localhost")
     {
         _output = output;
         _listener = new(output, HandleHttpRequests, host, "/api/v2/spans/");
@@ -67,9 +67,9 @@ public class MockZipkinCollector : IDisposable
 
     private IImmutableList<NameValueCollection> RequestHeaders { get; set; } = ImmutableList<NameValueCollection>.Empty;
 
-    public static async Task<MockZipkinCollector> Start(ITestOutputHelper output, string host = "localhost")
+    public static async Task<LegacyMockZipkinCollector> Start(ITestOutputHelper output, string host = "localhost")
     {
-        var collector = new MockZipkinCollector(output, host);
+        var collector = new LegacyMockZipkinCollector(output, host);
 
         var healthzResult = await collector._listener.VerifyHealthzAsync();
 
@@ -191,7 +191,7 @@ public class MockZipkinCollector : IDisposable
 
     private void WriteOutput(string msg)
     {
-        const string name = nameof(MockZipkinCollector);
+        const string name = nameof(LegacyMockZipkinCollector);
         _output.WriteLine($"[{name}]: {msg}");
     }
 }

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -45,7 +45,7 @@ public class HttpTests : TestHelper
         SetEnvironmentVariable("OTEL_PROPAGATORS", propagators);
         SetEnvironmentVariable("DISABLE_DistributedContextPropagator", "true");
 
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         const int expectedSpanCount = 3;
 

--- a/test/IntegrationTests/MassTransitTests.cs
+++ b/test/IntegrationTests/MassTransitTests.cs
@@ -36,7 +36,7 @@ public class MassTransitTests : TestHelper
     [Trait("Category", "EndToEnd")]
     public async Task SubmitsTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
         RunTestApplication(agent.Port);
 
         const int expectedSpans = 3;

--- a/test/IntegrationTests/MongoDBTests.cs
+++ b/test/IntegrationTests/MongoDBTests.cs
@@ -43,7 +43,7 @@ public class MongoDBTests : TestHelper
     [Trait("Containers", "Linux")]
     public async Task SubmitsTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
         RunTestApplication(agent.Port, arguments: $"--mongo-db {_mongoDB.Port}");
         var spans = await agent.WaitForSpansAsync(3);
         Assert.True(spans.Count >= 3, $"Expecting at least 3 spans, only received {spans.Count}");

--- a/test/IntegrationTests/MySqlDataTests.cs
+++ b/test/IntegrationTests/MySqlDataTests.cs
@@ -44,7 +44,7 @@ public class MySqlDataTests : TestHelper
     [Trait("Containers", "Linux")]
     public async Task SubmitsTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         RunTestApplication(agent.Port, arguments: $"--mysql {_mySql.Port}", enableClrProfiler: !IsCoreClr());
 

--- a/test/IntegrationTests/NpqsqlTests.cs
+++ b/test/IntegrationTests/NpqsqlTests.cs
@@ -42,7 +42,7 @@ public class NpqsqlTests : TestHelper
     [Trait("Containers", "Linux")]
     public async Task SubmitsTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         RunTestApplication(agent.Port, arguments: $"--postgres {_postgres.Port}", enableClrProfiler: !IsCoreClr());
         var spans = await agent.WaitForSpansAsync(1);

--- a/test/IntegrationTests/PluginsTests.cs
+++ b/test/IntegrationTests/PluginsTests.cs
@@ -35,7 +35,7 @@ public class PluginsTests : TestHelper
     {
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_PLUGINS", "TestApplication.Plugins.Plugin, TestApplication.Plugins, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
 
-        using var collector = await MockZipkinCollector.Start(Output);
+        using var collector = await LegacyMockZipkinCollector.Start(Output);
         RunTestApplication(collector.Port);
         var spans = await collector.WaitForSpansAsync(1);
 

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -302,7 +302,7 @@ public class SmokeTests : TestHelper
     {
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES", "MyCompany.MyProduct.MyLibrary");
 
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
         RunTestApplication(agent.Port, enableStartupHook: enableStartupHook, enableClrProfiler: enableClrProfiler);
 
         // The process emitting the spans already finished by this time, there is no need to wait more,

--- a/test/IntegrationTests/SqlClientTests.cs
+++ b/test/IntegrationTests/SqlClientTests.cs
@@ -43,7 +43,7 @@ public class SqlClientTests : TestHelper
     [Trait("Containers", "Linux")]
     public async Task SubmitTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         const int expectedSpanCount = 8;
 

--- a/test/IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/IntegrationTests/StackExchangeRedisTests.cs
@@ -44,7 +44,7 @@ public class StackExchangeRedisTests : TestHelper
     [Trait("Containers", "Linux")]
     public async Task SubmitsTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         RunTestApplication(agent.Port, arguments: $"--redis {_redis.Port}");
 

--- a/test/IntegrationTests/StrongNamedTests.cs
+++ b/test/IntegrationTests/StrongNamedTests.cs
@@ -42,7 +42,7 @@ public class StrongNamedTests : TestHelper
 
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_INTEGRATIONS_FILE", integrationsFile);
 
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         RunTestApplication(agent.Port);
 

--- a/test/IntegrationTests/WcfTestsBase.cs
+++ b/test/IntegrationTests/WcfTestsBase.cs
@@ -38,7 +38,7 @@ public abstract class WcfTestsBase : TestHelper, IDisposable
     [Trait("Category", "EndToEnd")]
     public async Task SubmitsTraces()
     {
-        using var agent = await MockZipkinCollector.Start(Output);
+        using var agent = await LegacyMockZipkinCollector.Start(Output);
 
         var serverHelper = new WcfServerTestHelper(Output);
         _serverProcess = serverHelper.RunWcfServer(agent.Port);


### PR DESCRIPTION
## Why

Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/915

This is a little PR to make the next PRs easier to review.

## What

Rename MockZipkinCollector to LegacyMockZipkinCollector

In the next PR, I want to introduce a new implementation of `MockZipkinCollector` and create a smoke test for it.

Then I want to create PRs so that the integration tests use `MockSpansCollector` (already introduced here: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1419) instead of `LegacyMockZipkinCollector` (and finally remove it).

## Tests

CI