### PR TITLE
Support OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG

### DIFF
--- a/.cspell/company-terms.txt
+++ b/.cspell/company-terms.txt
@@ -5,3 +5,5 @@ OTLP
 tracecontext
 triager
 Zipkin
+parentbased
+traceidratio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 
+- Add support for `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`.
+
 ### Changed
 
 ### Deprecated

--- a/docs/config.md
+++ b/docs/config.md
@@ -96,7 +96,8 @@ for more details.
 
 ## Samplers
 
-Samplers allows to control the noise and overhead introduced by OpenTelemetry.
+Samplers let you control potential noise and overhead introduced by OpenTelemetry 
+instrumentation by selecting which traces you want to collect and export.
 See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/sdk-environment-variables.md?plain=1#L45-L80)
 for more details.
 
@@ -112,8 +113,7 @@ for more details.
 - `traceidratio`,
 - `parentbased_always_on`,
 - `parentbased_always_off`,
-- `parentbased_traceidratio`,
-- `parentbased_jaeger_remote`.
+- `parentbased_traceidratio`.
 
 \[2\]: For `traceidratio` and `parentbased_traceidratio` samplers:
  Sampling probability, a number in the [0..1] range, e.g. "0.25".

--- a/docs/config.md
+++ b/docs/config.md
@@ -96,8 +96,9 @@ for more details.
 
 ## Samplers
 
-Samplers let you control potential noise and overhead introduced by OpenTelemetry 
-instrumentation by selecting which traces you want to collect and export.
+Samplers let you control potential noise and overhead introduced
+by OpenTelemetry instrumentation by selecting which traces you want
+to collect and export.
 See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/sdk-environment-variables.md?plain=1#L45-L80)
 for more details.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -102,8 +102,8 @@ to collect and export.
 See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/sdk-environment-variables.md?plain=1#L45-L80)
 for more details.
 
-| Environment variable      | Description                                     | Default value           |
-|---------------------------|-------------------------------------------------|-------------------------|
+| Environment variable      | Description                                           | Default value           |
+|---------------------------|-------------------------------------------------------|-------------------------|
 | `OTEL_TRACES_SAMPLER`     | Sampler to be used for traces \[1\]                   | `parentbased_always_on` |
 | `OTEL_TRACES_SAMPLER_ARG` | String value to be used as the sampler argument \[2\] |                         |
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -94,6 +94,31 @@ for more details.
 |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
 | `OTEL_PROPAGATORS`   | Comma-separated list of propagators. Supported options: `tracecontext`, `baggage`, `b3multi`, `b3`. See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/sdk-environment-variables.md#general-sdk-configuration) for more details. | `tracecontext,baggage` |
 
+## Samplers
+
+Samplers allows to control the noise and overhead introduced by OpenTelemetry.
+See [the OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/sdk-environment-variables.md?plain=1#L45-L80)
+for more details.
+
+| Environment variable      | Description                                     | Default value           |
+|---------------------------|-------------------------------------------------|-------------------------|
+| `OTEL_TRACES_SAMPLER`     | Sampler to be used for traces \[1\]                   | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | String value to be used as the sampler argument \[2\] |                         |
+
+\[1\]: Supported values are:
+
+- `always_on`,
+- `always_off`,
+- `traceidratio`,
+- `parentbased_always_on`,
+- `parentbased_always_off`,
+- `parentbased_traceidratio`,
+- `parentbased_jaeger_remote`.
+
+\[2\]: For `traceidratio` and `parentbased_traceidratio` samplers:
+ Sampling probability, a number in the [0..1] range, e.g. "0.25".
+ Default is 1.0.
+
 ## Exporters
 
 Exporters output the telemetry.
@@ -143,12 +168,12 @@ Important environment variables include:
 | `OTEL_EXPORTER_OTLP_HEADERS`             | Comma-separated list of additional HTTP headers sent with each export, for example: `Authorization=secret,X-Key=Value`.                                                                                    |                                                                                                           |
 | `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`      | Maximum allowed attribute value size.                                                                                                                                                                      | none                                                                                                      |
 | `OTEL_ATTRIBUTE_COUNT_LIMIT`             | Maximum allowed span attribute count.                                                                                                                                                                      | `128`                                                                                                     |
-| `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` | Maximum allowed attribute value size.                                                                                                                                                                       | none                                                                                                      |
-| `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`        | Maximum allowed span attribute count.                                                                                                                                                                       | `128`                                                                                                     |
-| `OTEL_SPAN_EVENT_COUNT_LIMIT`            | Maximum allowed span event count.                                                                                                                                                                           | `128`                                                                                                     |
-| `OTEL_SPAN_LINK_COUNT_LIMIT`             | Maximum allowed span link count.                                                                                                                                                                            | `128`                                                                                                     |
-| `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`       | Maximum allowed attribute per span event count.                                                                                                                                                             | `128`                                                                                                     |
-| `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`        | Maximum allowed attribute per span link count.                                                                                                                                                              | `128`                                                                                                     |
+| `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` | Maximum allowed attribute value size.                                                                                                                                                                      | none                                                                                                      |
+| `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`        | Maximum allowed span attribute count.                                                                                                                                                                      | `128`                                                                                                     |
+| `OTEL_SPAN_EVENT_COUNT_LIMIT`            | Maximum allowed span event count.                                                                                                                                                                          | `128`                                                                                                     |
+| `OTEL_SPAN_LINK_COUNT_LIMIT`             | Maximum allowed span link count.                                                                                                                                                                           | `128`                                                                                                     |
+| `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`       | Maximum allowed attribute per span event count.                                                                                                                                                            | `128`                                                                                                     |
+| `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`        | Maximum allowed attribute per span link count.                                                                                                                                                             | `128`                                                                                                     |
 
 **[1]**: Considerations on the `OTEL_EXPORTER_OTLP_PROTOCOL`:
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/ConfigurationKeys.cs
@@ -97,6 +97,16 @@ internal static class ConfigurationKeys
         public const string LegacySources = "OTEL_DOTNET_AUTO_LEGACY_SOURCES";
 
         /// <summary>
+        /// Configuration key for sampler to be used for traces.
+        /// </summary>
+        public const string TracesSampler = "OTEL_TRACES_SAMPLER";
+
+        /// <summary>
+        /// Configuration key for string value to be used as the sampler argument.
+        /// </summary>
+        public const string TracesSamplerArguments = "OTEL_TRACES_SAMPLER_ARG";
+
+        /// <summary>
         /// Configuration keys for instrumentation options.
         /// </summary>
         public static class InstrumentationOptions

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -71,12 +71,12 @@ internal static class EnvironmentConfigurationTracerHelper
     {
         var sampler = TracerSamplerHelper.GetSampler(settings.TracesSampler, settings.TracesSamplerArguments);
 
-        if (sampler != null)
+        if (sampler == null)
         {
-            return builder.SetSampler(sampler);
+            return builder;
         }
 
-        return builder;
+        return builder.SetSampler(sampler);
     }
 
     private static TracerProviderBuilder SetExporter(this TracerProviderBuilder builder, TracerSettings settings, PluginManager pluginManager)

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -52,14 +52,28 @@ internal static class EnvironmentConfigurationTracerHelper
             };
         }
 
-        // Exporters can cause dependency loads.
-        // Should be called later if dependency listeners are already setup.
-        builder.SetExporter(settings, pluginManager);
+        builder
+            .SetSampler(settings)
+            // Exporters can cause dependency loads.
+            // Should be called later if dependency listeners are already setup.
+            .SetExporter(settings, pluginManager)
+            .AddSource(settings.ActivitySources.ToArray());
 
-        builder.AddSource(settings.ActivitySources.ToArray());
         foreach (var legacySource in settings.LegacySources)
         {
             builder.AddLegacySource(legacySource);
+        }
+
+        return builder;
+    }
+
+    private static TracerProviderBuilder SetSampler(this TracerProviderBuilder builder, TracerSettings settings)
+    {
+        var sampler = TracerSamplerHelper.GetSampler(settings.TracesSampler, settings.TracesSamplerArguments);
+
+        if (sampler != null)
+        {
+            builder.SetSampler(sampler);
         }
 
         return builder;

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationTracerHelper.cs
@@ -73,7 +73,7 @@ internal static class EnvironmentConfigurationTracerHelper
 
         if (sampler != null)
         {
-            builder.SetSampler(sampler);
+            return builder.SetSampler(sampler);
         }
 
         return builder;

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSamplerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSamplerHelper.cs
@@ -1,0 +1,57 @@
+// <copyright file="TracerSamplerHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.AutoInstrumentation.Configuration;
+
+internal static class TracerSamplerHelper
+{
+    public static Sampler GetSampler(string tracerSampler, string tracerSamplerArguments)
+    {
+        switch (tracerSampler)
+        {
+            case "always_on":
+                return new AlwaysOnSampler();
+            case "always_off":
+                return new AlwaysOffSampler();
+            case "traceidratio":
+                return CreateTraceIdRatioBasedSampler(tracerSamplerArguments);
+            case "parentbased_always_on":
+                return new ParentBasedSampler(new AlwaysOnSampler());
+            case "parentbased_always_off":
+                return new ParentBasedSampler(new AlwaysOffSampler());
+            case "parentbased_traceidratio":
+                return new ParentBasedSampler(CreateTraceIdRatioBasedSampler(tracerSamplerArguments));
+        }
+
+        return null;
+    }
+
+    private static TraceIdRatioBasedSampler CreateTraceIdRatioBasedSampler(string arguments)
+    {
+        const double defaultRatio = 1.0;
+
+        var ratio = defaultRatio;
+
+        if (double.TryParse(arguments, out var parsedRatio) && parsedRatio >= 0.0 && parsedRatio <= 1.0)
+        {
+            ratio = parsedRatio;
+        }
+
+        return new TraceIdRatioBasedSampler(ratio);
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSettings.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using OpenTelemetry.AutoInstrumentation.Util;
 
 namespace OpenTelemetry.AutoInstrumentation.Configuration;
-// TODO Move settings to more suitable place?
 
 /// <summary>
 /// Tracer Settings
@@ -64,6 +63,9 @@ internal class TracerSettings : Settings
         OpenTracingEnabled = source.GetBool(ConfigurationKeys.Traces.OpenTracingEnabled) ?? false;
 
         InstrumentationOptions = new InstrumentationOptions(source);
+
+        TracesSampler = source.GetString(ConfigurationKeys.Traces.TracesSampler);
+        TracesSamplerArguments = source.GetString(ConfigurationKeys.Traces.TracesSamplerArguments);
     }
 
     /// <summary>
@@ -104,7 +106,17 @@ internal class TracerSettings : Settings
     /// <summary>
     /// Gets the instrumentation options.
     /// </summary>
-    public InstrumentationOptions InstrumentationOptions { get; private set; }
+    public InstrumentationOptions InstrumentationOptions { get; }
+
+    /// <summary>
+    /// Gets sampler to be used for traces.
+    /// </summary>
+    public string TracesSampler { get; }
+
+    /// <summary>
+    /// Gets a value to be used as the sampler argument.
+    /// </summary>
+    public string TracesSamplerArguments { get; }
 
     private static TracesExporter ParseTracesExporter(IConfigurationSource source)
     {

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/SettingsTests.cs
@@ -73,6 +73,8 @@ public class SettingsTests : IDisposable
             settings.EnabledInstrumentations.Should().NotBeEmpty();
             settings.ActivitySources.Should().BeEquivalentTo(new List<string> { "OpenTelemetry.AutoInstrumentation.*" });
             settings.LegacySources.Should().BeEmpty();
+            settings.TracesSampler.Should().BeNull();
+            settings.TracesSamplerArguments.Should().BeNull();
 
             // Instrumentation options tests
             settings.InstrumentationOptions.GraphQLSetDocument.Should().BeFalse();
@@ -212,6 +214,21 @@ public class SettingsTests : IDisposable
         settings.EnabledInstrumentations.Should().BeEquivalentTo(new List<TracerInstrumentation> { TracerInstrumentation.AspNet });
     }
 
+    [Fact]
+    internal void TracerSettings_TracerSampler()
+    {
+        const string expectedTracesSampler = nameof(expectedTracesSampler);
+        const string expectedTracesSamplerArguments = nameof(expectedTracesSamplerArguments);
+
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.TracesSampler, expectedTracesSampler);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.TracesSamplerArguments, expectedTracesSamplerArguments);
+
+        var settings = Settings.FromDefaultSources<TracerSettings>();
+
+        settings.TracesSampler.Should().Be(expectedTracesSampler);
+        settings.TracesSamplerArguments.Should().Be(expectedTracesSamplerArguments);
+    }
+
     [Theory]
     [InlineData(nameof(MetricInstrumentation.NetRuntime), MetricInstrumentation.NetRuntime)]
     [InlineData(nameof(MetricInstrumentation.AspNet), MetricInstrumentation.AspNet)]
@@ -319,6 +336,8 @@ public class SettingsTests : IDisposable
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Instrumentations, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.DisabledInstrumentations, null);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.TracesSampler, null);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.TracesSamplerArguments, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.InstrumentationOptions.GraphQLSetDocument, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.ExporterOtlpProtocol, null);
         Environment.SetEnvironmentVariable(ConfigurationKeys.FlushOnUnhandledException, null);

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/TracerSamplerHelperTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/TracerSamplerHelperTests.cs
@@ -1,0 +1,52 @@
+// <copyright file="TracerSamplerHelperTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using FluentAssertions;
+using OpenTelemetry.AutoInstrumentation.Configuration;
+using Xunit;
+
+namespace OpenTelemetry.AutoInstrumentation.Tests.Configuration;
+
+public class TracerSamplerHelperTests
+{
+    [Theory]
+    [InlineData("always_on", null, "AlwaysOnSampler")]
+    [InlineData("always_off", null, "AlwaysOffSampler")]
+    [InlineData("traceidratio", null, "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("traceidratio", "2", "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("traceidratio", "-1", "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("traceidratio", "non-a-number", "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("traceidratio", "0.25", "TraceIdRatioBasedSampler{0.250000}")]
+    [InlineData("parentbased_always_on", null, "ParentBased{AlwaysOnSampler}")]
+    [InlineData("parentbased_always_off", null, "ParentBased{AlwaysOffSampler}")]
+    [InlineData("parentbased_traceidratio", null, "ParentBased{TraceIdRatioBasedSampler{1.000000}}")]
+    [InlineData("parentbased_traceidratio", "0.25", "ParentBased{TraceIdRatioBasedSampler{0.250000}}")]
+    [InlineData("non-supported-value", null, null)]
+    [InlineData(null, null, null)]
+    public void GetSampler(string tracesSampler, string tracerSamplerArguments, string expectedDescription)
+    {
+        var sampler = TracerSamplerHelper.GetSampler(tracesSampler, tracerSamplerArguments);
+
+        if (expectedDescription == null)
+        {
+            sampler.Should().BeNull();
+        }
+        else
+        {
+            sampler.Description.Should().Be(expectedDescription);
+        }
+    }
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/TracerSamplerHelperTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configuration/TracerSamplerHelperTests.cs
@@ -34,19 +34,20 @@ public class TracerSamplerHelperTests
     [InlineData("parentbased_always_off", null, "ParentBased{AlwaysOffSampler}")]
     [InlineData("parentbased_traceidratio", null, "ParentBased{TraceIdRatioBasedSampler{1.000000}}")]
     [InlineData("parentbased_traceidratio", "0.25", "ParentBased{TraceIdRatioBasedSampler{0.250000}}")]
-    [InlineData("non-supported-value", null, null)]
-    [InlineData(null, null, null)]
-    public void GetSampler(string tracesSampler, string tracerSamplerArguments, string expectedDescription)
+    public void GetSamplerSupportedValues(string tracesSampler, string tracerSamplerArguments, string expectedDescription)
     {
         var sampler = TracerSamplerHelper.GetSampler(tracesSampler, tracerSamplerArguments);
 
-        if (expectedDescription == null)
-        {
-            sampler.Should().BeNull();
-        }
-        else
-        {
-            sampler.Description.Should().Be(expectedDescription);
-        }
+        sampler.Description.Should().Be(expectedDescription);
+    }
+
+    [Theory]
+    [InlineData("non-supported-value", null)]
+    [InlineData(null, null)]
+    public void GetSamplerNonSupportedValues(string tracesSampler, string tracerSamplerArguments)
+    {
+        var sampler = TracerSamplerHelper.GetSampler(tracesSampler, tracerSamplerArguments);
+
+        sampler.Should().BeNull();
     }
 }


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #1091

## What

Support for `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`.

## Tests

CI + newly added

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.

## Notes

There is no support for these variables on OTel SDK yet. There is no strict plan when it will be available. It will be removed in scope of #1697 when possible.