### PR TITLE
Make HttpClient instrumentation lazy (Metrics)

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -104,9 +104,9 @@ internal static class EnvironmentConfigurationTracerHelper
             new HttpClientInitializer(lazyInstrumentationLoader, pluginManager);
 
 #if NETFRAMEWORK
-            builder.AddSource("OpenTelemetry.Instrumentation.Http.HttpWebRequest");
+            builder.AddSource("OpenTelemetry.HttpWebRequest");
 #else
-            builder.AddSource("OpenTelemetry.Instrumentation.Http.HttpClient");
+            builder.AddSource("OpenTelemetry.Instrumentation.Http");
             builder.AddSource("System.Net.Http"); // This works only System.Net.Http >= 7.0.0
             builder.AddLegacySource("System.Net.Http.HttpRequestOut");
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -32,8 +32,6 @@ internal static class EnvironmentConfigurationTracerHelper
         TracerSettings settings,
         PluginManager pluginManager)
     {
-        builder.SetExporter(settings, pluginManager);
-
         foreach (var enabledInstrumentation in settings.EnabledInstrumentations)
         {
             _ = enabledInstrumentation switch
@@ -53,6 +51,10 @@ internal static class EnvironmentConfigurationTracerHelper
                 _ => null
             };
         }
+
+        // Exporters can cause dependency loads.
+        // Should be called later if dependency listeners are already setup.
+        builder.SetExporter(settings, pluginManager);
 
         builder.AddSource(settings.ActivitySources.ToArray());
         foreach (var legacySource in settings.LegacySources)
@@ -109,7 +111,7 @@ internal static class EnvironmentConfigurationTracerHelper
             builder.AddLegacySource("System.Net.Http.HttpRequestOut");
 #endif
 
-            return builder.AddHttpClientInstrumentation(pluginManager.ConfigureOptions);
+            return builder;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -20,7 +20,6 @@ using System.Threading;
 using OpenTelemetry.AutoInstrumentation.Configuration;
 using OpenTelemetry.AutoInstrumentation.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.Loading;
-using OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Context.Propagation;
@@ -129,14 +128,6 @@ internal static class Instrumentation
 
             if (MetricSettings.MetricsEnabled)
             {
-#if NET6_0_OR_GREATER
-
-                if (MetricSettings.EnabledInstrumentations.Contains(MetricInstrumentation.AspNet))
-                {
-                    LazyInstrumentationLoader.Add(new AspNetCoreMetricsInitializer());
-                }
-#endif
-
                 var builder = Sdk
                     .CreateMeterProviderBuilder()
                     .SetResourceBuilder(ResourceFactory.Create())

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Reflection;
 using System.Threading;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 
@@ -51,7 +52,7 @@ internal class HttpClientInitializer
 
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Http.Implementation.HttpWebRequestActivitySource, OpenTelemetry.Instrumentation.Http");
 
-        instrumentationType.GetProperty("Options")?.SetValue(null, options);
+        instrumentationType.GetField("Options", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, options);
 #else
         var options = new OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions();
         _pluginManager.ConfigureOptions(options);

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientMetricsInitializer.cs
@@ -1,0 +1,48 @@
+// <copyright file="HttpClientMetricsInitializer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Threading;
+
+namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
+
+internal class HttpClientMetricsInitializer
+{
+    private int _initialized;
+
+    public HttpClientMetricsInitializer(LazyInstrumentationLoader lazyInstrumentationLoader)
+    {
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net.Http", InitializeOnFirstCall));
+
+#if NETFRAMEWORK
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net", InitializeOnFirstCall));
+#endif
+    }
+
+    private void InitializeOnFirstCall(ILifespanManager lifespanManager)
+    {
+        if (Interlocked.Exchange(ref _initialized, value: 1) != default)
+        {
+            // InitializeOnFirstCall() was already called before
+            return;
+        }
+
+        var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Http.HttpClientMetrics, OpenTelemetry.Instrumentation.Http");
+        var instrumentation = Activator.CreateInstance(instrumentationType);
+
+        lifespanManager.Track(instrumentation);
+    }
+}

--- a/test/IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -27,7 +27,6 @@ namespace IntegrationTests.Helpers;
 
 public class EnvironmentHelper
 {
-    private static readonly Assembly ExecutingAssembly = Assembly.GetExecutingAssembly();
     private static readonly string RuntimeFrameworkDescription = RuntimeInformation.FrameworkDescription.ToLower();
     private static string _nukeOutputLocation;
 

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -63,6 +63,11 @@ public abstract class TestHelper
         EnvironmentHelper.CustomEnvironmentVariables[key] = value;
     }
 
+    public void RemoveEnvironmentVariable(string key)
+    {
+        EnvironmentHelper.CustomEnvironmentVariables.Remove(key);
+    }
+
     public void SetExporter(MockSpansCollector collector)
     {
         SetEnvironmentVariable("OTEL_TRACES_EXPORTER", "otlp");
@@ -84,6 +89,13 @@ public abstract class TestHelper
     public void EnableBytecodeInstrumentation()
     {
         SetEnvironmentVariable("CORECLR_ENABLE_PROFILING", "1");
+    }
+
+    public void EnableDefaultExporters()
+    {
+        RemoveEnvironmentVariable("OTEL_TRACES_EXPORTER");
+        RemoveEnvironmentVariable("OTEL_METRICS_EXPORTER");
+        RemoveEnvironmentVariable("OTEL_LOGS_EXPORTER");
     }
 
     /// <summary>

--- a/test/IntegrationTests/ModuleTests.DefaultNoExporters.NetCore.verified.txt
+++ b/test/IntegrationTests/ModuleTests.DefaultNoExporters.NetCore.verified.txt
@@ -1,0 +1,10 @@
+﻿[
+  OpenTelemetry,
+  OpenTelemetry.Api,
+  OpenTelemetry.AutoInstrumentation,
+  OpenTelemetry.AutoInstrumentation.Loader,
+  OpenTelemetry.AutoInstrumentation.StartupHook,
+  OpenTelemetry.Exporter.OpenTelemetryProtocol,
+  OpenTelemetry.Instrumentation.Process,
+  OpenTelemetry.Instrumentation.Runtime
+]

--- a/test/IntegrationTests/ModuleTests.DefaultNoExporters.NetFx.verified.txt
+++ b/test/IntegrationTests/ModuleTests.DefaultNoExporters.NetFx.verified.txt
@@ -1,0 +1,9 @@
+﻿[
+  OpenTelemetry,
+  OpenTelemetry.Api,
+  OpenTelemetry.AutoInstrumentation,
+  OpenTelemetry.AutoInstrumentation.Loader,
+  OpenTelemetry.Exporter.OpenTelemetryProtocol,
+  OpenTelemetry.Instrumentation.Process,
+  OpenTelemetry.Instrumentation.Runtime
+]

--- a/test/IntegrationTests/ModuleTests.cs
+++ b/test/IntegrationTests/ModuleTests.cs
@@ -37,11 +37,34 @@ public class ModuleTests : TestHelper
     [Fact]
     public async Task Default()
     {
+        EnableDefaultExporters();
+        EnableBytecodeInstrumentation();
+
         string verifyTestName =
 #if NETFRAMEWORK
         $"{nameof(ModuleTests)}.{nameof(Default)}.NetFx";
 #else
         $"{nameof(ModuleTests)}.{nameof(Default)}.NetCore";
+#endif
+
+        await RunTests(verifyTestName);
+    }
+
+    [Fact]
+    public async Task DefaultNoExporters()
+    {
+        // Exporters using RPC can cause dependency loads, which can cause next instrumentation loads.
+        // This test ensures correct instrumentation loading.
+
+        SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, Constants.ConfigurationValues.None);
+        SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, Constants.ConfigurationValues.None);
+        SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, Constants.ConfigurationValues.None);
+
+        string verifyTestName =
+#if NETFRAMEWORK
+        $"{nameof(ModuleTests)}.{nameof(DefaultNoExporters)}.NetFx";
+#else
+$"{nameof(ModuleTests)}.{nameof(DefaultNoExporters)}.NetCore";
 #endif
 
         await RunTests(verifyTestName);
@@ -54,6 +77,7 @@ public class ModuleTests : TestHelper
         SetEnvironmentVariable(ConfigurationKeys.Metrics.Instrumentations, Constants.ConfigurationValues.None);
         SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, Constants.ConfigurationValues.None);
         SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, Constants.ConfigurationValues.None);
+        SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, Constants.ConfigurationValues.None);
         SetEnvironmentVariable(ConfigurationKeys.Traces.ConsoleExporterEnabled, bool.FalseString);
         SetEnvironmentVariable(ConfigurationKeys.Metrics.ConsoleExporterEnabled, bool.FalseString);
         SetEnvironmentVariable(ConfigurationKeys.Traces.OpenTracingEnabled, bool.FalseString);

--- a/test/IntegrationTests/ModuleTests.cs
+++ b/test/IntegrationTests/ModuleTests.cs
@@ -64,7 +64,7 @@ public class ModuleTests : TestHelper
 #if NETFRAMEWORK
         $"{nameof(ModuleTests)}.{nameof(DefaultNoExporters)}.NetFx";
 #else
-$"{nameof(ModuleTests)}.{nameof(DefaultNoExporters)}.NetCore";
+        $"{nameof(ModuleTests)}.{nameof(DefaultNoExporters)}.NetCore";
 #endif
 
         await RunTests(verifyTestName);


### PR DESCRIPTION
## Why

Fixes #1437 

_I think this is the last possible optimization, since Runtime and Process instrumentations will be loaded anyway and can be controlled via enabled instrumentations._

## What

* Makes Http instrumentation loading lazy (metrics)
* Add no exporter tests 
    * Covers scenario when only console exporter is in use.
    * Futureproofs if there will be other exporters without http required.
    * Catches escaping optimizations where our exporters could obfuscate result.
* **Fixes Http instrumentation loading for tracing (bug)** 
* Fixes bug on .NET Core where exporter causes dependency load, but initializer is not yet setup.

## Tests

Existing + Fixes + DefaultNoExporter verification

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
