### PR TITLE
Fix windows script tests warning

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,7 +8,6 @@ jobs:
   powershell-script:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v3.1.0
       - uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: | 
@@ -20,7 +19,7 @@ jobs:
           mkdir testapp
           cd testapp
           dotnet new console
-          dotnet publish /p:TreatWarningsAsErrors=false -f net7.0 -c Release
+          dotnet publish -f net7.0 -c Release
           $module_url = "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/OpenTelemetry.DotNet.Auto.psm1"
           $dl_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
           $log_path = "C:\ProgramData\OpenTelemetry .NET AutoInstrumentation\logs\*"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,6 +8,7 @@ jobs:
   powershell-script:
     runs-on: windows-2022
     steps:
+      - uses: actions/checkout@v3.1.0
       - uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: | 
@@ -19,7 +20,7 @@ jobs:
           mkdir testapp
           cd testapp
           dotnet new console
-          dotnet publish -f net7.0 -c Release
+          dotnet publish /p:TreatWarningsAsErrors=false -f net7.0 -c Release
           $module_url = "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/OpenTelemetry.DotNet.Auto.psm1"
           $dl_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
           $log_path = "C:\ProgramData\OpenTelemetry .NET AutoInstrumentation\logs\*"
@@ -90,12 +91,12 @@ jobs:
         run: |
           set -e
           docker build -t mybuildimage -f "./docker/${{ matrix.base-image }}.dockerfile" .
-          docker run --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project --rm mybuildimage /bin/sh -c '
+          docker run --rm mybuildimage /bin/sh -c '
             set -e
             mkdir testapp
             cd testapp
             dotnet new console
-            dotnet publish /p:TreatWarningsAsErrors=false -f net7.0 -c Release
+            dotnet publish -f net7.0 -c Release
             curl -sSfL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/otel-dotnet-auto-install.sh -O
             sh ./otel-dotnet-auto-install.sh
               test "$(ls -A "$HOME/.otel-dotnet-auto")"


### PR DESCRIPTION
## Why

There is a warning when running windows script tests after release 
(https://github.com/dszmigielski/opentelemetry-dotnet-instrumentation/actions/runs/3655289669
https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/3646951119)

## What

Remove checkout on windows tests in release-publish pipeline as it is not needed.

## Tests

Tested on fork https://github.com/dszmigielski/opentelemetry-dotnet-instrumentation/actions/runs/3656131606

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
