### PR TITLE
Make GrpcNetClient instrumentation lazy

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
@@ -18,6 +18,7 @@ using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.AutoInstrumentation.Loading;
+using OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Metrics;

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using OpenTelemetry.AutoInstrumentation.Configuration;
 using OpenTelemetry.AutoInstrumentation.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.Loading;
+using OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Context.Propagation;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreInitializer.cs
@@ -1,0 +1,47 @@
+// <copyright file="AspNetCoreInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+using System;
+using OpenTelemetry.AutoInstrumentation.Plugins;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
+
+internal class AspNetCoreInitializer : InstrumentationInitializer
+{
+    private readonly PluginManager _pluginManager;
+
+    public AspNetCoreInitializer(PluginManager pluginManager)
+        : base("Microsoft.AspNetCore.Http")
+    {
+        _pluginManager = pluginManager;
+    }
+
+    public override void Initialize(ILifespanManager lifespanManager)
+    {
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentation, OpenTelemetry.Instrumentation.AspNetCore");
+        var httpInListenerType = Type.GetType("OpenTelemetry.Instrumentation.AspNetCore.Implementation.HttpInListener, OpenTelemetry.Instrumentation.AspNetCore");
+
+        var options = new OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions();
+        _pluginManager.ConfigureOptions(options);
+
+        var httpInListener = Activator.CreateInstance(httpInListenerType, args: options);
+        var instrumentation = Activator.CreateInstance(instrumentationType, args: httpInListener);
+
+        lifespanManager.Track(instrumentation);
+    }
+}
+#endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreMetricsInitializer.cs
@@ -1,4 +1,4 @@
-// <copyright file="AspNetMvcInitializer.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetCoreMetricsInitializer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,26 +14,26 @@
 // limitations under the License.
 // </copyright>
 
-#if NETFRAMEWORK
+#if NET6_0_OR_GREATER
 
 using System;
 
-namespace OpenTelemetry.AutoInstrumentation.Loading;
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
-internal class AspNetMvcInitializer : InstrumentationInitializer
+internal class AspNetCoreMetricsInitializer : InstrumentationInitializer
 {
-    private readonly Action<ILifespanManager> _initialize;
-
-    public AspNetMvcInitializer(Action<ILifespanManager> initialize)
-        : base("System.Web.Mvc")
+    public AspNetCoreMetricsInitializer()
+        : base("Microsoft.AspNetCore.Http")
     {
-        _initialize = initialize;
     }
 
     public override void Initialize(ILifespanManager lifespanManager)
     {
-        _initialize(lifespanManager);
+        var metricsType = Type.GetType("OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetrics, OpenTelemetry.Instrumentation.AspNetCore");
+
+        var aspNetCoreMetrics = Activator.CreateInstance(metricsType);
+
+        lifespanManager.Track(aspNetCoreMetrics);
     }
 }
-
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMetricsInitializer.cs
@@ -1,4 +1,4 @@
-// <copyright file="AspNetInitializer.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetMetricsInitializer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,19 +18,15 @@
 
 using System;
 using System.Threading;
-using OpenTelemetry.AutoInstrumentation.Plugins;
 
-namespace OpenTelemetry.AutoInstrumentation.Loading;
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
-internal class AspNetInitializer
+internal class AspNetMetricsInitializer
 {
-    private readonly PluginManager _pluginManager;
-
     private int _initialized;
 
-    public AspNetInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, PluginManager pluginManager)
+    public AspNetMetricsInitializer(LazyInstrumentationLoader lazyInstrumentationLoader)
     {
-        _pluginManager = pluginManager;
         lazyInstrumentationLoader.Add(new AspNetMvcInitializer(InitializeOnFirstCall));
         lazyInstrumentationLoader.Add(new AspNetWebApiInitializer(InitializeOnFirstCall));
     }
@@ -43,14 +39,11 @@ internal class AspNetInitializer
             return;
         }
 
-        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentation, OpenTelemetry.Instrumentation.AspNet");
-
-        var options = new OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions();
-        _pluginManager.ConfigureOptions(options);
-
-        var instrumentation = Activator.CreateInstance(instrumentationType, args: options);
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.AspNet.AspNetMetrics, OpenTelemetry.Instrumentation.AspNet");
+        var instrumentation = Activator.CreateInstance(instrumentationType);
 
         lifespanManager.Track(instrumentation);
     }
 }
+
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMvcInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMvcInitializer.cs
@@ -1,4 +1,4 @@
-// <copyright file="AspNetWebApiInitializer.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetMvcInitializer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,14 +18,14 @@
 
 using System;
 
-namespace OpenTelemetry.AutoInstrumentation.Loading;
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
-internal class AspNetWebApiInitializer : InstrumentationInitializer
+internal class AspNetMvcInitializer : InstrumentationInitializer
 {
     private readonly Action<ILifespanManager> _initialize;
 
-    public AspNetWebApiInitializer(Action<ILifespanManager> initialize)
-        : base("System.Web.Http")
+    public AspNetMvcInitializer(Action<ILifespanManager> initialize)
+        : base("System.Web.Mvc")
     {
         _initialize = initialize;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetWebApiInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetWebApiInitializer.cs
@@ -1,4 +1,4 @@
-// <copyright file="AspNetCoreMetricsInitializer.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetWebApiInitializer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,26 +14,26 @@
 // limitations under the License.
 // </copyright>
 
-#if NET6_0_OR_GREATER
+#if NETFRAMEWORK
 
 using System;
 
-namespace OpenTelemetry.AutoInstrumentation.Loading;
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
-internal class AspNetCoreMetricsInitializer : InstrumentationInitializer
+internal class AspNetWebApiInitializer : InstrumentationInitializer
 {
-    public AspNetCoreMetricsInitializer()
-        : base("Microsoft.AspNetCore.Http")
+    private readonly Action<ILifespanManager> _initialize;
+
+    public AspNetWebApiInitializer(Action<ILifespanManager> initialize)
+        : base("System.Web.Http")
     {
+        _initialize = initialize;
     }
 
     public override void Initialize(ILifespanManager lifespanManager)
     {
-        var metricsType = Type.GetType("OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetrics, OpenTelemetry.Instrumentation.AspNetCore");
-
-        var aspNetCoreMetrics = Activator.CreateInstance(metricsType);
-
-        lifespanManager.Track(aspNetCoreMetrics);
+        _initialize(lifespanManager);
     }
 }
+
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/MySqlDataInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/MySqlDataInitializer.cs
@@ -19,7 +19,7 @@
 using System;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 
-namespace OpenTelemetry.AutoInstrumentation.Loading;
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
 internal class MySqlDataInitializer : InstrumentationInitializer
 {

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
@@ -18,7 +18,7 @@ using System;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Instrumentation.Wcf;
 
-namespace OpenTelemetry.AutoInstrumentation.Loading;
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
 internal class WcfInitializer : InstrumentationInitializer
 {

--- a/test/IntegrationTests/ModuleTests.Default.NetCore.verified.txt
+++ b/test/IntegrationTests/ModuleTests.Default.NetCore.verified.txt
@@ -5,7 +5,6 @@
   OpenTelemetry.AutoInstrumentation.Loader,
   OpenTelemetry.AutoInstrumentation.StartupHook,
   OpenTelemetry.Exporter.OpenTelemetryProtocol,
-  OpenTelemetry.Instrumentation.GrpcNetClient,
   OpenTelemetry.Instrumentation.Http,
   OpenTelemetry.Instrumentation.Process,
   OpenTelemetry.Instrumentation.Runtime,

--- a/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
+++ b/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
@@ -4,7 +4,6 @@
   OpenTelemetry.AutoInstrumentation,
   OpenTelemetry.AutoInstrumentation.Loader,
   OpenTelemetry.Exporter.OpenTelemetryProtocol,
-  OpenTelemetry.Instrumentation.GrpcNetClient,
   OpenTelemetry.Instrumentation.Http,
   OpenTelemetry.Instrumentation.Process,
   OpenTelemetry.Instrumentation.Runtime,


### PR DESCRIPTION
## Why

Towards #1437 

## What

* Makes Grpc.Net client instrumentation loading lazy (traces)

## Tests

Existing

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
