### PR TITLE
Add eval at the end of the instrument script

### DIFF
--- a/instrument.sh
+++ b/instrument.sh
@@ -142,3 +142,5 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
   # Configure the bytecode instrumentation configuration file
   export OTEL_DOTNET_AUTO_INTEGRATIONS_FILE="$OTEL_DOTNET_AUTO_HOME/integrations.json"
 fi
+
+eval "$@"


### PR DESCRIPTION
## Why

Instrument script only sets env variables, but does not execute instrumented app.

## What

Add eval at the end of the script

