### PR TITLE
Make OTEL_TRACES_SAMPLER_ARG parsing locale invariant

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSamplerHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/TracerSamplerHelper.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Globalization;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.AutoInstrumentation.Configuration;
@@ -47,7 +48,8 @@ internal static class TracerSamplerHelper
 
         var ratio = defaultRatio;
 
-        if (double.TryParse(arguments, out var parsedRatio) && parsedRatio >= 0.0 && parsedRatio <= 1.0)
+        if (double.TryParse(arguments, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedRatio)
+            && parsedRatio >= 0.0 && parsedRatio <= 1.0)
         {
             ratio = parsedRatio;
         }


### PR DESCRIPTION
## Why

The `TracerSamplerHelperTests` failed on my machine (probably the locale was Polish).


## What

Make `OTEL_TRACES_SAMPLER_ARG` parsing locale invariant. Code is copied from https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/47806aca4f6e26a904d7d14d3749d024c66c9d18/src/OpenTelemetry.AutoInstrumentation/Configuration/StringConfigurationSource.cs#L45

## Tests

My machine

**I could try changing the locale during tests. Do you think it is worth?**

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] ~~`CHANGELOG.md` is updated.~~ Not mentioning as it was not released yet.
- [x] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~ I could try changing the locale during tests. Do you think it is worth?
