### PR TITLE
Bump re2 to 2022-12-01

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 if (NOT EXISTS ${OUTPUT_DEPS_DIR}/re2)
     add_custom_command(
         OUTPUT ${OUTPUT_DEPS_DIR}/re2
-        COMMAND git clone --quiet --depth 1 --branch 2018-10-01 https://github.com/google/re2.git && cd re2 && env ARFLAGS=\"-r -s -c\" CXXFLAGS=\"-O3 -g -fPIC\" make
+        COMMAND git clone --quiet --depth 1 --branch 2022-12-01 https://github.com/google/re2.git && cd re2 && env ARFLAGS=\"-r -s -c\" CXXFLAGS=\"-std=c++11 -O3 -g -fPIC\" make
         WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
     )
 endif()


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #1665

## What

Bump re2 to 2022-12-01
I do not find a possibility to compile the code without re2 under MacOS. There are differences between libc++ and libstdc++.
On linux it compiled, but runtime was working incorrectly (not tested as MacOS is not compiling).

Apple Clang is using C++98 by default.
C++11 flag was removed in https://github.com/google/re2/commit/a022cc0c55b0519629d64d775e7a5195af34a477
It has to be manually set on our side.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
