### PR TITLE
Use GITHUB_TOKEN to prevent 429 HTTP status code while checking GitHub links

### DIFF
--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -28,7 +28,8 @@ jobs:
     - uses: lycheeverse/lychee-action@v1.5.4
       with:
         fail: true
-        args: "--threads 1 --max-concurrency 1 --verbose --no-progress './**/*.md' './**/*.html'"
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - run: npm install
 


### PR DESCRIPTION
## Why

Fixes #1642

## What

Use github.token to precent 429 http code while checking github links
Inspired by https://github.com/lycheeverse/lychee-action/blob/b758e2b24878c5d7ef2a47529cad57b027d53f5b/.github/workflows/links.yml#L20-L21

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
