### PR TITLE
Recommend C/C++ Extension Pack VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "editorconfig.editorconfig",
     "davidanson.vscode-markdownlint",
     "ms-dotnettools.csharp",
+    "ms-vscode.cpptools-extension-pack",
     "streetsidesoftware.code-spell-checker",
   ]
 }


### PR DESCRIPTION
## Why

Works on my machine 😆 

## What

Add https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack as a recommended VS Code extension.