### PR TITLE
Avoid crash if bytecode instrumentation method is missing

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -57,6 +57,7 @@ private:
     //
     std::mutex module_id_to_info_map_lock_;
     std::unordered_map<ModuleID, ModuleMetadata*> module_id_to_info_map_;
+    ModuleID managed_profiler_module_id_ = 0;
 
     //
     // Helper methods

--- a/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
@@ -174,4 +174,16 @@ WSTRING TokenStr(const mdToken* token)
     return s;
 }
 
+WSTRING HResultStr(const HRESULT hr)
+{
+    std::wstringstream ss;
+    ss << "0x"
+       << std::setfill(L'0')
+       << std::setw(2*sizeof(HRESULT))
+       << std::hex
+       << hr;
+
+    return ss.str();
+}
+
 } // namespace trace

--- a/src/OpenTelemetry.AutoInstrumentation.Native/util.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/util.h
@@ -41,6 +41,9 @@ WSTRING HexStr(const void* data, int len);
 // Convert Token to string
 WSTRING TokenStr(const mdToken* token);
 
+// Convert HRESULT to a friendly string, e.g.: "0x80000002"
+WSTRING HResultStr(const HRESULT hr);
+
 template <class Container>
 bool Contains(const Container& items, const typename Container::value_type& value)
 {

--- a/test/IntegrationTests/Properties/launchSettings.json
+++ b/test/IntegrationTests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "IntegrationTests": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/test/IntegrationTests/StrongNamedTestsIntegrations.json
+++ b/test/IntegrationTests/StrongNamedTestsIntegrations.json
@@ -24,6 +24,28 @@
           "type": "OpenTelemetry.AutoInstrumentation.Instrumentations.Validations.StrongNamedValidation",
           "action": "CallTargetModification"
         }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "TestLibrary.InstrumentationTarget",
+          "type": "TestLibrary.InstrumentationTarget.Command",
+          "method": "InstrumentationTargetMissingBytecodeInstrumentationType",
+          "signature_types": [
+            "System.Void"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "OpenTelemetry.AutoInstrumentation",
+          "type": "OpenTelemetry.AutoInstrumentation.Instrumentations.Validations.MissingInstrumentationType",
+          "action": "CallTargetModification"
+        }
       }
     ]
   }

--- a/test/test-applications/integrations/TestApplication.StrongNamed/Program.cs
+++ b/test/test-applications/integrations/TestApplication.StrongNamed/Program.cs
@@ -24,5 +24,6 @@ public static class Program
     {
         var command = new Command();
         command.Execute();
+        command.InstrumentationTargetMissingBytecodeInstrumentationType();
     }
 }

--- a/test/test-applications/integrations/dependency-libs/TestLibrary.InstrumentationTarget/Command.cs
+++ b/test/test-applications/integrations/dependency-libs/TestLibrary.InstrumentationTarget/Command.cs
@@ -24,4 +24,9 @@ public class Command
     {
         Thread.Yield(); // Just to have some call to outside code.
     }
+
+    public void InstrumentationTargetMissingBytecodeInstrumentationType()
+    {
+        Thread.Sleep(0); // Just to have some call to outside code.
+    }
 }


### PR DESCRIPTION
This is similar to #1469 but in this case the instrumentation finds the type but not the expected method. 