### PR TITLE
Make ASP.NET instrumentation lazy

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using OpenTelemetry.AutoInstrumentation.Loading;
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Metrics;
@@ -27,7 +28,11 @@ internal static class EnvironmentConfigurationMetricHelper
 {
     private static readonly ILogger Logger = OtelLogging.GetLogger();
 
-    public static MeterProviderBuilder UseEnvironmentVariables(this MeterProviderBuilder builder, MetricSettings settings, PluginManager pluginManager)
+    public static MeterProviderBuilder UseEnvironmentVariables(
+        this MeterProviderBuilder builder,
+        LazyInstrumentationLoader lazyInstrumentationLoader,
+        MetricSettings settings,
+        PluginManager pluginManager)
     {
         builder
             .SetExporter(settings, pluginManager)
@@ -37,7 +42,7 @@ internal static class EnvironmentConfigurationMetricHelper
         {
             _ = enabledMeter switch
             {
-                MetricInstrumentation.AspNet => Wrappers.AddSdkAspNetInstrumentation(builder),
+                MetricInstrumentation.AspNet => Wrappers.AddAspNetInstrumentation(builder, lazyInstrumentationLoader),
                 MetricInstrumentation.HttpClient => Wrappers.AddHttpClientInstrumentation(builder),
                 MetricInstrumentation.NetRuntime => Wrappers.AddRuntimeInstrumentation(builder, pluginManager),
                 MetricInstrumentation.Process => Wrappers.AddProcessInstrumentation(builder, pluginManager),
@@ -73,10 +78,12 @@ internal static class EnvironmentConfigurationMetricHelper
         // Meters
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static MeterProviderBuilder AddSdkAspNetInstrumentation(MeterProviderBuilder builder)
+        public static MeterProviderBuilder AddAspNetInstrumentation(MeterProviderBuilder builder, LazyInstrumentationLoader lazyInstrumentationLoader)
         {
 #if NET462
-            builder.AddAspNetInstrumentation();
+            new AspNetMetricsInitializer(lazyInstrumentationLoader);
+
+            builder.AddMeter("OpenTelemetry.Instrumentation.AspNet");
 #elif NET6_0_OR_GREATER
             builder.AddMeter("OpenTelemetry.Instrumentation.AspNetCore");
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -37,7 +37,7 @@ internal static class EnvironmentConfigurationTracerHelper
         {
             _ = enabledInstrumentation switch
             {
-                TracerInstrumentation.AspNet => Wrappers.AddSdkAspNetInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
+                TracerInstrumentation.AspNet => Wrappers.AddAspNetInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
                 TracerInstrumentation.GrpcNetClient => Wrappers.AddGrpcClientInstrumentation(builder, pluginManager),
                 TracerInstrumentation.HttpClient => Wrappers.AddHttpClientInstrumentation(builder, pluginManager),
                 TracerInstrumentation.Npgsql => builder.AddSource("Npgsql"),
@@ -102,10 +102,12 @@ internal static class EnvironmentConfigurationTracerHelper
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static TracerProviderBuilder AddSdkAspNetInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager, LazyInstrumentationLoader lazyInstrumentationLoader)
+        public static TracerProviderBuilder AddAspNetInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager, LazyInstrumentationLoader lazyInstrumentationLoader)
         {
 #if NET462
-            builder.AddAspNetInstrumentation(pluginManager.ConfigureOptions);
+            new AspNetInitializer(lazyInstrumentationLoader, pluginManager);
+
+            builder.AddSource(OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.AspNetSourceName);
 #elif NET6_0_OR_GREATER
             lazyInstrumentationLoader.Add(new AspNetCoreInitializer(pluginManager));
 

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -139,7 +139,7 @@ internal static class Instrumentation
                 var builder = Sdk
                     .CreateMeterProviderBuilder()
                     .SetResourceBuilder(ResourceFactory.Create())
-                    .UseEnvironmentVariables(MetricSettings, _pluginManager)
+                    .UseEnvironmentVariables(LazyInstrumentationLoader, MetricSettings, _pluginManager)
                     .InvokePlugins(_pluginManager);
 
                 _meterProvider = builder.Build();

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetInitializer.cs
@@ -1,0 +1,56 @@
+// <copyright file="AspNetInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+using System.Threading;
+using OpenTelemetry.AutoInstrumentation.Plugins;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class AspNetInitializer
+{
+    private readonly PluginManager _pluginManager;
+
+    private int _firstInitialization = 1;
+
+    public AspNetInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, PluginManager pluginManager)
+    {
+        _pluginManager = pluginManager;
+        lazyInstrumentationLoader.Add(new AspNetMvcInitializer(InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new AspNetWebApiInitializer(InitializeOnFirstCall));
+    }
+
+    private void InitializeOnFirstCall(ILifespanManager lifespanManager)
+    {
+        if (Interlocked.Exchange(ref _firstInitialization, value: 0) != 1)
+        {
+            // InitializeOnFirstCall() was already called before
+            return;
+        }
+
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentation, OpenTelemetry.Instrumentation.AspNet");
+
+        var options = new OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions();
+        _pluginManager.ConfigureOptions(options);
+
+        var instrumentation = Activator.CreateInstance(instrumentationType, args: options);
+
+        lifespanManager.Track(instrumentation);
+    }
+}
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetInitializer.cs
@@ -37,7 +37,7 @@ internal class AspNetInitializer
 
     private void InitializeOnFirstCall(ILifespanManager lifespanManager)
     {
-        if (Interlocked.Exchange(ref _initialized, value: 1) != 0)
+        if (Interlocked.Exchange(ref _initialized, value: 1) != default)
         {
             // InitializeOnFirstCall() was already called before
             return;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetInitializer.cs
@@ -26,7 +26,7 @@ internal class AspNetInitializer
 {
     private readonly PluginManager _pluginManager;
 
-    private int _firstInitialization = 1;
+    private int _initialized;
 
     public AspNetInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, PluginManager pluginManager)
     {
@@ -37,7 +37,7 @@ internal class AspNetInitializer
 
     private void InitializeOnFirstCall(ILifespanManager lifespanManager)
     {
-        if (Interlocked.Exchange(ref _firstInitialization, value: 0) != 1)
+        if (Interlocked.Exchange(ref _initialized, value: 1) != 0)
         {
             // InitializeOnFirstCall() was already called before
             return;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetMetricsInitializer.cs
@@ -1,0 +1,49 @@
+// <copyright file="AspNetMetricsInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+using System.Threading;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class AspNetMetricsInitializer
+{
+    private int _firstInitialization = 1;
+
+    public AspNetMetricsInitializer(LazyInstrumentationLoader lazyInstrumentationLoader)
+    {
+        lazyInstrumentationLoader.Add(new AspNetMvcInitializer(InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new AspNetWebApiInitializer(InitializeOnFirstCall));
+    }
+
+    private void InitializeOnFirstCall(ILifespanManager lifespanManager)
+    {
+        if (Interlocked.Exchange(ref _firstInitialization, value: 0) != 1)
+        {
+            // InitializeOnFirstCall() was already called before
+            return;
+        }
+
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.AspNet.AspNetMetrics, OpenTelemetry.Instrumentation.AspNet");
+        var instrumentation = Activator.CreateInstance(instrumentationType);
+
+        lifespanManager.Track(instrumentation);
+    }
+}
+
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetMetricsInitializer.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.AutoInstrumentation.Loading;
 
 internal class AspNetMetricsInitializer
 {
-    private int _firstInitialization = 1;
+    private int _initialized;
 
     public AspNetMetricsInitializer(LazyInstrumentationLoader lazyInstrumentationLoader)
     {
@@ -33,7 +33,7 @@ internal class AspNetMetricsInitializer
 
     private void InitializeOnFirstCall(ILifespanManager lifespanManager)
     {
-        if (Interlocked.Exchange(ref _firstInitialization, value: 0) != 1)
+        if (Interlocked.Exchange(ref _initialized, value: 1) != default)
         {
             // InitializeOnFirstCall() was already called before
             return;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetMvcInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetMvcInitializer.cs
@@ -1,0 +1,39 @@
+// <copyright file="AspNetMvcInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class AspNetMvcInitializer : InstrumentationInitializer
+{
+    private readonly Action<ILifespanManager> _initialize;
+
+    public AspNetMvcInitializer(Action<ILifespanManager> initialize)
+        : base("System.Web.Mvc")
+    {
+        _initialize = initialize;
+    }
+
+    public override void Initialize(ILifespanManager lifespanManager)
+    {
+        _initialize(lifespanManager);
+    }
+}
+
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetWebApiInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/AspNetWebApiInitializer.cs
@@ -1,0 +1,39 @@
+// <copyright file="AspNetWebApiInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class AspNetWebApiInitializer : InstrumentationInitializer
+{
+    private readonly Action<ILifespanManager> _initialize;
+
+    public AspNetWebApiInitializer(Action<ILifespanManager> initialize)
+        : base("System.Web.Http")
+    {
+        _initialize = initialize;
+    }
+
+    public override void Initialize(ILifespanManager lifespanManager)
+    {
+        _initialize(lifespanManager);
+    }
+}
+
+#endif

--- a/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
+++ b/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
@@ -4,8 +4,6 @@
   OpenTelemetry.AutoInstrumentation,
   OpenTelemetry.AutoInstrumentation.Loader,
   OpenTelemetry.Exporter.OpenTelemetryProtocol,
-  OpenTelemetry.Instrumentation.AspNet,
-  OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule,
   OpenTelemetry.Instrumentation.GrpcNetClient,
   OpenTelemetry.Instrumentation.Http,
   OpenTelemetry.Instrumentation.Process,


### PR DESCRIPTION
## Why

Towards #1437 

## What

* Makes ASP.NET loading lazy (traces + metrics)

## Tests

Existing

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
