### PR TITLE
Enable nullable reference types for duck types

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -13,19 +13,6 @@ OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(Sys
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(System.Diagnostics.Activity activity, object state, System.DateTimeOffset? startTime) -> void
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.StartTime.get -> System.DateTimeOffset?
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.State.get -> object
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CanCreate() -> bool
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CreateInstance<T>(object instance) -> T
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CreateInstance<T, TOriginal>(TOriginal instance) -> T
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CreateTypeResult() -> void
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.ProxyType.get -> System.Type
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.DelegateCache<TProxyDelegate>
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Instance.get -> object
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.ToString() -> string
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Type.get -> System.Type
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ErrorLocationStruct
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ErrorLocationStruct.Column -> int
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ErrorLocationStruct.ErrorLocationStruct() -> void
@@ -68,8 +55,6 @@ OpenTelemetry.AutoInstrumentation.Instrumentations.Validations.StrongNamedValida
 OpenTelemetry.AutoInstrumentation.Instrumentations.Validations.StrongNamedValidation.StrongNamedValidation() -> void
 override OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn<T>.ToString() -> string
 override OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.ToString() -> string
-readonly OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.Success -> bool
-readonly OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.TargetType -> System.Type
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
@@ -87,22 +72,5 @@ static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.LogExcepti
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn.GetDefault() -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn<T>.GetDefault() -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn<T>
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.GetDefault() -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CanCreate(System.Type proxyType, object instance) -> bool
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CanCreate<T>(object instance) -> bool
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.Create(System.Type proxyType, object instance) -> object
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.Create<T>(object instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateReverse(System.Type typeToDeriveFrom, object delegationInstance) -> object
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.GetOrCreateReverseProxyType(System.Type typeToDeriveFrom, System.Type delegationType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.CanCreate(object instance) -> bool
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.Create(object instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.CreateFrom<TOriginal>(TOriginal instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.CreateReverse(object instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.GetReverseProxy(System.Type targetType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.GetProxy(System.Type targetType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.DelegateCache<TProxyDelegate>.GetDelegate() -> TProxyDelegate
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.GetOrCreateProxyType(System.Type proxyType, System.Type targetType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
 static OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ExecuteAsyncIntegration.OnAsyncMethodEnd<TTarget, TExecutionResult>(TTarget instance, TExecutionResult executionResult, System.Exception exception, OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState state) -> TExecutionResult
 static OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ExecuteAsyncIntegration.OnMethodBegin<TTarget, TContext>(TTarget instance, TContext context) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
-static readonly OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.Type -> System.Type
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.EnumToObjectMethodInfo.get -> System.Reflection.MethodInfo
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.GetTypeFromHandleMethodInfo.get -> System.Reflection.MethodInfo

--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -13,19 +13,6 @@ OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(Sys
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(System.Diagnostics.Activity activity, object state, System.DateTimeOffset? startTime) -> void
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.StartTime.get -> System.DateTimeOffset?
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.State.get -> object
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CanCreate() -> bool
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CreateInstance<T>(object instance) -> T
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CreateInstance<T, TOriginal>(TOriginal instance) -> T
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.CreateTypeResult() -> void
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.ProxyType.get -> System.Type
-OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.DelegateCache<TProxyDelegate>
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Instance.get -> object
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.ToString() -> string
-OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Type.get -> System.Type
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ErrorLocationStruct
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ErrorLocationStruct.Column -> int
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ErrorLocationStruct.ErrorLocationStruct() -> void
@@ -68,8 +55,6 @@ OpenTelemetry.AutoInstrumentation.Instrumentations.Validations.StrongNamedValida
 OpenTelemetry.AutoInstrumentation.Instrumentations.Validations.StrongNamedValidation.StrongNamedValidation() -> void
 override OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn<T>.ToString() -> string
 override OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.ToString() -> string
-readonly OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.Success -> bool
-readonly OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult.TargetType -> System.Type
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
@@ -87,22 +72,5 @@ static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker.LogExcepti
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn.GetDefault() -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn<T>.GetDefault() -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn<T>
 static OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.GetDefault() -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CanCreate(System.Type proxyType, object instance) -> bool
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CanCreate<T>(object instance) -> bool
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.Create(System.Type proxyType, object instance) -> object
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.Create<T>(object instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateReverse(System.Type typeToDeriveFrom, object delegationInstance) -> object
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.GetOrCreateReverseProxyType(System.Type typeToDeriveFrom, System.Type delegationType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.CanCreate(object instance) -> bool
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.Create(object instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.CreateFrom<TOriginal>(TOriginal instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.CreateReverse(object instance) -> T
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.GetReverseProxy(System.Type targetType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.GetProxy(System.Type targetType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.DelegateCache<TProxyDelegate>.GetDelegate() -> TProxyDelegate
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.GetOrCreateProxyType(System.Type proxyType, System.Type targetType) -> OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateTypeResult
 static OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ExecuteAsyncIntegration.OnAsyncMethodEnd<TTarget, TExecutionResult>(TTarget instance, TExecutionResult executionResult, System.Exception exception, OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState state) -> TExecutionResult
 static OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ExecuteAsyncIntegration.OnMethodBegin<TTarget, TContext>(TTarget instance, TContext context) -> OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState
-static readonly OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.CreateCache<T>.Type -> System.Type
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.EnumToObjectMethodInfo.get -> System.Reflection.MethodInfo
-static OpenTelemetry.AutoInstrumentation.DuckTyping.DuckType.GetTypeFromHandleMethodInfo.get -> System.Reflection.MethodInfo

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckAttribute.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Reflection;
 
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckAttributeBase.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckAttributeBase.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Reflection;
 
@@ -28,7 +30,7 @@ internal abstract class DuckAttributeBase : Attribute
     /// <summary>
     /// Gets or sets the underlying type member name
     /// </summary>
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets the binding flags
@@ -38,15 +40,15 @@ internal abstract class DuckAttributeBase : Attribute
     /// <summary>
     /// Gets or sets the generic parameter type names definition for a generic method call (required when calling generic methods and instance type is non public)
     /// </summary>
-    public string[] GenericParameterTypeNames { get; set; }
+    public string[]? GenericParameterTypeNames { get; set; }
 
     /// <summary>
     /// Gets or sets the parameter type names of the target method (optional / used to disambiguation)
     /// </summary>
-    public string[] ParameterTypeNames { get; set; }
+    public string[]? ParameterTypeNames { get; set; }
 
     /// <summary>
     /// Gets or sets the explicit interface type name
     /// </summary>
-    public string ExplicitInterfaceTypeName { get; set; }
+    public string? ExplicitInterfaceTypeName { get; set; }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckCopyAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckCopyAttribute.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckFieldAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckFieldAttribute.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 
 /// <summary>

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckIgnoreAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckIgnoreAttribute.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckIncludeAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckIncludeAttribute.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckReverseMethodAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckReverseMethodAttribute.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 
 /// <summary>

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Fields.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Fields.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// <summary>
 /// Duck Type
 /// </summary>
-public static partial class DuckType
+internal static partial class DuckType
 {
     private static MethodBuilder? GetFieldGetMethod(
         TypeBuilder? proxyTypeBuilder,

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Fields.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Fields.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -25,17 +27,17 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// </summary>
 public static partial class DuckType
 {
-    private static MethodBuilder GetFieldGetMethod(
-        TypeBuilder proxyTypeBuilder,
+    private static MethodBuilder? GetFieldGetMethod(
+        TypeBuilder? proxyTypeBuilder,
         Type targetType,
         MemberInfo proxyMember,
         FieldInfo targetField,
-        FieldInfo instanceField)
+        FieldInfo? instanceField)
     {
         string proxyMemberName = proxyMember.Name;
         Type proxyMemberReturnType = proxyMember is PropertyInfo pinfo ? pinfo.PropertyType : proxyMember is FieldInfo finfo ? finfo.FieldType : typeof(object);
 
-        MethodBuilder proxyMethod = proxyTypeBuilder?.DefineMethod(
+        MethodBuilder? proxyMethod = proxyTypeBuilder?.DefineMethod(
             "get_" + proxyMemberName,
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.Virtual,
             proxyMemberReturnType,
@@ -126,17 +128,17 @@ public static partial class DuckType
         return proxyMethod;
     }
 
-    private static MethodBuilder GetFieldSetMethod(
-        TypeBuilder proxyTypeBuilder,
+    private static MethodBuilder? GetFieldSetMethod(
+        TypeBuilder? proxyTypeBuilder,
         Type targetType,
         MemberInfo proxyMember,
         FieldInfo targetField,
-        FieldInfo instanceField)
+        FieldInfo? instanceField)
     {
         string proxyMemberName = proxyMember.Name;
         Type proxyMemberReturnType = proxyMember is PropertyInfo pinfo ? pinfo.PropertyType : proxyMember is FieldInfo finfo ? finfo.FieldType : typeof(object);
 
-        MethodBuilder method = proxyTypeBuilder?.DefineMethod(
+        MethodBuilder? method = proxyTypeBuilder?.DefineMethod(
             "set_" + proxyMemberName,
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.Virtual,
             typeof(void),

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Methods.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Methods.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// <summary>
 /// Duck Type
 /// </summary>
-public static partial class DuckType
+internal static partial class DuckType
 {
     private static List<MethodInfo> GetMethods(Type baseType)
     {

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Properties.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Properties.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,16 +29,16 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// </summary>
 public static partial class DuckType
 {
-    private static MethodBuilder GetPropertyGetMethod(
-        TypeBuilder proxyTypeBuilder,
+    private static MethodBuilder? GetPropertyGetMethod(
+        TypeBuilder? proxyTypeBuilder,
         Type targetType,
         MemberInfo proxyMember,
         PropertyInfo targetProperty,
-        FieldInfo instanceField,
+        FieldInfo? instanceField,
         Func<LazyILGenerator, Type, Type, Type> duckCastInnerToOuterFunc,
         Func<Type, Type, bool> needsDuckChaining)
     {
-        MethodInfo targetMethod = targetProperty.GetMethod;
+        MethodInfo? targetMethod = targetProperty.GetMethod;
         if (targetMethod is null)
         {
             return null;
@@ -66,7 +68,7 @@ public static partial class DuckType
             }
         }
 
-        MethodBuilder proxyMethod = proxyTypeBuilder?.DefineMethod(
+        MethodBuilder? proxyMethod = proxyTypeBuilder?.DefineMethod(
             "get_" + proxyMemberName,
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.Virtual,
             proxyMemberReturnType,
@@ -206,22 +208,22 @@ public static partial class DuckType
         return proxyMethod;
     }
 
-    private static MethodBuilder GetPropertySetMethod(
-        TypeBuilder proxyTypeBuilder,
+    private static MethodBuilder? GetPropertySetMethod(
+        TypeBuilder? proxyTypeBuilder,
         Type targetType,
         MemberInfo proxyMember,
         PropertyInfo targetProperty,
-        FieldInfo instanceField,
+        FieldInfo? instanceField,
         Func<LazyILGenerator, Type, Type, Type> duckCastOuterToInner,
         Func<Type, Type, bool> needsDuckChaining)
     {
-        MethodInfo targetMethod = targetProperty.SetMethod;
+        MethodInfo? targetMethod = targetProperty.SetMethod;
         if (targetMethod is null)
         {
             return null;
         }
 
-        string proxyMemberName = null;
+        string? proxyMemberName = null;
         Type[] proxyParameterTypes = Type.EmptyTypes;
         Type[] targetParametersTypes = GetPropertySetParametersTypes(proxyTypeBuilder, targetProperty, true).ToArray();
 
@@ -244,7 +246,7 @@ public static partial class DuckType
             }
         }
 
-        MethodBuilder proxyMethod = proxyTypeBuilder?.DefineMethod(
+        MethodBuilder? proxyMethod = proxyTypeBuilder?.DefineMethod(
             "set_" + proxyMemberName,
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.Virtual,
             typeof(void),
@@ -360,7 +362,7 @@ public static partial class DuckType
         return proxyMethod;
     }
 
-    private static IEnumerable<Type> GetPropertyGetParametersTypes(TypeBuilder typeBuilder, PropertyInfo property, bool originalTypes, bool isDynamicSignature = false)
+    private static IEnumerable<Type> GetPropertyGetParametersTypes(TypeBuilder? typeBuilder, PropertyInfo property, bool originalTypes, bool isDynamicSignature = false)
     {
         if (isDynamicSignature)
         {
@@ -381,7 +383,7 @@ public static partial class DuckType
         }
     }
 
-    private static IEnumerable<Type> GetPropertySetParametersTypes(TypeBuilder typeBuilder, PropertyInfo property, bool originalTypes, bool isDynamicSignature = false)
+    private static IEnumerable<Type> GetPropertySetParametersTypes(TypeBuilder? typeBuilder, PropertyInfo property, bool originalTypes, bool isDynamicSignature = false)
     {
         if (isDynamicSignature)
         {

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Properties.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Properties.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// <summary>
 /// Duck Type
 /// </summary>
-public static partial class DuckType
+internal static partial class DuckType
 {
     private static MethodBuilder? GetPropertyGetMethod(
         TypeBuilder? proxyTypeBuilder,

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Statics.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Statics.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// <summary>
 /// Duck Type
 /// </summary>
-public static partial class DuckType
+internal static partial class DuckType
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private static readonly object Locker;

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Statics.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Statics.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -40,15 +42,15 @@ public static partial class DuckType
     private static readonly Dictionary<ModuleBuilder, HashSet<string>> IgnoresAccessChecksToAssembliesSetDictionary;
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private static readonly MethodInfo _getTypeFromHandleMethodInfo;
+    private static readonly MethodInfo? _getTypeFromHandleMethodInfo;
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private static readonly MethodInfo _enumToObjectMethodInfo;
+    private static readonly MethodInfo? _enumToObjectMethodInfo;
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private static readonly PropertyInfo _duckTypeInstancePropertyInfo;
+    private static readonly PropertyInfo? _duckTypeInstancePropertyInfo;
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private static readonly MethodInfo _methodBuilderGetToken;
+    private static readonly MethodInfo? _methodBuilderGetToken;
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private static readonly ConstructorInfo _ignoresAccessChecksToAttributeCtor;
+    private static readonly ConstructorInfo? _ignoresAccessChecksToAttributeCtor;
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private static long _assemblyCount;
@@ -200,7 +202,7 @@ public static partial class DuckType
     public static class DelegateCache<TProxyDelegate>
         where TProxyDelegate : Delegate
     {
-        private static TProxyDelegate _delegate;
+        private static TProxyDelegate? _delegate;
 
         /// <summary>
         /// Get cached delegate from the DynamicMethod

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Utilities.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Utilities.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -32,7 +33,7 @@ public static partial class DuckType
     /// <param name="proxyType">Duck type</param>
     /// <param name="instance">Instance value</param>
     /// <exception cref="ArgumentNullException">If the duck type or the instance value is null</exception>
-    private static void EnsureArguments(Type proxyType, object instance)
+    private static void EnsureArguments(Type? proxyType, object? instance)
     {
         if (proxyType is null)
         {
@@ -124,7 +125,7 @@ public static partial class DuckType
     /// <param name="builder">Module builder</param>
     /// <param name="targetType">Target type</param>
     /// <returns>true for direct method; otherwise, false.</returns>
-    private static bool UseDirectAccessTo(ModuleBuilder builder, Type targetType)
+    private static bool UseDirectAccessTo(ModuleBuilder? builder, Type targetType)
     {
         if (builder is null)
         {
@@ -141,7 +142,7 @@ public static partial class DuckType
     /// <param name="builder">Type builder</param>
     /// <param name="targetType">Target type</param>
     /// <returns>true for direct method; otherwise, false.</returns>
-    private static bool UseDirectAccessTo(TypeBuilder builder, Type targetType)
+    private static bool UseDirectAccessTo(TypeBuilder? builder, Type targetType)
     {
         if (builder is null)
         {

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Utilities.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.Utilities.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// <summary>
 /// Duck Type
 /// </summary>
-public static partial class DuckType
+internal static partial class DuckType
 {
     /// <summary>
     /// Checks and ensures the arguments for the Create methods

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckType.cs
@@ -43,7 +43,7 @@ internal delegate T CreateProxyInstance<T>(object? instance);
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public static partial class DuckType
+internal static partial class DuckType
 {
     /// <summary>
     /// Create duck type proxy using a base type
@@ -1157,7 +1157,7 @@ public static partial class DuckType
     /// Generics Create Cache FastPath
     /// </summary>
     /// <typeparam name="T">Type of proxy definition</typeparam>
-    public static class CreateCache<T>
+    internal static class CreateCache<T>
     {
         /// <summary>
         /// Gets the type of T

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckTypeConstants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckTypeConstants.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 
 internal static class DuckTypeConstants

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckTypeExceptions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckTypeExceptions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckTypeExtensions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/DuckTypeExtensions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -32,7 +34,8 @@ internal static class DuckTypeExtensions
     /// <typeparam name="T">Target type</typeparam>
     /// <returns>DuckType instance</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T DuckCast<T>(this object instance)
+    [return: NotNullIfNotNull("instance")]
+    public static T? DuckCast<T>(this object? instance)
         => DuckType.Create<T>(instance);
 
     /// <summary>
@@ -53,7 +56,7 @@ internal static class DuckTypeExtensions
     /// <param name="value">Ducktype instance</param>
     /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryDuckCast<T>(this object instance, out T value)
+    public static bool TryDuckCast<T>(this object? instance, [NotNullWhen(true)] out T? value)
     {
         if (instance is null)
         {
@@ -79,7 +82,7 @@ internal static class DuckTypeExtensions
     /// <param name="value">Ducktype instance</param>
     /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryDuckCast(this object instance, Type targetType, out object value)
+    public static bool TryDuckCast(this object? instance, Type? targetType, [NotNullWhen(true)] out object? value)
     {
         if (instance is null)
         {
@@ -107,7 +110,7 @@ internal static class DuckTypeExtensions
     /// <typeparam name="T">Target type</typeparam>
     /// <returns>DuckType instance</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T DuckAs<T>(this object instance)
+    public static T? DuckAs<T>(this object? instance)
         where T : class
     {
         if (instance is null)
@@ -131,7 +134,7 @@ internal static class DuckTypeExtensions
     /// <param name="targetType">Target type</param>
     /// <returns>DuckType instance</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static object DuckAs(this object instance, Type targetType)
+    public static object? DuckAs(this object? instance, Type? targetType)
     {
         if (instance is null)
         {
@@ -157,7 +160,7 @@ internal static class DuckTypeExtensions
     /// <typeparam name="T">Duck type</typeparam>
     /// <returns>true if the proxy can be created; otherwise, false</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool DuckIs<T>(this object instance)
+    public static bool DuckIs<T>(this object? instance)
     {
         if (instance is null)
         {
@@ -174,7 +177,7 @@ internal static class DuckTypeExtensions
     /// <param name="targetType">Duck type</param>
     /// <returns>true if the proxy can be created; otherwise, false</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool DuckIs(this object instance, Type targetType)
+    public static bool DuckIs(this object? instance, Type? targetType)
     {
         if (instance is null)
         {
@@ -210,7 +213,7 @@ internal static class DuckTypeExtensions
     /// <param name="value">The Ducktype instance</param>
     /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryDuckImplement(this object instance, Type typeToDeriveFrom, out object value)
+    public static bool TryDuckImplement(this object? instance, Type? typeToDeriveFrom, [NotNullWhen(true)] out object? value)
     {
         if (instance is null)
         {

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IDuckType.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IDuckType.cs
@@ -24,9 +24,7 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 /// <summary>
 /// Duck type interface
 /// </summary>
-[Browsable(false)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public interface IDuckType
+internal interface IDuckType
 {
     /// <summary>
     /// Gets instance

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IDuckType.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IDuckType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/ILHelpersExtensions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/ILHelpersExtensions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IgnoresAccessChecksToAttribute.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IgnoresAccessChecksToAttribute.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace System.Runtime.CompilerServices;
 

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/LazyILGenerator.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/LazyILGenerator.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -24,11 +26,11 @@ namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 // ReSharper disable once InconsistentNaming
 internal class LazyILGenerator
 {
-    private readonly ILGenerator _generator;
+    private readonly ILGenerator? _generator;
     private readonly List<Action<ILGenerator>> _instructions;
     private int _offset;
 
-    public LazyILGenerator(ILGenerator generator)
+    public LazyILGenerator(ILGenerator? generator)
     {
         _generator = generator;
         _instructions = new List<Action<ILGenerator>>(16);
@@ -69,12 +71,12 @@ internal class LazyILGenerator
         _offset++;
     }
 
-    public LocalBuilder DeclareLocal(Type localType, bool pinned)
+    public LocalBuilder? DeclareLocal(Type localType, bool pinned)
     {
         return _generator?.DeclareLocal(localType, pinned);
     }
 
-    public LocalBuilder DeclareLocal(Type localType)
+    public LocalBuilder? DeclareLocal(Type localType)
     {
         return _generator?.DeclareLocal(localType);
     }

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/TypesTuple.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/TypesTuple.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
@@ -61,7 +63,7 @@ internal readonly struct TypesTuple : IEquatable<TypesTuple>
     /// </summary>
     /// <param name="obj">Object to compare</param>
     /// <returns>True if both are equals; otherwise, false.</returns>
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         return obj is TypesTuple vTuple &&
                ProxyDefinitionType == vTuple.ProxyDefinitionType &&


### PR DESCRIPTION
## Why

We want to add nullable reference types wherever possible.

Fixes #

## What

Enable nullable reference types for duck type files, using the `#nullable enable` directive. This PR also makes the duck typing types internal to avoid needing to document them (and their nullable reference types) in the public API files we track.

## Tests

Tested via existing bytecode instrumentation tests.

## Checklist

- [X] ~`CHANGELOG.md` is updated.~
- [X] ~Documentation is updated.~
- [X] ~New features are covered by tests.~
