### PR TITLE
Separate extension points for signal options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ This release is built on top of [OpenTelemetry .NET](https://github.com/open-tel
 
 - Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
   [`1.4.0-beta.3`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-beta.3)
+- Updated plugins method signature to overwrite OpenTelemetry .NET SDK exporters'
+ and instrumentations' options. `ConfigureOptions` changed to `ConfigureTracesOptions`,
+ `ConfigureMetricsOptions` or `ConfigureLogsOptions`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ This release is built on top of [OpenTelemetry .NET](https://github.com/open-tel
 - Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
   [`1.4.0-beta.3`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-beta.3)
 - Updated plugins method signature to overwrite OpenTelemetry .NET SDK exporters'
- and instrumentations' options. `ConfigureOptions` changed to `ConfigureTracesOptions`,
- `ConfigureMetricsOptions` or `ConfigureLogsOptions`.
+  and instrumentations' options. `ConfigureOptions` changed to `ConfigureTracesOptions`,
+  `ConfigureMetricsOptions` or `ConfigureLogsOptions`.
 
 ### Removed
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -17,6 +17,13 @@ public class MyPlugin
 
         return builder;
     }
+        
+    // To configure any traces options used by OpenTelemetry .NET Automatic Instrumentation
+    public void ConfigureTracesOptions(OpenTelemetry.NameSpace.OptionType options)
+    {
+        // My custom logic here
+        // Find supported options below
+    }
 
     // To configure metrics SDK
     public OpenTelemetry.Metrics.MeterProviderBuilder ConfigureMeterProvider(OpenTelemetry.Metrics.MeterProviderBuilder builder)
@@ -25,15 +32,22 @@ public class MyPlugin
 
         return builder;
     }
+    
+    // To configure any metrics options used by OpenTelemetry .NET Automatic Instrumentation
+    public void ConfigureMetricsOptions(OpenTelemetry.NameSpace.OptionType options)
+    {
+        // My custom logic here
+        // Find supported options below
+    }
 
-    // To configure logs SDK
-    public void ConfigureOptions(OpenTelemetry.Logs.OpenTelemetryLoggerOptions options)
+    // To configure logs SDK (the method names is the same as for other logs options)
+    public void ConfigureLogsOptions(OpenTelemetry.Logs.OpenTelemetryLoggerOptions options)
     {
         // My custom logic here
     }
 
-    // To configure any options used by OpenTelemetry .NET Automatic Instrumentation
-    public void ConfigureOptions(OpenTelemetry.NameSpace.OptionType options)
+    // To configure any logs options used by OpenTelemetry .NET Automatic Instrumentation
+    public void ConfigureLogsOptions(OpenTelemetry.NameSpace.OptionType options)
     {
         // My custom logic here
         // Find supported options below
@@ -64,9 +78,8 @@ public class MyPlugin
 | Options type                                                        | NuGet package                                  | NuGet version |
 |---------------------------------------------------------------------|------------------------------------------------|---------------|
 | OpenTelemetry.Metrics.MetricReaderOptions                           | OpenTelemetry                                  | 1.4.0-beta.3  |
-| OpenTelemetry.Exporter.ConsoleExporterOptions                       | OpenTelemetry.Exporter.Console                 | 1.3.1         |
+| OpenTelemetry.Exporter.ConsoleExporterOptions                       | OpenTelemetry.Exporter.Console                 | 1.4.0-beta.3  |
 | OpenTelemetry.Exporter.PrometheusExporterOptions                    | OpenTelemetry.Exporter.Prometheus.HttpListener | 1.4.0-beta.3  |
-| OpenTelemetry.Exporter.OtlpExporterOptions                          | OpenTelemetry.Exporter.OpenTelemetryProtocol   | 1.4.0-beta.3  |
 | OpenTelemetry.Exporter.OtlpExporterOptions                          | OpenTelemetry.Exporter.OpenTelemetryProtocol   | 1.4.0-beta.3  |
 | OpenTelemetry.Instrumentation.Runtime.RuntimeInstrumentationOptions | OpenTelemetry.Instrumentation.Runtime          | 1.1.0-beta.1  |
 | OpenTelemetry.Instrumentation.Process.ProcessInstrumentationOptions | OpenTelemetry.Instrumentation.Process          | 1.0.0-alpha.2 |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,7 +40,7 @@ public class MyPlugin
         // Find supported options below
     }
 
-    // To configure logs SDK (the method names is the same as for other logs options)
+    // To configure logs SDK (the method name is the same as for other logs options)
     public void ConfigureLogsOptions(OpenTelemetry.Logs.OpenTelemetryLoggerOptions options)
     {
         // My custom logic here

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationMetricHelper.cs
@@ -107,13 +107,13 @@ internal static class EnvironmentConfigurationMetricHelper
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static MeterProviderBuilder AddRuntimeInstrumentation(MeterProviderBuilder builder, PluginManager pluginManager)
         {
-            return builder.AddRuntimeInstrumentation(pluginManager.ConfigureOptions);
+            return builder.AddRuntimeInstrumentation(pluginManager.ConfigureMetricsOptions);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static MeterProviderBuilder AddProcessInstrumentation(MeterProviderBuilder builder, PluginManager pluginManager)
         {
-            return builder.AddProcessInstrumentation(pluginManager.ConfigureOptions);
+            return builder.AddProcessInstrumentation(pluginManager.ConfigureMetricsOptions);
         }
 
         // Exporters
@@ -123,8 +123,8 @@ internal static class EnvironmentConfigurationMetricHelper
         {
             return builder.AddConsoleExporter((consoleExporterOptions, metricReaderOptions) =>
             {
-                pluginManager.ConfigureOptions(consoleExporterOptions);
-                pluginManager.ConfigureOptions(metricReaderOptions);
+                pluginManager.ConfigureMetricsOptions(consoleExporterOptions);
+                pluginManager.ConfigureMetricsOptions(metricReaderOptions);
             });
         }
 
@@ -133,10 +133,7 @@ internal static class EnvironmentConfigurationMetricHelper
         {
             Logger.Warning("Prometheus exporter is configured. It is intended for the inner dev loop. Do NOT use in production");
 
-            return builder.AddPrometheusHttpListener(options =>
-            {
-                pluginManager.ConfigureOptions(options);
-            });
+            return builder.AddPrometheusHttpListener(pluginManager.ConfigureMetricsOptions);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -149,8 +146,8 @@ internal static class EnvironmentConfigurationMetricHelper
                     options.Protocol = settings.OtlpExportProtocol.Value;
                 }
 
-                pluginManager.ConfigureOptions(options);
-                pluginManager.ConfigureOptions(metricReaderOptions);
+                pluginManager.ConfigureMetricsOptions(options);
+                pluginManager.ConfigureMetricsOptions(metricReaderOptions);
             });
         }
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -187,8 +187,9 @@ internal static class EnvironmentConfigurationTracerHelper
                 if (settings.OtlpExportProtocol.HasValue)
                 {
                     options.Protocol = settings.OtlpExportProtocol.Value;
-                    pluginManager.ConfigureTracesOptions(options);
                 }
+
+                pluginManager.ConfigureTracesOptions(options);
             });
         }
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -164,19 +164,19 @@ internal static class EnvironmentConfigurationTracerHelper
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static TracerProviderBuilder AddConsoleExporter(TracerProviderBuilder builder, PluginManager pluginManager)
         {
-            return builder.AddConsoleExporter(pluginManager.ConfigureOptions);
+            return builder.AddConsoleExporter(pluginManager.ConfigureTracesOptions);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static TracerProviderBuilder AddZipkinExporter(TracerProviderBuilder builder, PluginManager pluginManager)
         {
-            return builder.AddZipkinExporter(pluginManager.ConfigureOptions);
+            return builder.AddZipkinExporter(pluginManager.ConfigureTracesOptions);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static TracerProviderBuilder AddJaegerExporter(TracerProviderBuilder builder, PluginManager pluginManager)
         {
-            return builder.AddJaegerExporter(pluginManager.ConfigureOptions);
+            return builder.AddJaegerExporter(pluginManager.ConfigureTracesOptions);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -187,7 +187,7 @@ internal static class EnvironmentConfigurationTracerHelper
                 if (settings.OtlpExportProtocol.HasValue)
                 {
                     options.Protocol = settings.OtlpExportProtocol.Value;
-                    pluginManager.ConfigureOptions(options);
+                    pluginManager.ConfigureTracesOptions(options);
                 }
             });
         }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreInitializer.cs
@@ -36,7 +36,7 @@ internal class AspNetCoreInitializer : InstrumentationInitializer
         var httpInListenerType = Type.GetType("OpenTelemetry.Instrumentation.AspNetCore.Implementation.HttpInListener, OpenTelemetry.Instrumentation.AspNetCore");
 
         var options = new OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions();
-        _pluginManager.ConfigureOptions(options);
+        _pluginManager.ConfigureTracesOptions(options);
 
         var httpInListener = Activator.CreateInstance(httpInListenerType, args: options);
         var instrumentation = Activator.CreateInstance(instrumentationType, args: httpInListener);

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetInitializer.cs
@@ -46,7 +46,7 @@ internal class AspNetInitializer
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentation, OpenTelemetry.Instrumentation.AspNet");
 
         var options = new OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions();
-        _pluginManager.ConfigureOptions(options);
+        _pluginManager.ConfigureTracesOptions(options);
 
         var instrumentation = Activator.CreateInstance(instrumentationType, args: options);
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/GrpcClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/GrpcClientInitializer.cs
@@ -37,7 +37,7 @@ internal class GrpcClientInitializer : InstrumentationInitializer
         var options = new OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientInstrumentationOptions();
         options.SuppressDownstreamInstrumentation = !Instrumentation.TracerSettings.EnabledInstrumentations.Contains(TracerInstrumentation.HttpClient);
 
-        _pluginManager.ConfigureOptions(options);
+        _pluginManager.ConfigureTracesOptions(options);
 
         var instrumentation = Activator.CreateInstance(instrumentationType, options);
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
@@ -47,7 +47,7 @@ internal class HttpClientInitializer
         }
 
         var options = new OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions();
-        _pluginManager.ConfigureOptions(options);
+        _pluginManager.ConfigureTracesOptions(options);
 
 #if NETFRAMEWORK
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Http.Implementation.HttpWebRequestActivitySource, OpenTelemetry.Instrumentation.Http");

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/MySqlDataInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/MySqlDataInitializer.cs
@@ -36,7 +36,7 @@ internal class MySqlDataInitializer : InstrumentationInitializer
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.MySqlData.MySqlDataInstrumentation, OpenTelemetry.Instrumentation.MySqlData");
 
         var options = new OpenTelemetry.Instrumentation.MySqlData.MySqlDataInstrumentationOptions();
-        _pluginManager.ConfigureOptions(options);
+        _pluginManager.ConfigureTracesOptions(options);
 
         var instrumentation = Activator.CreateInstance(instrumentationType, options);
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientInitializer.cs
@@ -47,7 +47,7 @@ internal class SqlClientInitializer
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentation, OpenTelemetry.Instrumentation.SqlClient");
 
         var options = new OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions();
-        _pluginManager.ConfigureOptions(options);
+        _pluginManager.ConfigureTracesOptions(options);
 
         var instrumentation = Activator.CreateInstance(instrumentationType, options);
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
@@ -34,7 +34,7 @@ internal class WcfInitializer : InstrumentationInitializer
     {
         var options = new WcfInstrumentationOptions();
 
-        _pluginManager.ConfigureOptions(options);
+        _pluginManager.ConfigureTracesOptions(options);
 
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationActivitySource, OpenTelemetry.Instrumentation.Wcf");
 

--- a/src/OpenTelemetry.AutoInstrumentation/Logger/LogBuilderExtensions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Logger/LogBuilderExtensions.cs
@@ -52,11 +52,11 @@ internal static class LogBuilderExtensions
 
                 options.IncludeFormattedMessage = settings.IncludeFormattedMessage;
 
-                pluginManager.ConfigureOptions(options);
+                pluginManager.ConfigureLogsOptions(options);
 
                 if (settings.ConsoleExporterEnabled)
                 {
-                    options.AddConsoleExporter(pluginManager.ConfigureOptions);
+                    options.AddConsoleExporter(pluginManager.ConfigureLogsOptions);
                 }
 
                 switch (settings.LogExporter)
@@ -69,7 +69,7 @@ internal static class LogBuilderExtensions
                                 otlpOptions.Protocol = settings.OtlpExportProtocol.Value;
                             }
 
-                            pluginManager.ConfigureOptions(otlpOptions);
+                            pluginManager.ConfigureLogsOptions(otlpOptions);
                         });
                         break;
                     case LogExporter.None:

--- a/src/OpenTelemetry.AutoInstrumentation/Plugins/PluginManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Plugins/PluginManager.cs
@@ -51,11 +51,26 @@ internal class PluginManager
         return ConfigureBuilder(builder, "ConfigureMeterProvider");
     }
 
-    public void ConfigureOptions<T>(T options)
+    public void ConfigureMetricsOptions<T>(T options)
+    {
+        ConfigureOptions(options, "ConfigureMetricsOptions");
+    }
+
+    public void ConfigureTracesOptions<T>(T options)
+    {
+        ConfigureOptions(options, "ConfigureTracesOptions");
+    }
+
+    public void ConfigureLogsOptions<T>(T options)
+    {
+        ConfigureOptions(options, "ConfigureLogsOptions");
+    }
+
+    private void ConfigureOptions<T>(T options, string methodName)
     {
         foreach (var plugin in _plugins)
         {
-            var mi = plugin.Type.GetMethod("ConfigureOptions", new Type[] { typeof(T) });
+            var mi = plugin.Type.GetMethod(methodName, new[] { typeof(T) });
             if (mi is not null)
             {
                 mi.Invoke(plugin.Instance, new object[] { options });
@@ -67,7 +82,7 @@ internal class PluginManager
     {
         foreach (var plugin in _plugins)
         {
-            var mi = plugin.Type.GetMethod(methodName, new Type[] { typeof(T) });
+            var mi = plugin.Type.GetMethod(methodName, new[] { typeof(T) });
             if (mi is not null)
             {
                 builder = (T)mi.Invoke(plugin.Instance, new object[] { builder });

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -102,7 +102,7 @@ public abstract class TestHelper
     /// RunTestApplication starts the test application, wait up to DefaultProcessTimeout.
     /// Assertion exceptions are thrown if it timed out or the exit code is non-zero.
     /// </summary>
-    public void RunTestApplication(TestSettings testSettings = null)
+    public (string StandardOutput, string ErrorOutput) RunTestApplication(TestSettings testSettings = null)
     {
         testSettings ??= new();
         using var process = StartTestApplication(testSettings);
@@ -121,6 +121,8 @@ public abstract class TestHelper
 
         processTimeout.Should().BeFalse("Test application timed out");
         process.ExitCode.Should().Be(0, "Test application exited with non-zero exit code");
+
+        return (helper.StandardOutput, helper.ErrorOutput);
     }
 
     /// <summary>

--- a/test/IntegrationTests/PluginsTests.cs
+++ b/test/IntegrationTests/PluginsTests.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System.Linq;
+using FluentAssertions;
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -44,9 +45,10 @@ public class PluginsTests : TestHelper
 #endif
 
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_PLUGINS", "TestApplication.Plugins.Plugin, TestApplication.Plugins, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
-        RunTestApplication();
+        var (standardOutput, _) = RunTestApplication();
 
         collector.AssertExpectations();
+        standardOutput.Should().Contain("Plugin.ConfigureTracesOptions(OtlpExporterOptions options) invoked.");
     }
 
     [Fact]
@@ -58,8 +60,10 @@ public class PluginsTests : TestHelper
         collector.Expect("MyCompany.MyProduct.MyLibrary");
 
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_PLUGINS", "TestApplication.Plugins.Plugin, TestApplication.Plugins, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
-        RunTestApplication();
+
+        var (standardOutput, _) = RunTestApplication();
 
         collector.AssertExpectations();
+        standardOutput.Should().Contain("Plugin.ConfigureMetricsOptions(OtlpExporterOptions options) invoked.");
     }
 }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/PluginManagerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/PluginManagerTests.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using OpenTelemetry.AutoInstrumentation.Configuration;
 using OpenTelemetry.AutoInstrumentation.Plugins;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -115,7 +116,7 @@ public class PluginManagerTests
     }
 
     [Fact]
-    public void ConfigureOptionsSuccess()
+    public void ConfigureLogsOptionsSuccess()
     {
         var pluginAssemblyQualifiedName = typeof(MockPlugin).AssemblyQualifiedName;
         var settings = GetSettings(pluginAssemblyQualifiedName);
@@ -126,7 +127,7 @@ public class PluginManagerTests
             builder.AddOpenTelemetry(options =>
             {
                 options.IncludeFormattedMessage = false;
-                pluginManager.ConfigureOptions(options);
+                pluginManager.ConfigureLogsOptions(options);
 
                 // Verify that plugin changes the state
                 options.IncludeFormattedMessage.Should().BeTrue();
@@ -165,12 +166,10 @@ public class PluginManagerTests
             return builder;
         }
 
-        public OpenTelemetryLoggerOptions ConfigureOptions(OpenTelemetryLoggerOptions options)
+        public void ConfigureLoggingOptions(OpenTelemetryLoggerOptions options)
         {
             // Dummy overwritten setting
             options.IncludeFormattedMessage = true;
-
-            return options;
         }
     }
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/PluginManagerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/PluginManagerTests.cs
@@ -166,7 +166,7 @@ public class PluginManagerTests
             return builder;
         }
 
-        public void ConfigureLoggingOptions(OpenTelemetryLoggerOptions options)
+        public void ConfigureLogsOptions(OpenTelemetryLoggerOptions options)
         {
             // Dummy overwritten setting
             options.IncludeFormattedMessage = true;

--- a/test/test-applications/integrations/TestApplication.Plugins/Plugin.cs
+++ b/test/test-applications/integrations/TestApplication.Plugins/Plugin.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -32,7 +34,7 @@ public class Plugin
         return builder.AddMeter(TestApplication.Smoke.Program.SourceName);
     }
 
-    public void ConfigureOptions(HttpClientInstrumentationOptions options)
+    public void ConfigureTracesOptions(HttpClientInstrumentationOptions options)
     {
 #if NETFRAMEWORK
         options.EnrichWithHttpWebRequest = (activity, message) =>
@@ -42,5 +44,15 @@ public class Plugin
         {
             activity.SetTag("example.plugin", "MyExamplePlugin");
         };
+    }
+
+    public void ConfigureTracesOptions(OtlpExporterOptions options)
+    {
+        Console.WriteLine($"{nameof(Plugin)}.{nameof(ConfigureTracesOptions)}({nameof(OtlpExporterOptions)} {nameof(options)}) invoked.");
+    }
+
+    public void ConfigureMetricsOptions(OtlpExporterOptions options)
+    {
+        Console.WriteLine($"{nameof(Plugin)}.{nameof(ConfigureMetricsOptions)}({nameof(OtlpExporterOptions)} {nameof(options)}) invoked.");
     }
 }

--- a/test/test-applications/integrations/TestApplication.Plugins/TestApplication.Plugins.csproj
+++ b/test/test-applications/integrations/TestApplication.Plugins/TestApplication.Plugins.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.4.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Why

There were no possibility to distinguish which option is configured on the plugin side.
ConfigureOptions for OtlpExporter protocol have had same signature.

## What

Separate extension points for Traces, Metrics, and Logs.

## Tests

CI + newly created.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
