### PR TITLE
Update GraphQL tags and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Replace `OTEL_DOTNET_AUTO_LOAD_TRACER_AT_STARTUP` by `OTEL_DOTNET_AUTO_TRACES_ENABLED`
   and `OTEL_DOTNET_AUTO_LOAD_METER_AT_STARTUP` by `OTEL_DOTNET_AUTO_METRICS_ENABLED`.
 - Disable OpenTracing by default. OpenTracing can be re-enabled via `OTEL_DOTNET_AUTO_OPENTRACING_ENABLED`.
+- GraphQL exceptions are recorded as OTel events.
 
 ### Removed
 

--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -89,6 +89,7 @@ OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionContext.Err
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionContext.Operation.get -> OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IOperation
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Code.get -> string
+OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.InnerException.get -> System.Exception
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Locations.get -> System.Collections.Generic.IEnumerable<object>
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Message.get -> string
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Path.get -> System.Collections.Generic.IEnumerable<string>

--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -89,6 +89,7 @@ OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionContext.Err
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionContext.Operation.get -> OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IOperation
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Code.get -> string
+OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.InnerException.get -> System.Exception
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Locations.get -> System.Collections.Generic.IEnumerable<object>
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Message.get -> string
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.IExecutionError.Path.get -> System.Collections.Generic.IEnumerable<string>

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/ExecuteAsyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/ExecuteAsyncIntegration.cs
@@ -36,8 +36,6 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL;
     MaximumVersion = GraphQLCommon.Major2)]
 public class ExecuteAsyncIntegration
 {
-    private const string ErrorType = "GraphQL.ExecutionError";
-
     /// <summary>
     /// OnMethodBegin callback
     /// </summary>
@@ -78,7 +76,7 @@ public class ExecuteAsyncIntegration
             }
             else if (state.State is IExecutionContext context)
             {
-                GraphQLCommon.RecordExecutionErrorsIfPresent(activity, ErrorType, context.Errors);
+                GraphQLCommon.RecordExecutionErrorsIfPresent(activity, context.Errors);
             }
         }
         finally

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/IExecutionError.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/GraphQL/IExecutionError.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 
 namespace OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL;
@@ -42,4 +43,9 @@ public interface IExecutionError
     /// Gets the path in the document where the error applies
     /// </summary>
     IEnumerable<string> Path { get; }
+
+    /// <summary>
+    /// Gets the original thrown exception.
+    /// </summary>
+    Exception InnerException { get; }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Tagging/Tags.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Tagging/Tags.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Diagnostics;
-
 namespace OpenTelemetry.AutoInstrumentation.Tagging;
 
 /// <summary>
@@ -23,26 +21,6 @@ namespace OpenTelemetry.AutoInstrumentation.Tagging;
 /// </summary>
 internal static class Tags
 {
-    /// <summary>
-    /// The error message of an exception
-    /// </summary>
-    public const string ErrorMsg = "error.msg";
-
-    /// <summary>
-    /// The type of an exception
-    /// </summary>
-    public const string ErrorType = "error.type";
-
-    /// <summary>
-    /// The stack trace of an exception
-    /// </summary>
-    public const string ErrorStack = "error.stack";
-
-    /// <summary>
-    /// The status of a span
-    /// </summary>
-    public const string Status = "status";
-
     /// <summary>
     /// The hostname of a outgoing server connection.
     /// </summary>

--- a/test/IntegrationTests/GraphQLTests.cs
+++ b/test/IntegrationTests/GraphQLTests.cs
@@ -64,7 +64,7 @@ public class GraphQLTests : TestHelper
 
         // FAILURE: query fails 'execute' step
         Request(requests, body: @"{""query"":""subscription NotImplementedSub{throwNotImplementedException{name}}""}");
-        Expect(collector, spanName: "subscription NotImplementedSub", graphQLOperationType: "subscription", graphQLOperationName: "NotImplementedSub", graphQLDocument: "subscription NotImplementedSub{throwNotImplementedException{name}}", setDocument: setDocument, failsExecution: true);
+        Expect(collector, spanName: "subscription NotImplementedSub", graphQLOperationType: "subscription", graphQLOperationName: "NotImplementedSub", graphQLDocument: "subscription NotImplementedSub{throwNotImplementedException{name}}", setDocument: setDocument, verifyFailure: VerifyNotImplementedException);
 
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_GRAPHQL_SET_DOCUMENT", setDocument.ToString());
         int aspNetCorePort = TcpPortProvider.GetOpenPort();
@@ -103,6 +103,21 @@ public class GraphQLTests : TestHelper
         });
     }
 
+    private static bool VerifyNotImplementedException(Span span)
+    {
+        var exceptionEvent = span.Events.SingleOrDefault();
+
+        if (exceptionEvent == null)
+        {
+            return false;
+        }
+
+        return
+            exceptionEvent.Attributes.Any(x => x.Key == "exception.type" && x.Value?.StringValue == "System.NotImplementedException") &&
+            exceptionEvent.Attributes.Any(x => x.Key == "exception.message") &&
+            exceptionEvent.Attributes.Any(x => x.Key == "exception.stacktrace");
+    }
+
     private static void Expect(
         MockSpansCollector collector,
         string spanName,
@@ -110,7 +125,7 @@ public class GraphQLTests : TestHelper
         string graphQLOperationName,
         string graphQLDocument,
         bool setDocument,
-        bool failsExecution = false)
+        Predicate<Span> verifyFailure = null)
     {
         bool Predicate(Span span)
         {
@@ -124,9 +139,9 @@ public class GraphQLTests : TestHelper
                 return false;
             }
 
-            if (failsExecution && !span.Attributes.Any(attr => attr.Key == "error.msg"))
+            if (verifyFailure != null)
             {
-                return false;
+                return verifyFailure(span);
             }
 
             if (!span.Attributes.Any(attr => attr.Key == "graphql.operation.type" && attr.Value?.StringValue == graphQLOperationType))


### PR DESCRIPTION
## Why

Fixes #1485 

## What

* Records exceptions in correct manner (as OTel events).
* Gets correct exception information that was actually thrown.

## Tests

* Modified GraphQL integration tests.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
