### PR TITLE
Use Task.Delay in HealthzHelper

### DIFF
--- a/test/IntegrationTests/Helpers/HealthzHelper.cs
+++ b/test/IntegrationTests/Helpers/HealthzHelper.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -37,7 +36,7 @@ internal static class HealthzHelper
         {
             try
             {
-                var response = await client.GetAsync(healthzUrl);
+                var response = await client.GetAsync(healthzUrl).ConfigureAwait(false);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     return;
@@ -50,7 +49,7 @@ internal static class HealthzHelper
                 output.WriteLine($"Healthz endpoint call failed: {ex.Message}");
             }
 
-            Thread.Sleep(intervalMilliseconds);
+            await Task.Delay(intervalMilliseconds).ConfigureAwait(false);
         }
 
         throw new InvalidOperationException($"Healthz endpoint never returned OK: {healthzUrl}");

--- a/test/IntegrationTests/Helpers/HealthzHelper.cs
+++ b/test/IntegrationTests/Helpers/HealthzHelper.cs
@@ -36,7 +36,7 @@ internal static class HealthzHelper
         {
             try
             {
-                var response = await client.GetAsync(healthzUrl).ConfigureAwait(false);
+                var response = await client.GetAsync(healthzUrl);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     return;
@@ -49,7 +49,7 @@ internal static class HealthzHelper
                 output.WriteLine($"Healthz endpoint call failed: {ex.Message}");
             }
 
-            await Task.Delay(intervalMilliseconds).ConfigureAwait(false);
+            await Task.Delay(intervalMilliseconds);
         }
 
         throw new InvalidOperationException($"Healthz endpoint never returned OK: {healthzUrl}");


### PR DESCRIPTION
Address https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1547#discussion_r1017037859

PS. I  initially added `.ConfigureAwait(false)` to the async calls but then I realized it could affect the xunit output... Then I realized that we are running the tests sequentially anyway (to avoid races during test setup like getting a free TCP port)... I decided to leave everything as it is 😉 