### PR TITLE
Fix configuration sources

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/CompositeConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/CompositeConfigurationSource.cs
@@ -61,7 +61,7 @@ internal class CompositeConfigurationSource : IConfigurationSource, IEnumerable<
     public string GetString(string key)
     {
         return _sources.Select(source => source.GetString(key))
-            .FirstOrDefault(value => value != null);
+             .FirstOrDefault(value => !string.IsNullOrEmpty(value));
     }
 
     /// <summary>

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/EnvironmentConfigurationSource.cs
@@ -24,8 +24,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 /// </summary>
 internal class EnvironmentConfigurationSource : StringConfigurationSource
 {
-    /// <inheritdoc />
-    public override string GetString(string key)
+    protected override string GetStringInternal(string key)
     {
         try
         {

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/NameValueConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/NameValueConfigurationSource.cs
@@ -36,8 +36,7 @@ internal class NameValueConfigurationSource : StringConfigurationSource
         _nameValueCollection = nameValueCollection;
     }
 
-    /// <inheritdoc />
-    public override string GetString(string key)
+    protected override string GetStringInternal(string key)
     {
         return _nameValueCollection[key];
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Configuration/StringConfigurationSource.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configuration/StringConfigurationSource.cs
@@ -25,7 +25,16 @@ namespace OpenTelemetry.AutoInstrumentation.Configuration;
 internal abstract class StringConfigurationSource : IConfigurationSource
 {
     /// <inheritdoc />
-    public abstract string GetString(string key);
+    public virtual string GetString(string key)
+    {
+        var value = GetStringInternal(key);
+        if (string.IsNullOrEmpty(value))
+        {
+            return null;
+        }
+
+        return value;
+    }
 
     /// <inheritdoc />
     public virtual int? GetInt32(string key)
@@ -53,4 +62,6 @@ internal abstract class StringConfigurationSource : IConfigurationSource
         var value = GetString(key);
         return bool.TryParse(value, out bool result) ? result : null;
     }
+
+    protected abstract string GetStringInternal(string key);
 }


### PR DESCRIPTION
## Why

> The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset.

_src: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/_

## What

Ensures that all configuration sources follow that rule.

## Tests

Unit tests added.

## Checklist

- [x] New features are covered by tests.
