### PR TITLE
Fix PS module name in readme

### DIFF
--- a/OpenTelemetry.DotNet.Auto.psm1
+++ b/OpenTelemetry.DotNet.Auto.psm1
@@ -254,7 +254,7 @@ function Register-OpenTelemetryForCurrentSession() {
     $installDir = Get-Current-InstallDir
 
     if (-not $installDir) {
-        throw "OpenTelemetry Core must be setup first. Run 'Install-OpenTelemetryCore' to setup Opentelemetry Core."
+        throw "OpenTelemetry Core must be setup first. Run 'Install-OpenTelemetryCore' to setup OpenTelemetry Core."
     }
 
     $varsTable = Get-Environment-Variables-Table -InstallDir $installDir -OTelServiceName $OTelServiceName
@@ -273,7 +273,7 @@ function Register-OpenTelemetryForIIS() {
     $installDir = Get-Current-InstallDir
 
     if (-not $installDir) {
-        throw "OpenTelemetry Core must be setup first. Run 'Install-OpenTelemetryCore' to setup Opentelemetry Core."
+        throw "OpenTelemetry Core must be setup first. Run 'Install-OpenTelemetryCore' to setup OpenTelemetry Core."
     }
 
     Setup-Windows-Service -InstallDir $installDir -WindowsServiceName "W3SVC"
@@ -302,7 +302,7 @@ function Register-OpenTelemetryForWindowsService() {
     $installDir = Get-Current-InstallDir
 
     if (-not $installDir) {
-        throw "OpenTelemetry Core must be setup first. Run 'Install-OpenTelemetryCore' to setup Opentelemetry Core."
+        throw "OpenTelemetry Core must be setup first. Run 'Install-OpenTelemetryCore' to setup OpenTelemetry Core."
     }
 
     Setup-Windows-Service -InstallDir $installDir -WindowsServiceName $WindowsServiceName -OTelServiceName $OTelServiceName

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,7 +182,7 @@ Register-OpenTelemetryForCurrentSession -OTelServiceName "MyServiceDisplayName"
 Get-OpenTelemetryInstallDirectory
 
 # List all available commands
-Get-Command -Module install
+Get-Command -Module OpenTelemetry.DotNet.Auto
 
 # Get command's usage information
 Get-Help Install-OpenTelemetryCore -Detailed


### PR DESCRIPTION
## What

Found one place where the old PowerShell module name was left unchanged.

_Added Opentelemetry => OpenTelemetry case fix also to this PR found in the PS module_

## Checklist

- [x] Documentation is updated.
