### PR TITLE
Remove-httplistener-healthz

### DIFF
--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -130,9 +130,7 @@ public class AspNetTests
             wasStarted.Should().BeTrue($"Container based on {testApplicationName} has to be operational for the test.");
             Output.WriteLine($"Container was started successfully.");
 
-            var webAppHealthzUrl = $"http://localhost:{webPort}/healthz";
-            var webAppHealthzResult = await HealthzHelper.TestHealtzAsync(webAppHealthzUrl, "IIS WebApp", Output);
-            webAppHealthzResult.Should().BeTrue("IIS WebApp health check never returned OK.");
+            await HealthzHelper.TestAsync($"http://localhost:{webPort}/healthz", Output);
             Output.WriteLine($"IIS WebApp was started successfully.");
         }
         catch

--- a/test/IntegrationTests/Helpers/HealthzHelper.cs
+++ b/test/IntegrationTests/Helpers/HealthzHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -24,33 +25,34 @@ namespace IntegrationTests.Helpers;
 
 internal static class HealthzHelper
 {
-    public static async Task<bool> TestHealtzAsync(string healthzUrl, string logPrefix, ITestOutputHelper output)
+    public static async Task TestAsync(string healthzUrl, ITestOutputHelper output)
     {
-        output.WriteLine($"{logPrefix} healthz endpoint: {healthzUrl}");
+        output.WriteLine($"Testing healthz endpoint: {healthzUrl}");
         HttpClient client = new();
 
-        for (int retry = 0; retry < 5; retry++)
+        var intervalMilliseconds = 500;
+        var maxMillisecondsToWait = 15_000;
+        var maxRetries = maxMillisecondsToWait / intervalMilliseconds;
+        for (int retry = 0; retry < maxRetries; retry++)
         {
-            HttpResponseMessage response;
-
             try
             {
-                response = await client.GetAsync(healthzUrl);
+                var response = await client.GetAsync(healthzUrl);
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    return;
+                }
+
+                output.WriteLine($"Healthz endpoint retured HTTP status code: {response.StatusCode}");
             }
-            catch (TaskCanceledException)
+            catch (Exception ex)
             {
-                response = null;
+                output.WriteLine($"Healthz endpoint call failed: {ex.Message}");
             }
 
-            if (response?.StatusCode == HttpStatusCode.OK)
-            {
-                return true;
-            }
-
-            output.WriteLine($"{logPrefix} healthz failed {retry + 1}/5");
-            await Task.Delay(TimeSpan.FromSeconds(4));
+            Thread.Sleep(intervalMilliseconds);
         }
 
-        return false;
+        throw new InvalidOperationException($"Healthz endpoint never returned OK: {healthzUrl}");
     }
 }


### PR DESCRIPTION
## Why

Follows https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1545

## What

- Remove `healthz` from HttpListener as it was a workaround for a bug present on non-Windows implementation
- Refine HealthzHelper based on `GraphQLTests` and reuse it
