### PR TITLE
Release 0.5.1-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,23 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.5.0...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.5.1-beta.1...HEAD)
 
-This release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.5.1-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.5.1-beta.1)
+
+This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
   [`1.4.0-beta.3`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-beta.3)
@@ -31,10 +45,6 @@ This release is built on top of [OpenTelemetry .NET](https://github.com/open-tel
 - Updated plugins method signature to overwrite OpenTelemetry .NET SDK exporters'
   and instrumentations' options. `ConfigureOptions` changed to `ConfigureTracesOptions`,
   `ConfigureMetricsOptions` or `ConfigureLogsOptions`.
-
-### Removed
-
-### Fixed
 
 ## [0.5.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.5.0)
 

--- a/OpenTelemetry.DotNet.Auto.psm1
+++ b/OpenTelemetry.DotNet.Auto.psm1
@@ -197,7 +197,7 @@ function Install-OpenTelemetryCore() {
         [string]$InstallDir = "<auto>"
     )
 
-    $version = "v0.5.0"
+    $version = "v0.5.1-beta.1"
     $installDir = Get-CLIInstallDir-From-InstallDir $InstallDir
     $tempDir = Get-Temp-Directory
     $dlPath = $null

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ to .NET applications without having to modify their source code.
 
 ⚠️ The following documentation refers to the in-development version
 of OpenTelemetry .NET Automatic Instrumentation. Docs for the latest version
-([0.5.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
-can be found [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.5.0/docs/README.md).
+([0.5.1-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
+can be found [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.5.1-beta.1/docs/README.md).
 
 ---
 
@@ -117,7 +117,7 @@ and instrument your .NET application using the provided Shell scripts.
 Example usage:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.0/otel-dotnet-auto-install.sh -O
+curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.1/otel-dotnet-auto-install.sh -O
 sh ./otel-dotnet-auto-install.sh
 . $HOME/.otel-dotnet-auto/instrument.sh
 OTEL_SERVICE_NAME=myapp OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging,service.version=1.0.0 dotnet run
@@ -131,7 +131,7 @@ uses environment variables as parameters:
 | `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
 | `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
 | `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `v0.5.0`           |
+| `VERSION`               | Version to download                                              | No       | `v0.5.1-beta.1`           |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -152,7 +152,7 @@ Example usage:
 
 ```powershell
 # Download and import the module
-$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.0/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.1/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path
 Import-Module $download_path

--- a/nuget/OpenTelemetry.AutoInstrumentation.nuspec
+++ b/nuget/OpenTelemetry.AutoInstrumentation.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OpenTelemetry.AutoInstrumentation</id>
-    <version>0.5.0</version>
+    <version>0.5.1-beta.1</version>
     <description>OpenTelemetry Auto-Instrumentation</description>
     <authors>OpenTelemetry Authors</authors>
     <owners>OpenTelemetry Authors</owners>

--- a/otel-dotnet-auto-install.sh
+++ b/otel-dotnet-auto-install.sh
@@ -31,7 +31,7 @@ esac
 
 test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-test -z "$VERSION" && VERSION="v0.5.0"
+test -z "$VERSION" && VERSION="v0.5.1-beta.1"
 
 RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
 ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
@@ -6,7 +6,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 # Project definition
 # ******************************************************
 
-project("OpenTelemetry.AutoInstrumentation.Native" VERSION 0.5.0)
+project("OpenTelemetry.AutoInstrumentation.Native" VERSION 0.5.1)
 
 # ******************************************************
 # Environment detection

--- a/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
@@ -67,12 +67,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "The OpenTelemetry Authors"
             VALUE "FileDescription", "OpenTelemetry CLR Profiler"
-            VALUE "FileVersion", "0.5.0.0"
+            VALUE "FileVersion", "0.5.1.0"
             VALUE "InternalName", "OpenTelemetry.AutoInstrumentation.Native.DLL"
             VALUE "LegalCopyright", "Copyright 2021 The OpenTelemetry Authors"
             VALUE "OriginalFilename", "OpenTelemetry.AutoInstrumentation.Native.DLL"
             VALUE "ProductName", "OpenTelemetry .NET AutoInstrumentation"
-            VALUE "ProductVersion", "0.5.0"
+            VALUE "ProductVersion", "0.5.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
@@ -64,10 +64,10 @@ const WSTRING opentelemetry_autoinstrumentation_loader_assemblyName = WStr("Open
 const WSTRING managed_profiler_name = WStr("OpenTelemetry.AutoInstrumentation");
 
 const WSTRING managed_profiler_full_assembly_version =
-    WStr("OpenTelemetry.AutoInstrumentation, Version=0.5.0.0, Culture=neutral, PublicKeyToken=null");
+    WStr("OpenTelemetry.AutoInstrumentation, Version=0.5.1.0, Culture=neutral, PublicKeyToken=null");
 
 const WSTRING managed_profiler_full_assembly_version_strong_name =
-    WStr("OpenTelemetry.AutoInstrumentation, Version=0.5.0.0, Culture=neutral, PublicKeyToken=c0db600a13f60b51");
+    WStr("OpenTelemetry.AutoInstrumentation, Version=0.5.1.0, Culture=neutral, PublicKeyToken=c0db600a13f60b51");
 
 const WSTRING nonwindows_nativemethods_type = WStr("OpenTelemetry.AutoInstrumentation.NativeMethods+NonWindows");
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/version.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.5.0";
+constexpr auto PROFILER_VERSION = "0.5.1-beta.1";

--- a/src/OpenTelemetry.AutoInstrumentation/Constants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Constants.cs
@@ -20,7 +20,7 @@ internal static class Constants
 {
     public static class Tracer
     {
-        public const string Version = "0.5.0";
+        public const string Version = "0.5.1-beta.1";
         public const string AutoInstrumentationVersionName = "telemetry.auto.version";
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonExcludedAssets.props" />
 
   <PropertyGroup>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if !NETFRAMEWORK
-using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using IntegrationTests.Helpers;

--- a/test/IntegrationTests/LogTests.cs
+++ b/test/IntegrationTests/LogTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if !NETFRAMEWORK
-
 using System;
 using IntegrationTests.Helpers;
 using Xunit;

--- a/test/IntegrationTests/MassTransitTests.cs
+++ b/test/IntegrationTests/MassTransitTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if !NETFRAMEWORK
-using System.Threading.Tasks;
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/IntegrationTests/MongoDBTests.cs
+++ b/test/IntegrationTests/MongoDBTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if !NETFRAMEWORK
-using System.Threading.Tasks;
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/IntegrationTests/MySqlDataTests.cs
+++ b/test/IntegrationTests/MySqlDataTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if NET6_0_OR_GREATER
-using System.Threading.Tasks;
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/IntegrationTests/SqlClientSystemDataTests.cs
+++ b/test/IntegrationTests/SqlClientSystemDataTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if NETFRAMEWORK
-
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -55,5 +54,4 @@ public sealed class IgnoreRunningOnNet481Fact : FactAttribute
         }
     }
 }
-
 #endif

--- a/test/IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/IntegrationTests/StackExchangeRedisTests.cs
@@ -15,8 +15,6 @@
 // </copyright>
 
 #if NET6_0_OR_GREATER
-
-using System.Threading.Tasks;
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/IntegrationTests/WcfCoreTests.cs
+++ b/test/IntegrationTests/WcfCoreTests.cs
@@ -16,7 +16,6 @@
 
 // This test won't work outside of windows as it need the server side which is .NET Framework only.
 #if NET6_0_OR_GREATER && _WINDOWS
-
 using Xunit.Abstractions;
 
 namespace IntegrationTests;

--- a/test/IntegrationTests/WcfNetFrameworkTests.cs
+++ b/test/IntegrationTests/WcfNetFrameworkTests.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 #if NET462
-
 using Xunit.Abstractions;
 
 namespace IntegrationTests;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/ConstantsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/ConstantsTests.cs
@@ -24,6 +24,6 @@ public class ConstantsTests
     [Fact]
     public void VersionTag()
     {
-        Constants.Tracer.Version.Should().Be(typeof(Constants).Assembly.GetName().Version?.ToString(fieldCount: 3));
+        Constants.Tracer.Version.Should().Contain(typeof(Constants).Assembly.GetName().Version?.ToString(fieldCount: 3));
     }
 }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if NET6_0_OR_GREATER
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -77,4 +76,3 @@ public class LazyInstrumentationLoaderTests
         }
     }
 }
-#endif


### PR DESCRIPTION
This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):

- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components): [`1.4.0-beta.3`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-beta.3)
- `System.Diagnostics.DiagnosticSource`: [`7.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/7.0.0)

### Added

- Add support for `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BSP_EXPORT_TIMEOUT`, `OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`.
- Add support for `OTEL_METRIC_EXPORT_TIMEOUT`.
- Add support for `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_ATTRIBUTE_COUNT_LIMIT`, `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`, `OTEL_SPAN_EVENT_COUNT_LIMIT`, `OTEL_SPAN_LINK_COUNT_LIMIT`, `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`, `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT` for `otlp` exporter.

### Changed

- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components): [`1.4.0-beta.3`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-beta.3)
- Updated plugins method signature to overwrite OpenTelemetry .NET SDK exporters' and instrumentations' options. `ConfigureOptions` changed to `ConfigureTracesOptions`, `ConfigureMetricsOptions` or `ConfigureLogsOptions`.