### PR TITLE
Bump nlohmann/json to 3.11.2 (non-windows)

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -102,7 +102,7 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
 if (NOT EXISTS ${OUTPUT_DEPS_DIR}/json)
     add_custom_command(
         OUTPUT ${OUTPUT_DEPS_DIR}/json
-        COMMAND git clone --quiet --depth 1 --branch v3.11.1 https://github.com/nlohmann/json.git
+        COMMAND git clone --quiet --depth 1 --branch v3.11.2 https://github.com/nlohmann/json.git
         WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
     )
 endif()


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Keep in sync with Windows version.

## What

Bump nlohmann/json to 3.11.2 (non-windows)
Windows package is already on this version.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
