### PR TITLE
Add MockZipkinCollector and Zipkin exporter smoke test

### DIFF
--- a/test/IntegrationTests/Helpers/MockSpansCollector.cs
+++ b/test/IntegrationTests/Helpers/MockSpansCollector.cs
@@ -105,6 +105,11 @@ public class MockSpansCollector : IDisposable
                 var found = false;
                 for (var i = missingExpectations.Count - 1; i >= 0; i--)
                 {
+                    if (missingExpectations[i].InstrumentationScopeName != resourceSpans.InstrumentationScopeName)
+                    {
+                        continue;
+                    }
+
                     if (!missingExpectations[i].Predicate(resourceSpans.Span))
                     {
                         continue;

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -1,0 +1,203 @@
+// <copyright file="MockZipkinCollector.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using IntegrationTests.Helpers.Mocks;
+using Newtonsoft.Json;
+using OpenTelemetry.Proto.Collector.Trace.V1;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTests.Helpers;
+
+public class MockZipkinCollector : IDisposable
+{
+    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
+
+    private readonly ITestOutputHelper _output;
+    private readonly TestHttpListener _listener;
+
+    private readonly BlockingCollection<ZSpanMock> _spans = new(100); // bounded to avoid memory leak
+    private readonly List<Expectation> _expectations = new();
+
+    private MockZipkinCollector(ITestOutputHelper output, string host = "localhost")
+    {
+        _output = output;
+        _listener = new TestHttpListener(output, HandleHttpRequests, host, "/api/v2/spans/");
+    }
+
+    /// <summary>
+    /// Gets the TCP port that this collector is listening on.
+    /// </summary>
+    public int Port { get => _listener.Port; }
+
+    public static async Task<MockZipkinCollector> Start(ITestOutputHelper output, string host = "localhost")
+    {
+        var collector = new MockZipkinCollector(output, host);
+
+        var healthzResult = await collector._listener.VerifyHealthzAsync();
+
+        if (!healthzResult)
+        {
+            collector.Dispose();
+            throw new InvalidOperationException($"Cannot start {nameof(MockZipkinCollector)}!");
+        }
+
+        return collector;
+    }
+
+    public void Dispose()
+    {
+        WriteOutput("Shutting down.");
+        _spans.Dispose();
+        _listener.Dispose();
+    }
+
+    public void Expect(Func<ZSpanMock, bool> predicate = null, string description = null)
+    {
+        predicate ??= x => true;
+        description ??= "<no description>";
+
+        _expectations.Add(new Expectation { Predicate = predicate, Description = description });
+    }
+
+    public void AssertExpectations(TimeSpan? timeout = null)
+    {
+        if (_expectations.Count == 0)
+        {
+            throw new InvalidOperationException("Expectations were not set");
+        }
+
+        var missingExpectations = new List<Expectation>(_expectations);
+        var expectationsMet = new List<ZSpanMock>();
+        var additionalEntries = new List<ZSpanMock>();
+
+        timeout ??= DefaultWaitTimeout;
+        var cts = new CancellationTokenSource();
+
+        try
+        {
+            cts.CancelAfter(timeout.Value);
+            foreach (var span in _spans.GetConsumingEnumerable(cts.Token))
+            {
+                var found = false;
+                for (var i = missingExpectations.Count - 1; i >= 0; i--)
+                {
+                    if (!missingExpectations[i].Predicate(span))
+                    {
+                        continue;
+                    }
+
+                    expectationsMet.Add(span);
+                    missingExpectations.RemoveAt(i);
+                    found = true;
+                    break;
+                }
+
+                if (!found)
+                {
+                    additionalEntries.Add(span);
+                    continue;
+                }
+
+                if (missingExpectations.Count == 0)
+                {
+                    return;
+                }
+            }
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // CancelAfter called with non-positive value
+            FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+        }
+        catch (OperationCanceledException)
+        {
+            // timeout
+            FailExpectations(missingExpectations, expectationsMet, additionalEntries);
+        }
+    }
+
+    private static void FailExpectations(
+        List<Expectation> missingExpectations,
+        List<ZSpanMock> expectationsMet,
+        List<ZSpanMock> additionalEntries)
+    {
+        var message = new StringBuilder();
+        message.AppendLine();
+
+        message.AppendLine("Missing expectations:");
+        foreach (var logline in missingExpectations)
+        {
+            message.AppendLine($"  - \"{logline.Description}\"");
+        }
+
+        message.AppendLine("Entries meeting expectations:");
+        foreach (var logline in expectationsMet)
+        {
+            message.AppendLine($"    \"{logline}\"");
+        }
+
+        message.AppendLine("Additional entries:");
+        foreach (var logline in additionalEntries)
+        {
+            message.AppendLine($"  + \"{logline}\"");
+        }
+
+        Assert.Fail(message.ToString());
+    }
+
+    private void HandleHttpRequests(HttpListenerContext ctx)
+    {
+        using var reader = new StreamReader(ctx.Request.InputStream);
+        var zspans = JsonConvert.DeserializeObject<List<ZSpanMock>>(reader.ReadToEnd());
+        foreach (var span in zspans ?? Enumerable.Empty<ZSpanMock>())
+        {
+            _spans.Add(span);
+        }
+
+        // NOTE: HttpStreamRequest doesn't support Transfer-Encoding: Chunked
+        // (Setting content-length avoids that)
+        ctx.Response.ContentType = "application/json";
+        var buffer = Encoding.UTF8.GetBytes("{}");
+        ctx.Response.ContentLength64 = buffer.LongLength;
+        ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+        ctx.Response.Close();
+    }
+
+    private void WriteOutput(string msg)
+    {
+        const string name = nameof(MockZipkinCollector);
+        _output.WriteLine($"[{name}]: {msg}");
+    }
+
+    private class Expectation
+    {
+        public Func<ZSpanMock, bool> Predicate { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -23,11 +23,8 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Google.Protobuf;
 using IntegrationTests.Helpers.Mocks;
 using Newtonsoft.Json;
-using OpenTelemetry.Proto.Collector.Trace.V1;
-using OpenTelemetry.Proto.Trace.V1;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/IntegrationTests/Helpers/Mocks/ZSpanMock.cs
+++ b/test/IntegrationTests/Helpers/Mocks/ZSpanMock.cs
@@ -30,7 +30,7 @@ using IntegrationTests.Helpers.Compatibility;
 namespace IntegrationTests.Helpers.Mocks;
 
 [DebuggerDisplay("TraceId={TraceId}, SpanId={SpanId}, Service={Service}, Name={Name}")]
-internal class ZSpanMock : IMockSpan
+public class ZSpanMock : IMockSpan
 {
     [JsonExtensionData]
     private Dictionary<string, JToken> _zipkinData;


### PR DESCRIPTION
## Why

Follows https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1428

> In the next PR, I want to introduce a new implementation of MockZipkinCollector and create a smoke test for it.

Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/915

## What

- Add MockZipkinCollector
- Add SmokeTests.ZipkinExporter
- Fix MockSpansCollector: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1439/commits/593ce9bfd15cb76afc37ea8223848bfbdad436c4

Next, I want to start creating PRs so that the integration tests use `MockSpansCollector` instead of `LegacyMockZipkinCollector` (and finally remove it).

## Tests

CI

