### PR TITLE
Make SqlClient instrumentation lazy

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -42,7 +42,7 @@ internal static class EnvironmentConfigurationTracerHelper
                 TracerInstrumentation.GrpcNetClient => Wrappers.AddGrpcClientInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
                 TracerInstrumentation.HttpClient => Wrappers.AddHttpClientInstrumentation(builder, pluginManager),
                 TracerInstrumentation.Npgsql => builder.AddSource("Npgsql"),
-                TracerInstrumentation.SqlClient => Wrappers.AddSqlClientInstrumentation(builder, pluginManager),
+                TracerInstrumentation.SqlClient => Wrappers.AddSqlClientInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
                 TracerInstrumentation.Wcf => Wrappers.AddWcfInstrumentation(builder, pluginManager, lazyInstrumentationLoader),
 #if NET6_0_OR_GREATER
                 TracerInstrumentation.MassTransit => builder.AddSource("MassTransit"),
@@ -129,9 +129,11 @@ internal static class EnvironmentConfigurationTracerHelper
 #endif
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static TracerProviderBuilder AddSqlClientInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager)
+        public static TracerProviderBuilder AddSqlClientInstrumentation(TracerProviderBuilder builder, PluginManager pluginManager, LazyInstrumentationLoader lazyInstrumentationLoader)
         {
-            return builder.AddSqlClientInstrumentation(pluginManager.ConfigureOptions);
+            lazyInstrumentationLoader.Add(new SqlClientInitializer(pluginManager));
+
+            return builder.AddSource("OpenTelemetry.SqlClient");
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientInitializer.cs
@@ -1,0 +1,43 @@
+// <copyright file="SqlClientInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using OpenTelemetry.AutoInstrumentation.Plugins;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
+
+internal class SqlClientInitializer : InstrumentationInitializer
+{
+    private readonly PluginManager _pluginManager;
+
+    public SqlClientInitializer(PluginManager pluginManager)
+        : base("Microsoft.Data.SqlClient")
+    {
+        _pluginManager = pluginManager;
+    }
+
+    public override void Initialize(ILifespanManager lifespanManager)
+    {
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentation, OpenTelemetry.Instrumentation.SqlClient");
+
+        var options = new OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions();
+        _pluginManager.ConfigureOptions(options);
+
+        var instrumentation = Activator.CreateInstance(instrumentationType, options);
+
+        lifespanManager.Track(instrumentation);
+    }
+}

--- a/test/IntegrationTests/ModuleTests.Default.NetCore.verified.txt
+++ b/test/IntegrationTests/ModuleTests.Default.NetCore.verified.txt
@@ -7,6 +7,5 @@
   OpenTelemetry.Exporter.OpenTelemetryProtocol,
   OpenTelemetry.Instrumentation.Http,
   OpenTelemetry.Instrumentation.Process,
-  OpenTelemetry.Instrumentation.Runtime,
-  OpenTelemetry.Instrumentation.SqlClient
+  OpenTelemetry.Instrumentation.Runtime
 ]

--- a/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
+++ b/test/IntegrationTests/ModuleTests.Default.NetFx.verified.txt
@@ -6,6 +6,5 @@
   OpenTelemetry.Exporter.OpenTelemetryProtocol,
   OpenTelemetry.Instrumentation.Http,
   OpenTelemetry.Instrumentation.Process,
-  OpenTelemetry.Instrumentation.Runtime,
-  OpenTelemetry.Instrumentation.SqlClient
+  OpenTelemetry.Instrumentation.Runtime
 ]


### PR DESCRIPTION
## Why

Towards #1437 

## What

* Makes SqlClient instrumentation loading lazy (traces)

## Tests

Existing

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
