### PR TITLE
Make WCF instrumentation lazy

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using OpenTelemetry.AutoInstrumentation.Loading;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Trace;
 
@@ -24,7 +25,11 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 
 internal static class EnvironmentConfigurationTracerHelper
 {
-    public static TracerProviderBuilder UseEnvironmentVariables(this TracerProviderBuilder builder, TracerSettings settings, PluginManager pluginManager)
+    public static TracerProviderBuilder UseEnvironmentVariables(
+        this TracerProviderBuilder builder,
+        LazyInstrumentationLoader lazyInstrumentationLoader,
+        TracerSettings settings,
+        PluginManager pluginManager)
     {
         builder.SetExporter(settings, pluginManager);
 
@@ -32,16 +37,16 @@ internal static class EnvironmentConfigurationTracerHelper
         {
             _ = enabledInstrumentation switch
             {
-                TracerInstrumentation.AspNet => Wrappers.AddSdkAspNetInstrumentation(builder, pluginManager),
+                TracerInstrumentation.AspNet => Wrappers.AddSdkAspNetInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
                 TracerInstrumentation.GrpcNetClient => Wrappers.AddGrpcClientInstrumentation(builder, pluginManager),
                 TracerInstrumentation.HttpClient => Wrappers.AddHttpClientInstrumentation(builder, pluginManager),
                 TracerInstrumentation.Npgsql => builder.AddSource("Npgsql"),
                 TracerInstrumentation.SqlClient => Wrappers.AddSqlClientInstrumentation(builder, pluginManager),
-                TracerInstrumentation.Wcf => Wrappers.AddWcfInstrumentation(builder, pluginManager),
+                TracerInstrumentation.Wcf => Wrappers.AddWcfInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
 #if NETCOREAPP3_1_OR_GREATER
                 TracerInstrumentation.MassTransit => builder.AddSource("MassTransit"),
                 TracerInstrumentation.MongoDB => builder.AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources"),
-                TracerInstrumentation.MySqlData => builder.AddSource("OpenTelemetry.Instrumentation.MySqlData"),
+                TracerInstrumentation.MySqlData => Wrappers.AddMySqlClientInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
                 TracerInstrumentation.StackExchangeRedis => builder.AddSource("OpenTelemetry.Instrumentation.StackExchangeRedis"),
 #endif
                 _ => null
@@ -83,9 +88,11 @@ internal static class EnvironmentConfigurationTracerHelper
         // Instrumentations
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static TracerProviderBuilder AddWcfInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager)
+        public static TracerProviderBuilder AddWcfInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager, LazyInstrumentationLoader lazyInstrumentationLoader)
         {
-            return builder.AddWcfInstrumentation(pluginManager.ConfigureOptions);
+            lazyInstrumentationLoader.Add(new WcfInitializer(pluginManager));
+
+            return builder.AddSource("OpenTelemetry.Instrumentation.Wcf");
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -95,17 +102,28 @@ internal static class EnvironmentConfigurationTracerHelper
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static TracerProviderBuilder AddSdkAspNetInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager)
+        public static TracerProviderBuilder AddSdkAspNetInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager, LazyInstrumentationLoader lazyInstrumentationLoader)
         {
 #if NET462
             builder.AddAspNetInstrumentation(pluginManager.ConfigureOptions);
 #elif NETCOREAPP3_1_OR_GREATER
+            lazyInstrumentationLoader.Add(new AspNetCoreInitializer(pluginManager));
+
             builder.AddSource("OpenTelemetry.Instrumentation.AspNetCore");
             builder.AddLegacySource("Microsoft.AspNetCore.Hosting.HttpRequestIn");
 #endif
 
             return builder;
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        public static TracerProviderBuilder AddMySqlClientInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager, LazyInstrumentationLoader lazyInstrumentationLoader)
+        {
+            lazyInstrumentationLoader.Add(new MySqlDataInitializer(pluginManager));
+
+            return builder.AddSource("OpenTelemetry.Instrumentation.MySqlData");
+        }
+#endif
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static TracerProviderBuilder AddSqlClientInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager)

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -19,9 +19,7 @@ using System.Diagnostics.Tracing;
 using System.Threading;
 using OpenTelemetry.AutoInstrumentation.Configuration;
 using OpenTelemetry.AutoInstrumentation.Diagnostics;
-#if NETCOREAPP3_1_OR_GREATER
 using OpenTelemetry.AutoInstrumentation.Loading;
-#endif
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Context.Propagation;
@@ -38,9 +36,7 @@ namespace OpenTelemetry.AutoInstrumentation;
 internal static class Instrumentation
 {
     private static readonly ILogger Logger = OtelLogging.GetLogger();
-#if NETCOREAPP3_1_OR_GREATER
     private static readonly LazyInstrumentationLoader LazyInstrumentationLoader = new();
-#endif
 
     private static int _firstInitialization = 1;
     private static int _isExiting = 0;
@@ -73,9 +69,7 @@ internal static class Instrumentation
 
     internal static PluginManager PluginManager => _pluginManager;
 
-#if NETCOREAPP3_1_OR_GREATER
     internal static ILifespanManager LifespanManager => LazyInstrumentationLoader.LifespanManager;
-#endif
 
     internal static GeneralSettings GeneralSettings { get; } = Settings.FromDefaultSources<GeneralSettings>();
 
@@ -122,27 +116,10 @@ internal static class Instrumentation
 
             if (TracerSettings.TracesEnabled)
             {
-                // Setup the instrumentations that have additional setup occurring during AssemblyLoad
-                // -> this should be refactored in a separate PR
-                // e.g. we could have a static method that returns a collection of initializers
-                //      and TracerSettings.EnabledInstrumentations would be passed as input
-#if NETCOREAPP3_1_OR_GREATER
-
-                if (TracerSettings.EnabledInstrumentations.Contains(TracerInstrumentation.AspNet))
-                {
-                    LazyInstrumentationLoader.Add(new AspNetCoreInitializer(_pluginManager));
-                }
-
-                if (TracerSettings.EnabledInstrumentations.Contains(TracerInstrumentation.MySqlData))
-                {
-                    LazyInstrumentationLoader.Add(new MySqlDataInitializer(_pluginManager));
-                }
-#endif
-
                 var builder = Sdk
                     .CreateTracerProviderBuilder()
                     .SetResourceBuilder(ResourceFactory.Create())
-                    .UseEnvironmentVariables(TracerSettings, _pluginManager)
+                    .UseEnvironmentVariables(LazyInstrumentationLoader, TracerSettings, _pluginManager)
                     .InvokePlugins(_pluginManager);
 
                 _tracerProvider = builder.Build();

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/ILifespanManager.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if NETCOREAPP3_1_OR_GREATER
 using System;
 
 namespace OpenTelemetry.AutoInstrumentation.Loading;
@@ -29,4 +28,3 @@ internal interface ILifespanManager : IDisposable
     /// <param name="instance">Trackable object</param>
     void Track(object instance);
 }
-#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if NETCOREAPP3_1_OR_GREATER
 namespace OpenTelemetry.AutoInstrumentation.Loading;
 
 /// <summary>
@@ -32,5 +31,3 @@ internal abstract class InstrumentationInitializer
 
     public abstract void Initialize(ILifespanManager lifespanManager);
 }
-
-#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationLifespanManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationLifespanManager.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Collections.Concurrent;
 
@@ -42,4 +41,3 @@ internal class InstrumentationLifespanManager : ILifespanManager
         }
     }
 }
-#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/LazyInstrumentationLoader.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if NETCOREAPP3_1_OR_GREATER
 using System;
 using OpenTelemetry.AutoInstrumentation.Logging;
 
@@ -79,4 +78,3 @@ internal class LazyInstrumentationLoader : IDisposable
         }
     }
 }
-#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/WcfInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/WcfInitializer.cs
@@ -1,0 +1,43 @@
+// <copyright file="WcfInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using OpenTelemetry.AutoInstrumentation.Plugins;
+using OpenTelemetry.Instrumentation.Wcf;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class WcfInitializer : InstrumentationInitializer
+{
+    private readonly PluginManager _pluginManager;
+
+    public WcfInitializer(PluginManager pluginManager)
+        : base("System.ServiceModel.Primitives")
+    {
+        _pluginManager = pluginManager;
+    }
+
+    public override void Initialize(ILifespanManager lifespanManager)
+    {
+        var options = new WcfInstrumentationOptions();
+
+        _pluginManager.ConfigureOptions(options);
+
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationActivitySource, OpenTelemetry.Instrumentation.Wcf");
+
+        instrumentationType.GetProperty("Options")?.SetValue(null, options);
+    }
+}

--- a/test/IntegrationTests/ModuleTests.Default.NetCore.verified.txt
+++ b/test/IntegrationTests/ModuleTests.Default.NetCore.verified.txt
@@ -9,6 +9,5 @@
   OpenTelemetry.Instrumentation.Http,
   OpenTelemetry.Instrumentation.Process,
   OpenTelemetry.Instrumentation.Runtime,
-  OpenTelemetry.Instrumentation.SqlClient,
-  OpenTelemetry.Instrumentation.Wcf
+  OpenTelemetry.Instrumentation.SqlClient
 ]

--- a/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
+++ b/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
@@ -10,6 +10,5 @@
   OpenTelemetry.Instrumentation.Http,
   OpenTelemetry.Instrumentation.Process,
   OpenTelemetry.Instrumentation.Runtime,
-  OpenTelemetry.Instrumentation.SqlClient,
-  OpenTelemetry.Instrumentation.Wcf
+  OpenTelemetry.Instrumentation.SqlClient
 ]


### PR DESCRIPTION
## Why

Towards #1437 

## What

* Makes Wcf loading lazy
* Refactors locations of existing lazy loaders

## Tests

Existing

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
