### PR TITLE
CLR profiler requires .NET 6.0

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -72,12 +72,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     {
         if (runtime_information_.is_desktop())
         {
-            Logger::Debug(".NET Runtime: .NET Framework ", runtime_information_.major_version, ".", runtime_information_.minor_version);
+            // on .NET Framework it is the CLR version therfore major_version == 4 and minor_version == 0
+            Logger::Debug(".NET Runtime: .NET Framework");
         }
-        else if (runtime_information_.major_version < 4)
+        else if (runtime_information_.major_version < 5)
         {
-            Logger::Debug(".NET Runtime: .NET Core ", runtime_information_.major_version, ".", runtime_information_.minor_version);
-        } else {
+            // on .NET Core the major_version == 4 and minor_version == 0 (sic!) 
+            Logger::Debug(".NET Runtime: .NET Core");
+        }
+        else {
             Logger::Debug(".NET Runtime: .NET ", runtime_information_.major_version, ".", runtime_information_.minor_version);
         }
     }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -47,23 +47,46 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
     CorProfilerBase::Initialize(cor_profiler_info_unknown);
 
-#if defined(ARM64) || defined(ARM)
-    //
-    // In ARM64 and ARM, complete ReJIT support is only available from .NET 5.0
-    //
-    ICorProfilerInfo12* info12;
-    HRESULT hrInfo12 = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo12), (void**) &info12);
-    if (SUCCEEDED(hrInfo12))
+    if (IsDebugEnabled())
     {
-        Logger::Info(".NET 5.0 runtime or greater was detected.");
+        const auto env_variables = GetEnvironmentVariables(env_vars_prefixes_to_display);
+        Logger::Debug("Environment variables:");
+
+        for (const auto& env_variable : env_variables)
+        {
+            Logger::Debug("  ", env_variable);
+        }
     }
-    else
+
+    // get ICorProfilerInfo7 interface for .NET Framework >= 4.6.1 and any .NET (Core) 
+    HRESULT hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo7), (void**) &this->info_);
+    if (FAILED(hr))
     {
-        Logger::Warn("Profiler disabled: .NET 5.0 runtime or greater is required on this "
-                     "architecture.");
+        Logger::Warn("Failed to attach profiler: Not supported .NET Framework version (lower than 4.6.1).");
         return E_FAIL;
     }
-#endif
+
+    // code is ready to get runtime information
+    runtime_information_ = GetRuntimeInformation(this->info_);
+    if (IsDebugEnabled())
+    {
+        if (runtime_information_.is_desktop())
+        {
+            Logger::Debug(".NET Runtime: .NET Framework ", runtime_information_.major_version, ".", runtime_information_.minor_version);
+        }
+        else if (runtime_information_.major_version < 4)
+        {
+            Logger::Debug(".NET Runtime: .NET Core ", runtime_information_.major_version, ".", runtime_information_.minor_version);
+        } else {
+            Logger::Debug(".NET Runtime: .NET ", runtime_information_.major_version, ".", runtime_information_.minor_version);
+        }
+    }
+
+    if (runtime_information_.is_core() && runtime_information_.major_version < 6)
+    {
+        Logger::Warn("Failed to attach profiler: Not supported .NET version (lower than 6.0).");
+        return E_FAIL;
+    }
 
     const auto process_name = GetCurrentProcessName();
     const auto exclude_process_names = GetEnvironmentValues(environment::exclude_process_names);
@@ -76,48 +99,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         return E_FAIL;
     }
 
-    // get ICorProfilerInfo7 interface for .NET Framework >= 4.6.1 and any .NET (Core) 
-    HRESULT hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo7), (void**) &this->info_);
-    if (FAILED(hr))
+    if (runtime_information_.is_core())
     {
-        Logger::Warn("Failed to attach profiler: interface ICorProfilerInfo7 not found.");
-        return E_FAIL;
-    }
-
-    // code is ready to get runtime information
-    runtime_information_ = GetRuntimeInformation(this->info_);
-    if (process_name == WStr("w3wp.exe") || process_name == WStr("iisexpress.exe"))
-    {
-        is_desktop_iis = runtime_information_.is_desktop();
-    }
-
-    // get ICorProfilerInfo10 for >= .NET Core 3.0
-    ICorProfilerInfo10* info10 = nullptr;
-    hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo10), (void**) &info10);
-
-    if (SUCCEEDED(hr))
-    {
-        Logger::Debug("Interface ICorProfilerInfo10 found.");
         // .NET Core applications should use the dotnet startup hook to bootstrap OpenTelemetry so that the
         // necessary dependencies will be available. Bootstrapping with the profiling APIs occurs too early
         // and the necessary dependencies are not available yet.
-        use_dotnet_startuphook_bootstrapper = true;
-    }
-    info10 = nullptr;
 
-    if (IsDebugEnabled())
-    {
-        const auto env_variables = GetEnvironmentVariables(env_vars_prefixes_to_display);
-        Logger::Info("Environment variables:");
-
-        for (const auto& env_variable : env_variables)
-        {
-            Logger::Info("  ", env_variable);
-        }
-    }
-
-    if (use_dotnet_startuphook_bootstrapper)
-    {
         // Ensure that OTel StartupHook is listed.
         const auto home_path = GetEnvironmentValue(environment::profiler_home_path);
         const auto startup_hooks = GetEnvironmentValues(environment::dotnet_startup_hooks, ENV_VAR_PATH_SEPARATOR);
@@ -127,6 +114,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
             return E_FAIL;
         }
     }
+
+    is_desktop_iis = runtime_information_.is_desktop() && (process_name == WStr("w3wp.exe") || process_name == WStr("iisexpress.exe"));
 
     if (IsAzureAppServices())
     {
@@ -690,7 +679,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 {
     auto _ = trace::Stats::Instance()->JITCompilationStartedMeasure();
 
-    if (!is_attached_ || !is_safe_to_block || use_dotnet_startuphook_bootstrapper)
+    if (!is_attached_ || !is_safe_to_block || runtime_information_.is_core())
     {
         return S_OK;
     }
@@ -887,7 +876,7 @@ WSTRING CorProfiler::GetBytecodeInstrumentationAssembly() const
     {
         Logger::Error("GetBytecodeInstrumentationAssembly: called before runtime_information was initialized.");
     }
-    else if (!runtime_information_.is_core())
+    else if (runtime_information_.is_desktop())
     {
         // When on .NET Framework use the signature with the public key so strong name works.
         bytecodeInstrumentationAssembly = managed_profiler_full_assembly_version_strong_name;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -59,7 +59,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     }
     else
     {
-        Logger::Warn("OpenTelemetry .NET Automatic Instrumentation Diagnostics - Profiler disabled: .NET 5.0 runtime or greater is required on this "
+        Logger::Warn("Profiler disabled: .NET 5.0 runtime or greater is required on this "
                      "architecture.");
         return E_FAIL;
     }
@@ -71,7 +71,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // attach profiler only if this process's name is NOT on the list
     if (!exclude_process_names.empty() && Contains(exclude_process_names, process_name))
     {
-        Logger::Info("OpenTelemetry .NET Automatic Instrumentation Diagnostics - Profiler disabled: ", process_name, " found in ",
+        Logger::Info("Profiler disabled: ", process_name, " found in ",
                      environment::exclude_process_names, ".");
         return E_FAIL;
     }
@@ -80,7 +80,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     HRESULT hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo7), (void**) &this->info_);
     if (FAILED(hr))
     {
-        Logger::Warn("OpenTelemetry .NET Automatic Instrumentation Diagnostics - Failed to attach profiler: interface ICorProfilerInfo7 not found.");
+        Logger::Warn("Failed to attach profiler: interface ICorProfilerInfo7 not found.");
         return E_FAIL;
     }
 
@@ -137,7 +137,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
         if (app_pool_id_value.size() > 1 && app_pool_id_value.at(0) == '~')
         {
-            Logger::Info("OpenTelemetry .NET Automatic Instrumentation Diagnostics - Profiler disabled: ", environment::azure_app_services_app_pool_id, " ",
+            Logger::Info("Profiler disabled: ", environment::azure_app_services_app_pool_id, " ",
                          app_pool_id_value, " is recognized as an Azure App Services infrastructure process.");
             return E_FAIL;
         }
@@ -147,7 +147,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
         if (cli_telemetry_profile_value == WStr("AzureKudu"))
         {
-            Logger::Info("OpenTelemetry .NET Automatic Instrumentation Diagnostics - Profiler disabled: ", app_pool_id_value,
+            Logger::Info("Profiler disabled: ", app_pool_id_value,
                          " is recognized as Kudu, an Azure App Services reserved process.");
             return E_FAIL;
         }
@@ -211,7 +211,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     hr = this->info_->SetEventMask2(event_mask, COR_PRF_HIGH_ADD_ASSEMBLY_REFERENCES);
     if (FAILED(hr))
     {
-        Logger::Warn("OpenTelemetry .NET Automatic Instrumentation Diagnostics - Failed to attach profiler: unable to set event mask.");
+        Logger::Warn("Failed to attach profiler: unable to set event mask.");
         return E_FAIL;
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -29,7 +29,6 @@ private:
 
     // Startup helper variables
     bool first_jit_compilation_completed = false;
-    bool use_dotnet_startuphook_bootstrapper = false;
 
     bool corlib_module_loaded = false;
     AppDomainID corlib_app_domain_id = 0;


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1659

Towards https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1644

Address https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1658#pullrequestreview-1192175186

## What

1. Do not attach the CLR Profiler for unsupported .NET runtime versions.
1. Refine logging in native.
1. Refactor native code.

## Tests

CI 

manual together with changes from https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/1658

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~
- [x] ~~Documentation is updated.~~
- [x] ~~New features are covered by tests.~~
