### PR TITLE
Fix .NET Framework tests

### DIFF
--- a/test/IntegrationTests/SqlClientSystemDataTests.cs
+++ b/test/IntegrationTests/SqlClientSystemDataTests.cs
@@ -34,7 +34,7 @@ public class SqlClientSystemDataTests : TestHelper
     {
         using var collector = new MockSpansCollector(Output);
         SetExporter(collector);
-        collector.Expect("OpenTelemetry.SqlClient");
+        collector.Expect("OpenTelemetry.Instrumentation.SqlClient");
 
         RunTestApplication();
 

--- a/test/test-applications/integrations/Directory.Build.props
+++ b/test/test-applications/integrations/Directory.Build.props
@@ -7,4 +7,9 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" Link="GlobalSuppressions.integrations.cs" />
   </ItemGroup>
+
+  <!-- .NET Framework apps do not have shared store to bump these libraries -->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+  </ItemGroup>
 </Project>

--- a/test/test-applications/integrations/TestApplication.DomainNeutral/App.config
+++ b/test/test-applications/integrations/TestApplication.DomainNeutral/App.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- To be removed when https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1646 is fixed -->
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/test-applications/integrations/TestApplication.DomainNeutral/TestApplication.DomainNeutral.csproj
+++ b/test/test-applications/integrations/TestApplication.DomainNeutral/TestApplication.DomainNeutral.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AddTestStrongNameAssemblyKeyOnNetFramework>true</AddTestStrongNameAssemblyKeyOnNetFramework>
   </PropertyGroup>
 

--- a/test/test-applications/integrations/TestApplication.GrpcNetClient/TestApplication.GrpcNetClient.csproj
+++ b/test/test-applications/integrations/TestApplication.GrpcNetClient/TestApplication.GrpcNetClient.csproj
@@ -14,9 +14,6 @@
     <!-- Workaround! Microsoft.Extensions.Logging.Abstractions v.3.1.0 is minimal version supported by auto instrumentation.
     Grpc.Net.Client references older version. It prevents to load required version from Additional Dependencies store-->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
-    <!-- Workaround! System.Diagnostics.DiagnosticSource v.7.0.0 is minimal version supported by auto instrumentation.
-    Grpc.Net.Client references older version. It prevents to use older version during runtime.-->
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0"  Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.Http.NetFramework/TestApplication.Http.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Http.NetFramework/TestApplication.Http.NetFramework.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
@@ -10,10 +9,5 @@
 
   <ItemGroup>
     <None Include="App.config" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
-  </ItemGroup>
-  
+  </ItemGroup>  
 </Project>

--- a/test/test-applications/integrations/TestApplication.Modules/TestApplication.Modules.csproj
+++ b/test/test-applications/integrations/TestApplication.Modules/TestApplication.Modules.csproj
@@ -5,7 +5,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
+++ b/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="$(ApiVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0"  Condition="'$(TargetFramework)' == 'net462'" />
     <!-- Workaround! Microsoft.Extensions.Logging.Abstractions v.3.1.0 is minimal version supported by auto instrumentation.
     MongoDB.Driver 2.18+ references older version. It prevents to load required version from Additional Dependencies store-->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(ApiVersion)'>='2.18.0'" />

--- a/test/test-applications/integrations/TestApplication.Npgsql/App.config
+++ b/test/test-applications/integrations/TestApplication.Npgsql/App.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- To be removed when https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1646 is fixed -->
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/test-applications/integrations/TestApplication.Npgsql/TestApplication.Npgsql.csproj
+++ b/test/test-applications/integrations/TestApplication.Npgsql/TestApplication.Npgsql.csproj
@@ -1,8 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="6.0.5" />

--- a/test/test-applications/integrations/TestApplication.Plugins/TestApplication.Plugins.csproj
+++ b/test/test-applications/integrations/TestApplication.Plugins/TestApplication.Plugins.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="OpenTelemetry" Version="1.4.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
   </ItemGroup>
 
     <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.Smoke/TestApplication.Smoke.csproj
+++ b/test/test-applications/integrations/TestApplication.Smoke/TestApplication.Smoke.csproj
@@ -4,7 +4,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
   </ItemGroup>
 

--- a/test/test-applications/integrations/TestApplication.SqlClient.NetFramework/App.config
+++ b/test/test-applications/integrations/TestApplication.SqlClient.NetFramework/App.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- To be removed when https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1646 is fixed -->
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/test-applications/integrations/TestApplication.SqlClient.NetFramework/TestApplication.SqlClient.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.SqlClient.NetFramework/TestApplication.SqlClient.NetFramework.csproj
@@ -1,13 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\dependency-libs\TestApplication.Shared\TestApplication.Shared.csproj" />

--- a/test/test-applications/integrations/TestApplication.SqlClient/App.config
+++ b/test/test-applications/integrations/TestApplication.SqlClient/App.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- To be removed when https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1646 is fixed -->
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/test-applications/integrations/TestApplication.SqlClient/TestApplication.SqlClient.csproj
+++ b/test/test-applications/integrations/TestApplication.SqlClient/TestApplication.SqlClient.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.StrongNamed/App.config
+++ b/test/test-applications/integrations/TestApplication.StrongNamed/App.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- To be removed when https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1646 is fixed -->
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/test-applications/integrations/TestApplication.StrongNamed/TestApplication.StrongNamed.csproj
+++ b/test/test-applications/integrations/TestApplication.StrongNamed/TestApplication.StrongNamed.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <AddTestStrongNameAssemblyKeyOnNetFramework>true</AddTestStrongNameAssemblyKeyOnNetFramework>
   </PropertyGroup>
 

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.Core/TestApplication.Wcf.Client.Core.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.Core/TestApplication.Wcf.Client.Core.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.7" ExcludeAssets="runtime" />

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/App.config
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/App.config
@@ -30,4 +30,16 @@
       <endpoint address="net.tcp://127.0.0.1:9090/Telemetry" binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Shared.IStatusServiceContract" name="StatusService_Tcp" />
     </client>
   </system.serviceModel>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/App.config
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/App.config
@@ -38,4 +38,16 @@
       </service>
     </services>
   </system.serviceModel>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
## What

Fixes .NET framework tests after 1.4.0-beta.3 bump
Syncs S.D.DS version to 7.0 (although some tests can use older version without crashing)
Fixes in dependency redirections

## Tests

Existing.
