### PR TITLE
Use hexadecimal value when logging HRESULT

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -2160,7 +2160,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID funct
 {
     if (is_attached_)
     {
-        Logger::Debug("ReJITCompilationFinished: [functionId: ", functionId, ", rejitId: ", rejitId, ", hrStatus: ", hrStatus,
+        Logger::Debug("ReJITCompilationFinished: [functionId: ", functionId, ", rejitId: ", rejitId, ", hrStatus: ", HResultStr(hrStatus),
                     ", safeToBlock: ", fIsSafeToBlock, "]");
     }
 
@@ -2173,7 +2173,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef
     if (is_attached_)
     {
         Logger::Warn("ReJITError: [functionId: ", functionId, ", moduleId: ", moduleId, ", methodId: ", methodId,
-                    ", hrStatus: ", hrStatus, "]");
+                    ", hrStatus: ", HResultStr(hrStatus), "]");
     }
 
     return S_OK;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler_base.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler_base.cpp
@@ -37,7 +37,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainCreationStarted(AppDomainID 
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainCreationFinished(AppDomainID appDomainId, HRESULT hrStatus)
 {
-    Logger::Debug("AppDomainCreationFinished: ", appDomainId, " hrStatus=", hrStatus);
+    Logger::Debug("AppDomainCreationFinished: ", appDomainId, " hrStatus=", HResultStr(hrStatus));
     return S_OK;
 }
 
@@ -49,7 +49,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainShutdownStarted(AppDomainID 
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus)
 {
-    Logger::Debug("AppDomainShutdownFinished: ", appDomainId, " ", hrStatus);
+    Logger::Debug("AppDomainShutdownFinished: ", appDomainId, " hrStatus=", HResultStr(hrStatus));
     return S_OK;
 }
 
@@ -61,7 +61,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyLoadStarted(AssemblyID assemb
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus)
 {
-    Logger::Debug("AssemblyLoadFinished: ", assemblyId, " ", hrStatus);
+    Logger::Debug("AssemblyLoadFinished: ", assemblyId, " hrStatus=", HResultStr(hrStatus));
     return S_OK;
 }
 
@@ -73,7 +73,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyUnloadStarted(AssemblyID asse
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyUnloadFinished(AssemblyID assemblyId, HRESULT hrStatus)
 {
-    Logger::Debug("AssemblyUnloadFinished: ", assemblyId, " ", hrStatus);
+    Logger::Debug("AssemblyUnloadFinished: ", assemblyId, " hrStatus=", HResultStr(hrStatus));
     return S_OK;
 }
 
@@ -85,7 +85,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleLoadStarted(ModuleID moduleId)
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus)
 {
-    Logger::Debug("ModuleLoadFinished: ", moduleId, " ", hrStatus);
+    Logger::Debug("ModuleLoadFinished: ", moduleId, " hrStatus=", HResultStr(hrStatus));
     return S_OK;
 }
 
@@ -96,7 +96,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleUnloadStarted(ModuleID moduleId
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus)
 {
-    Logger::Debug("ModuleUnloadFinished: ", moduleId, " ", hrStatus);
+    Logger::Debug("ModuleUnloadFinished: ", moduleId, " hrStatus=", HResultStr(hrStatus));
     return S_OK;
 }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
@@ -119,15 +119,15 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
         else if (hr == E_INVALIDARG)
         {
             Logger::Info("NGEN:: Error Invalid arguments in [ModuleId=", currentModuleId,
-                         ",MethodDef=", currentMethodDef, ", HR=", hr, "]");
+                         ",MethodDef=", currentMethodDef, ", HR=E_INVALIDARG]");
         }
         else if (hr == CORPROF_E_DATAINCOMPLETE)
         {
-            Logger::Info("NGEN:: Error Incomplete data in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef, ", HR=", hr, "]");
+            Logger::Info("NGEN:: Error Incomplete data in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef, ", HR=CORPROF_E_DATAINCOMPLETE]");
         }
         else
         {
-            Logger::Info("NGEN:: Error in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef, ", HR=", hr, "]");
+            Logger::Info("NGEN:: Error in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef, ", HR=", HResultStr(hr), "]");
         }
     }
 }


### PR DESCRIPTION
## Why

To make HRESULT logged by the native profiler more readable.

## What

Added a call to HResultStr to the log statements that were already logging HRESULT.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
