### PR TITLE
AspNetTests: use MockSpansCollector instead of LegacyMockZipkinCollector

### DIFF
--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -141,7 +141,7 @@ public class AspNetTests : TestHelper
         {
             builder = builder.WithEnvironment("OTEL_TRACES_EXPORTER", testSettings.OtlpTracesSettings.Exporter);
             Output.WriteLine($"OTLP endpoint: {agentBaseUrl}");
-            builder = builder.WithEnvironment("OTEL_EXPORTER_ZIPKIN_ENDPOINT", agentBaseUrl);
+            builder = builder.WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT", agentBaseUrl);
         }
 
         if (testSettings.MetricsSettings != null)

--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -115,7 +115,7 @@ public class AspNetTests : TestHelper
 
         Output.WriteLine("Collecting docker logs to: " + logPath);
 
-        var agentPort = testSettings.TracesSettings?.Port ?? testSettings.MetricsSettings?.Port;
+        var agentPort = testSettings.TracesSettings?.Port ?? testSettings.OtlpTracesSettings?.Port ?? testSettings.MetricsSettings?.Port;
         var builder = new TestcontainersBuilder<TestcontainersContainer>()
             .WithImage(testApplicationName)
             .WithCleanUp(cleanUp: true)

--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -131,15 +131,23 @@ public class AspNetTests : TestHelper
 
         if (testSettings.TracesSettings != null)
         {
+            builder = builder.WithEnvironment("OTEL_TRACES_EXPORTER", testSettings.TracesSettings.Exporter);
             string zipkinEndpoint = $"{agentBaseUrl}/api/v2/spans";
-            Output.WriteLine($"Zipkin Endpoint: {zipkinEndpoint}");
-
+            Output.WriteLine($"Zipkin endpoint: {zipkinEndpoint}");
             builder = builder.WithEnvironment("OTEL_EXPORTER_ZIPKIN_ENDPOINT", zipkinEndpoint);
+        }
+
+        if (testSettings.OtlpTracesSettings != null)
+        {
+            builder = builder.WithEnvironment("OTEL_TRACES_EXPORTER", testSettings.OtlpTracesSettings.Exporter);
+            Output.WriteLine($"OTLP endpoint: {agentBaseUrl}");
+            builder = builder.WithEnvironment("OTEL_EXPORTER_ZIPKIN_ENDPOINT", agentBaseUrl);
         }
 
         if (testSettings.MetricsSettings != null)
         {
-            Output.WriteLine($"Otlp Endpoint: {agentBaseUrl}");
+            builder = builder.WithEnvironment("OTEL_METRICS_EXPORTER", testSettings.MetricsSettings.Exporter);
+            Output.WriteLine($"OTLP endpoint: {agentBaseUrl}");
             builder = builder.WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT", agentBaseUrl);
             builder = builder.WithEnvironment("OTEL_METRIC_EXPORT_INTERVAL", "1000");
         }

--- a/test/test-applications/integrations/TestApplication.AspNet/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.AspNet/Dockerfile
@@ -9,7 +9,6 @@ ENV COR_ENABLE_PROFILING=1 `
     COR_PROFILER_PATH=C:\opentelemetry\win-${platform}\OpenTelemetry.AutoInstrumentation.Native.dll `
     OTEL_DOTNET_AUTO_HOME=C:\opentelemetry\ `
     OTEL_DOTNET_AUTO_INTEGRATIONS_FILE=C:\opentelemetry\integrations.json `
-    OTEL_TRACES_EXPORTER=zipkin `
     OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES=TestApplication.* `
     OTEL_SERVICE_NAME=TestApplication.AspNet `
     OTEL_DOTNET_AUTO_DEBUG=1 `


### PR DESCRIPTION
## Why

Part of https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/915

## What

This PR improves AspNetTests

- Use MockSpansCollector instead of LegacyMockZipkinCollector
- Remove conditional logic in tests (makes it less error-prone + less code)

## Tests

CI

Verify test (20 times): https://github.com/pellared/opentelemetry-dotnet-instrumentation/actions/runs/3272908421
