### PR TITLE
Fix wcf test server app

### DIFF
--- a/test/test-applications/integrations/TestApplication.Wcf.Client.Core/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.Core/Program.cs
@@ -40,19 +40,22 @@ internal static class Program
         // Note: Best practice is to re-use your client/channel instances.
         // This code is not meant to illustrate best practices, only the
         // instrumentation.
-        StatusServiceClient client = new StatusServiceClient(binding, remoteAddress);
+        var client = new StatusServiceClient(binding, remoteAddress);
         client.Endpoint.EndpointBehaviors.Add(new TelemetryEndpointBehavior());
         try
         {
             await client.OpenAsync().ConfigureAwait(false);
 
-            var response = await client.PingAsync(
-                new StatusRequest
-                {
-                    Status = Guid.NewGuid().ToString("N"),
-                }).ConfigureAwait(false);
+            var statusRequest = new StatusRequest
+            {
+                Status = Guid.NewGuid().ToString("N"),
+            };
 
-            Console.WriteLine($"Server returned: {response?.ServerTime}");
+            var time = DateTimeOffset.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'");
+            var response = await client.PingAsync(
+                statusRequest).ConfigureAwait(false);
+
+            Console.WriteLine($"[{time}] Sending request with status {statusRequest.Status}. Server returned: {response?.ServerTime:yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'}");
         }
         finally
         {

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/Program.cs
@@ -34,18 +34,21 @@ internal static class Program
         // Note: Best practice is to re-use your client/channel instances.
         // This code is not meant to illustrate best practices, only the
         // instrumentation.
-        StatusServiceClient client = new StatusServiceClient(name);
+        var client = new StatusServiceClient(name);
         try
         {
             await client.OpenAsync().ConfigureAwait(false);
 
-            var response = await client.PingAsync(
-                new StatusRequest
-                {
-                    Status = Guid.NewGuid().ToString("N"),
-                }).ConfigureAwait(false);
+            var statusRequest = new StatusRequest
+            {
+                Status = Guid.NewGuid().ToString("N"),
+            };
 
-            Console.WriteLine($"Server returned: {response?.ServerTime}");
+            var time = DateTimeOffset.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'");
+            var response = await client.PingAsync(
+                statusRequest).ConfigureAwait(false);
+
+            Console.WriteLine($"[{time}] Sending request with status {statusRequest.Status}. Server returned: {response?.ServerTime:yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'}");
         }
         finally
         {

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/Program.cs
@@ -17,25 +17,29 @@
 using System;
 using System.ServiceModel;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace TestApplication.Wcf.Server.NetFramework;
 
 internal static class Program
 {
-    public static void Main()
+    public static async Task Main()
     {
         try
         {
             try
             {
-                ServiceHost serviceHost = new ServiceHost(typeof(StatusService));
+                var serviceHost = new ServiceHost(typeof(StatusService));
                 serviceHost.Open();
 
                 while (StatusService.TimesHit != 2)
                 {
-                    Console.WriteLine("Server waiting for calls");
+                    Console.WriteLine($"[{DateTimeOffset.UtcNow:yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'}] Server waiting for calls");
                     Thread.Sleep(1000);
                 }
+
+                // Wait for the last request to be fully handled
+                await Task.Delay(2000);
 
                 serviceHost.Close();
             }
@@ -49,6 +53,6 @@ internal static class Program
             Console.WriteLine($"ServerException: top-level try-catch {e}");
         }
 
-        Console.WriteLine("WCFServer: exiting main()");
+        Console.WriteLine($"[{DateTimeOffset.UtcNow:yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'}] WCFServer: exiting main()");
     }
 }

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/StatusService.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/StatusService.cs
@@ -35,15 +35,20 @@ public class StatusService : IStatusServiceContract
 
     public Task<StatusResponse> PingAsync(StatusRequest request)
     {
-        lock (Lock)
-        {
-            TimesHit += 1;
-        }
+        var time = DateTimeOffset.UtcNow;
 
-        return Task.FromResult(
-            new StatusResponse
+        try
+        {
+            return Task.FromResult(
+                new StatusResponse { ServerTime = time, });
+        }
+        finally
+        {
+            lock (Lock)
             {
-                ServerTime = DateTimeOffset.UtcNow,
-            });
+                TimesHit += 1;
+                Console.WriteLine($"[{time:yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'}] Client request accepted. Status: {request.Status}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why

WCF integrations test are unstable

Fixes #1591

## What

Output improvements for easier debugging. Move increment to finally block. Wait after receiving the second call before closing the server.
