### PR TITLE
TestApplication.MongoDB - support for MongoDB.Driver 2.18.0+

### DIFF
--- a/test/IntegrationTests/MongoDBTests.cs
+++ b/test/IntegrationTests/MongoDBTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if !NETFRAMEWORK
-using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
+++ b/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
@@ -16,6 +16,9 @@
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="$(ApiVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <!-- Workaround! Microsoft.Extensions.Logging.Abstractions v.3.1.0 is minimal version supported by auto instrumentation.
+    MongoDB.Driver 2.18+ references older version. It prevents to load required version from Additional Dependencies store-->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(ApiVersion)'>='2.18.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes tests in #1434

## What

MongoDB.Driver 2.18.0 references `Microsoft.Extensions.Logging.Abstractions` 2.0. OpenTelemetry requires 3.1.0+.

## Tests

CI + Manual tests with 2.18.0+. It will be repeated on CI machine in scope of #1434

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
