### PR TITLE
Make HttpClient instrumentation lazy

### DIFF
--- a/OpenTelemetry.AutoInstrumentation.sln
+++ b/OpenTelemetry.AutoInstrumentation.sln
@@ -157,6 +157,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationsJsonGenerator",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.Modules", "test\test-applications\integrations\TestApplication.Modules\TestApplication.Modules.csproj", "{F8C3A1FF-2333-45C8-9174-75F12526DFDD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.Http.NetFramework", "test\test-applications\integrations\TestApplication.Http.NetFramework\TestApplication.Http.NetFramework.csproj", "{5D0FECF8-1954-449D-8C42-5373D91154FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -737,6 +739,18 @@ Global
 		{F8C3A1FF-2333-45C8-9174-75F12526DFDD}.Release|x64.Build.0 = Release|x64
 		{F8C3A1FF-2333-45C8-9174-75F12526DFDD}.Release|x86.ActiveCfg = Release|x86
 		{F8C3A1FF-2333-45C8-9174-75F12526DFDD}.Release|x86.Build.0 = Release|x86
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Debug|Any CPU.Build.0 = Debug|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Debug|x64.ActiveCfg = Debug|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Debug|x64.Build.0 = Debug|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Debug|x86.ActiveCfg = Debug|x86
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Debug|x86.Build.0 = Debug|x86
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Release|Any CPU.ActiveCfg = Release|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Release|Any CPU.Build.0 = Release|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Release|x64.ActiveCfg = Release|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Release|x64.Build.0 = Release|x64
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Release|x86.ActiveCfg = Release|x86
+		{5D0FECF8-1954-449D-8C42-5373D91154FA}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -794,6 +808,7 @@ Global
 		{06664166-35D6-484D-9171-DCB99D1D310A} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 		{0A950D85-E813-4CA3-8927-334BB7787372} = {00F4C92D-6652-4BD8-A334-B35D3E711BE6}
 		{F8C3A1FF-2333-45C8-9174-75F12526DFDD} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
+		{5D0FECF8-1954-449D-8C42-5373D91154FA} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/GenericInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/GenericInitializer.cs
@@ -1,0 +1,35 @@
+// <copyright file="GenericInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading;
+
+internal class GenericInitializer : InstrumentationInitializer
+{
+    private readonly Action<ILifespanManager> _initialize;
+
+    public GenericInitializer(string assemblyName, Action<ILifespanManager> initialize)
+        : base(assemblyName)
+    {
+        _initialize = initialize;
+    }
+
+    public override void Initialize(ILifespanManager lifespanManager)
+    {
+        _initialize(lifespanManager);
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
@@ -1,0 +1,65 @@
+// <copyright file="HttpClientInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Threading;
+using OpenTelemetry.AutoInstrumentation.Plugins;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
+
+internal class HttpClientInitializer
+{
+    private readonly PluginManager _pluginManager;
+
+    private int _initialized;
+
+    public HttpClientInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, PluginManager pluginManager)
+    {
+        _pluginManager = pluginManager;
+
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net.Http", InitializeOnFirstCall));
+
+#if NETFRAMEWORK
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net", InitializeOnFirstCall));
+#endif
+    }
+
+    private void InitializeOnFirstCall(ILifespanManager lifespanManager)
+    {
+        if (Interlocked.Exchange(ref _initialized, value: 1) != default)
+        {
+            // InitializeOnFirstCall() was already called before
+            return;
+        }
+
+#if NETFRAMEWORK
+        var options = new OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions();
+        _pluginManager.ConfigureOptions(options);
+
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Http.Implementation.HttpWebRequestActivitySource, OpenTelemetry.Instrumentation.Http");
+
+        instrumentationType.GetProperty("Options")?.SetValue(null, options);
+#else
+        var options = new OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions();
+        _pluginManager.ConfigureOptions(options);
+
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Http.HttpClientInstrumentation, OpenTelemetry.Instrumentation.Http");
+        var instrumentation = Activator.CreateInstance(instrumentationType, options);
+
+        lifespanManager.Track(instrumentation);
+#endif
+    }
+}

--- a/test/IntegrationTests/Helpers/TestHttpServer.NetFramework.cs
+++ b/test/IntegrationTests/Helpers/TestHttpServer.NetFramework.cs
@@ -45,7 +45,7 @@ public class TestHttpServer : IDisposable
 
         _listenerThread = new Thread(HandleHttpRequests);
         _listenerThread.Start();
-}
+    }
 
     /// <summary>
     /// Gets the TCP port that this listener is listening on.

--- a/test/IntegrationTests/HttpNetFrameworkTests.cs
+++ b/test/IntegrationTests/HttpNetFrameworkTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="HttpNetFrameworkTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+using IntegrationTests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IntegrationTests;
+
+public class HttpNetFrameworkTests : TestHelper
+{
+    public HttpNetFrameworkTests(ITestOutputHelper output)
+        : base("Http.NetFramework", output)
+    {
+    }
+
+    [Fact]
+    [Trait("Category", "EndToEnd")]
+    public void SubmitTraces()
+    {
+        using var collector = new MockSpansCollector(Output);
+        SetExporter(collector);
+
+        collector.Expect("OpenTelemetry.HttpWebRequest");
+        collector.Expect("TestApplication.Http.NetFramework");
+
+        RunTestApplication();
+
+        collector.AssertExpectations();
+    }
+}
+#endif

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/Helpers/TcpPortProvider.cs
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/Helpers/TcpPortProvider.cs
@@ -1,0 +1,42 @@
+// <copyright file="TcpPortProvider.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace TestApplication.Http.NetFramework.Helpers;
+
+internal static class TcpPortProvider
+{
+    public static int GetOpenPort()
+    {
+        TcpListener tcpListener = null;
+
+        try
+        {
+            tcpListener = new TcpListener(IPAddress.Loopback, 0);
+            tcpListener.Start();
+
+            int port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+
+            return port;
+        }
+        finally
+        {
+            tcpListener?.Stop();
+        }
+    }
+}

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/Program.cs
@@ -25,7 +25,7 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        using var listener = new TestServer("localhost", "/test/");
+        using var listener = new TestServer("/test/");
         var address = $"http://localhost:{listener.Port}";
 
         var request = (HttpWebRequest)WebRequest.Create($"{address}/test");

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/Program.cs
@@ -1,0 +1,51 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace TestApplication.Http.NetFramework;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        using var listener = new TestServer("localhost", "/test/");
+        var address = $"http://localhost:{listener.Port}";
+
+        var request = (HttpWebRequest)WebRequest.Create($"{address}/test");
+        request.Method = "POST";
+        request.ContentType = "text/plain";
+
+        using (Stream requestStream = request.GetRequestStream())
+        {
+            var content = Encoding.UTF8.GetBytes("Ping");
+
+            requestStream.Write(content, 0, content.Length);
+        }
+
+        var response = request.GetResponse();
+
+        using (var responseStream = response.GetResponseStream())
+        using (var responseReader = new StreamReader(responseStream))
+        {
+            var text = responseReader.ReadToEnd();
+            Console.WriteLine("[CLIENT] Received: {0}", text);
+        }
+    }
+}

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/TestApplication.Http.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/TestApplication.Http.NetFramework.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462</TargetFrameworks>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+  </ItemGroup>
+  
+</Project>

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/TestServer.cs
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/TestServer.cs
@@ -1,0 +1,136 @@
+// <copyright file="TestServer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using TestApplication.Http.NetFramework.Helpers;
+
+namespace TestApplication.Http.NetFramework;
+
+public class TestServer : IDisposable
+{
+    private static readonly ActivitySource MyActivitySource = new ActivitySource("TestApplication.Http.NetFramework", "1.0.0");
+
+    private readonly HttpListener _listener;
+    private readonly Thread _listenerThread;
+    private readonly string _prefix;
+
+    public TestServer(string host, string sufix = "/")
+    {
+        // try up to 5 consecutive ports before giving up
+        int retries = 4;
+        while (true)
+        {
+            // seems like we can't reuse a listener if it fails to start,
+            // so create a new listener each time we retry
+            _listener = new HttpListener();
+
+            try
+            {
+                _listener.Start();
+
+                // See https://docs.microsoft.com/en-us/dotnet/api/system.net.httplistenerprefixcollection.add?redirectedfrom=MSDN&view=net-6.0#remarks
+                // for info about the host value.
+                Port = TcpPortProvider.GetOpenPort();
+                _prefix = new UriBuilder("http", host, Port, sufix).ToString();
+                _listener.Prefixes.Add(_prefix);
+
+                // successfully listening
+                _listenerThread = new Thread(HandleHttpRequests);
+                _listenerThread.Start();
+                Console.WriteLine($"[LISTENER] Listening on '{_prefix}'");
+                return;
+            }
+            catch (HttpListenerException) when (retries > 0)
+            {
+                _listener.Close(); // a new listener is created in the beginnning of the loop
+                retries--;
+            }
+
+            _listener.Close(); // always close listener if exception is thrown, whether it was caught or not
+            throw new InvalidOperationException("Listener shut down. Could not find available port.");
+        }
+    }
+
+    /// <summary>
+    /// Gets the TCP port that this listener is listening on.
+    /// </summary>
+    public int Port { get; }
+
+    public void Dispose()
+    {
+        Console.WriteLine($"[LISTENER] shutting down.");
+        _listener.Close();
+    }
+
+    private void HandleHttpRequests()
+    {
+        while (_listener.IsListening)
+        {
+            try
+            {
+                var ctx = _listener.GetContext();
+
+                using var reader = new StreamReader(ctx.Request.InputStream);
+                var request = reader.ReadToEnd();
+
+                Console.WriteLine("[SERVER] Received: {0}", request);
+
+                using (var activity = MyActivitySource.StartActivity("manual span"))
+                {
+                    activity?.SetTag("test_tag", "test_value");
+                }
+
+                // NOTE: HttpStreamRequest doesn't support Transfer-Encoding: Chunked
+                // (Setting content-length avoids that)
+                ctx.Response.ContentType = "text/plain";
+                var buffer = Encoding.UTF8.GetBytes("Pong");
+                ctx.Response.ContentLength64 = buffer.LongLength;
+                ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            }
+            catch (HttpListenerException)
+            {
+                // listener was stopped,
+                // ignore to let the loop end and the method return
+            }
+            catch (ObjectDisposedException)
+            {
+                // the response has been already disposed.
+            }
+            catch (InvalidOperationException)
+            {
+                // this can occur when setting Response.ContentLength64, with the framework claiming that the response has already been submitted
+                // for now ignore, and we'll see if this introduces downstream issues
+            }
+            catch (Exception) when (!_listener.IsListening)
+            {
+                // we don't care about any exception when listener is stopped
+            }
+            catch (Exception ex)
+            {
+                // somethig unexpected happened
+                // log instead of crashing the thread
+                Console.WriteLine("[EXCEPTION]: {0}", ex.Message);
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/TestServer.cs
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/TestServer.cs
@@ -32,7 +32,7 @@ public class TestServer : IDisposable
     private readonly Thread _listenerThread;
     private readonly string _prefix;
 
-    public TestServer(string host, string sufix = "/")
+    public TestServer(string sufix)
     {
         // try up to 5 consecutive ports before giving up
         int retries = 4;
@@ -46,10 +46,8 @@ public class TestServer : IDisposable
             {
                 _listener.Start();
 
-                // See https://docs.microsoft.com/en-us/dotnet/api/system.net.httplistenerprefixcollection.add?redirectedfrom=MSDN&view=net-6.0#remarks
-                // for info about the host value.
                 Port = TcpPortProvider.GetOpenPort();
-                _prefix = new UriBuilder("http", host, Port, sufix).ToString();
+                _prefix = new UriBuilder("http", "localhost", Port, sufix).ToString();
                 _listener.Prefixes.Add(_prefix);
 
                 // successfully listening
@@ -78,6 +76,7 @@ public class TestServer : IDisposable
     {
         Console.WriteLine($"[LISTENER] shutting down.");
         _listener.Close();
+        _listenerThread.Join();
     }
 
     private void HandleHttpRequests()

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/TestServer.cs
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/TestServer.cs
@@ -30,7 +30,6 @@ public class TestServer : IDisposable
 
     private readonly HttpListener _listener;
     private readonly Thread _listenerThread;
-    private readonly string _prefix;
 
     public TestServer(string sufix)
     {
@@ -40,7 +39,7 @@ public class TestServer : IDisposable
         _listener.Start();
         var prefix = new UriBuilder("http", "localhost", Port, sufix).ToString();
         _listener.Prefixes.Add(prefix);
-        Console.WriteLine($"[LISTENER] Listening on '{_prefix}'");
+        Console.WriteLine($"[LISTENER] Listening on '{prefix}'");
 
         _listenerThread = new Thread(HandleHttpRequests);
         _listenerThread.Start();


### PR DESCRIPTION
## Why

Towards #1437 

## What

* Makes Http instrumentation loading lazy (traces)
* Add Http .NET Framework tests

## Tests

Existing + new .NET Framework tests

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
