### PR TITLE
Introduce common timeouts in integration tests

### DIFF
--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -36,8 +36,6 @@ namespace IntegrationTests.Helpers;
 
 public class MockLogsCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
-
     private readonly ITestOutputHelper _output;
     private readonly TestHttpServer _listener;
     private readonly BlockingCollection<LogRecord> _logs = new(100); // bounded to avoid memory leak
@@ -87,7 +85,7 @@ public class MockLogsCollector : IDisposable
         var expectationsMet = new List<LogRecord>();
         var additionalEntries = new List<LogRecord>();
 
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.Expectation;
         var cts = new CancellationTokenSource();
 
         try
@@ -135,7 +133,7 @@ public class MockLogsCollector : IDisposable
 
     public void AssertEmpty(TimeSpan? timeout = null)
     {
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.NoExpectation;
         if (_logs.TryTake(out var logRecord, timeout.Value))
         {
             Assert.Fail($"Expected nothing, but got: {logRecord}");

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -36,8 +36,6 @@ namespace IntegrationTests.Helpers;
 
 public class MockMetricsCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
-
     private readonly ITestOutputHelper _output;
     private readonly TestHttpServer _listener;
 
@@ -88,7 +86,7 @@ public class MockMetricsCollector : IDisposable
         var expectationsMet = new List<Collected>();
         var additionalEntries = new List<Collected>();
 
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.Expectation;
         var cts = new CancellationTokenSource();
 
         try
@@ -145,9 +143,9 @@ public class MockMetricsCollector : IDisposable
         }
     }
 
-    internal void AssertEpmty(TimeSpan? timeout = null)
+    internal void AssertEmpty(TimeSpan? timeout = null)
     {
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.NoExpectation;
         if (_metricsSnapshots.TryTake(out var metricsResource, timeout.Value))
         {
             Assert.Fail($"Expected nothing, but got: {metricsResource}");

--- a/test/IntegrationTests/Helpers/MockSpansCollector.cs
+++ b/test/IntegrationTests/Helpers/MockSpansCollector.cs
@@ -36,8 +36,6 @@ namespace IntegrationTests.Helpers;
 
 public class MockSpansCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
-
     private readonly ITestOutputHelper _output;
     private readonly TestHttpServer _listener;
 
@@ -89,7 +87,7 @@ public class MockSpansCollector : IDisposable
         var expectationsMet = new List<Collected>();
         var additionalEntries = new List<Collected>();
 
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.Expectation;
         var cts = new CancellationTokenSource();
 
         try
@@ -142,7 +140,7 @@ public class MockSpansCollector : IDisposable
 
     public void AssertEmpty(TimeSpan? timeout = null)
     {
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.NoExpectation;
         if (_spans.TryTake(out var resourceSpan, timeout.Value))
         {
             Assert.Fail($"Expected nothing, but got: {resourceSpan}");

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -40,8 +40,6 @@ namespace IntegrationTests.Helpers;
 
 public class MockZipkinCollector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
-
     private readonly ITestOutputHelper _output;
     private readonly TestHttpServer _listener;
 
@@ -89,7 +87,7 @@ public class MockZipkinCollector : IDisposable
         var expectationsMet = new List<ZSpanMock>();
         var additionalEntries = new List<ZSpanMock>();
 
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.Expectation;
         var cts = new CancellationTokenSource();
 
         try

--- a/test/IntegrationTests/Helpers/OtlpResourceExpector.cs
+++ b/test/IntegrationTests/Helpers/OtlpResourceExpector.cs
@@ -27,8 +27,6 @@ namespace IntegrationTests.Helpers;
 
 public class OtlpResourceExpector : IDisposable
 {
-    private static readonly TimeSpan DefaultWaitTimeout = TimeSpan.FromMinutes(1);
-
     private readonly List<ResourceExpectation> _resourceExpectations = new();
 
     private readonly ManualResetEvent _resourceAttributesEvent = new(false); // synchronizes access to _resourceAttributes
@@ -61,7 +59,7 @@ public class OtlpResourceExpector : IDisposable
             throw new InvalidOperationException("Expectations were not set");
         }
 
-        timeout ??= DefaultWaitTimeout;
+        timeout ??= Timeout.Expectation;
 
         try
         {

--- a/test/IntegrationTests/Helpers/ProcessHelper.cs
+++ b/test/IntegrationTests/Helpers/ProcessHelper.cs
@@ -26,8 +26,6 @@ namespace IntegrationTests.Helpers;
 /// </summary>
 public class ProcessHelper : IDisposable
 {
-    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
-
     private readonly ManualResetEventSlim _outputMutex = new();
     private readonly StringBuilder _outputBuffer = new();
     private readonly StringBuilder _errorBuffer = new();
@@ -54,7 +52,7 @@ public class ProcessHelper : IDisposable
 
     public bool Drain()
     {
-        return Drain(DefaultTimeout);
+        return Drain(Timeout.ProcessExit);
     }
 
     public bool Drain(TimeSpan timeout)

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -25,9 +25,6 @@ namespace IntegrationTests.Helpers;
 
 public abstract class TestHelper
 {
-    // Warning: Long timeouts can cause integer overflow!
-    private static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes(5);
-
     protected TestHelper(string testApplicationName, ITestOutputHelper output)
     {
         Output = output;
@@ -100,7 +97,7 @@ public abstract class TestHelper
         Output.WriteLine($"ProcessName: " + process.ProcessName);
         using var helper = new ProcessHelper(process);
 
-        bool processTimeout = !process.WaitForExit((int)DefaultProcessTimeout.TotalMilliseconds);
+        bool processTimeout = !process.WaitForExit((int)Timeout.ProcessExit.TotalMilliseconds);
         if (processTimeout)
         {
             process.Kill();

--- a/test/IntegrationTests/Helpers/Timeout.cs
+++ b/test/IntegrationTests/Helpers/Timeout.cs
@@ -1,0 +1,26 @@
+// <copyright file="Timeout.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace IntegrationTests.Helpers;
+
+internal static class Timeout
+{
+    public static readonly TimeSpan ProcessExit = TimeSpan.FromMinutes(5); // caution: long timeouts can cause integer overflow!
+    public static readonly TimeSpan Expectation = TimeSpan.FromMinutes(1); // long to avoid flaky tests
+    public static readonly TimeSpan NoExpectation = TimeSpan.FromSeconds(3); // short to not make the tests unnecessary long
+}

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Net;
-using System.Net.Http;
 using System.Reflection;
 using FluentAssertions;
 using FluentAssertions.Extensions;
@@ -24,6 +22,8 @@ using Xunit;
 using Xunit.Abstractions;
 
 #if NETFRAMEWORK
+using System.Net;
+using System.Net.Http;
 using IntegrationTests.Helpers.Compatibility;
 #else
 using System;
@@ -269,7 +269,7 @@ public class SmokeTests : TestHelper
         EnableBytecodeInstrumentation();
         RunTestApplication();
 
-        collector.AssertEmpty(5.Seconds());
+        collector.AssertEmpty();
     }
 
 #endif
@@ -281,7 +281,7 @@ public class SmokeTests : TestHelper
         using var collector = new MockSpansCollector(Output);
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS", "none");
         RunTestApplication();
-        collector.AssertEmpty(1.Seconds());
+        collector.AssertEmpty();
     }
 
     [Fact]
@@ -291,7 +291,7 @@ public class SmokeTests : TestHelper
         using var collector = new MockMetricsCollector(Output);
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS", "none");
         RunTestApplication();
-        collector.AssertEpmty(1.Seconds());
+        collector.AssertEmpty();
     }
 
     [Fact]
@@ -302,7 +302,7 @@ public class SmokeTests : TestHelper
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_LOGS_DISABLED_INSTRUMENTATIONS", "ILogger");
         EnableBytecodeInstrumentation();
         RunTestApplication();
-        collector.AssertEmpty(1.Seconds());
+        collector.AssertEmpty();
     }
 
     [Fact]
@@ -314,7 +314,7 @@ public class SmokeTests : TestHelper
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_METRICS_DISABLED_INSTRUMENTATIONS", "HttpClient");
         EnableBytecodeInstrumentation();
         RunTestApplication();
-        collector.AssertEpmty(1.Seconds());
+        collector.AssertEmpty();
     }
 
     [Fact]
@@ -325,7 +325,7 @@ public class SmokeTests : TestHelper
         SetExporter(collector);
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_DISABLED_INSTRUMENTATIONS", "AspNet,HttpClient");
         RunTestApplication();
-        collector.AssertEmpty(1.Seconds());
+        collector.AssertEmpty();
     }
 
     private void VerifyTestApplicationInstrumented()
@@ -353,6 +353,6 @@ public class SmokeTests : TestHelper
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES", "MyCompany.MyProduct.MyLibrary");
         RunTestApplication();
 
-        collector.AssertEmpty(5.Seconds());
+        collector.AssertEmpty();
     }
 }


### PR DESCRIPTION
## Why

DRY the code.

## What

Introduce common default timeout constants used in integration tests.
