### PR TITLE
WCF instrumentation on .NET Framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This beta release is built on top of [OpenTelemetry .NET](https://github.com/ope
 
 ### Fixed
 
+- Fix WCF instrumenation on .NET Framework.
+
 ### Security
 
 ## [0.5.1-beta.2](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.5.1-beta.2)

--- a/docs/wcf-config.md
+++ b/docs/wcf-config.md
@@ -36,7 +36,7 @@ the clients you want to instrument:
       </netTcpBinding>
     </bindings>
     <client>
-      <endpoint address="http://localhost:9009/Telemetry" binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Shared.IStatusServiceContract" name="StatusService_Http" />
+      <endpoint address="http://localhost:9009/Telemetry" binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Client.NetFramework.IStatusServiceContract" name="StatusService_Http" />
     </client>
   </system.serviceModel>
 </configuration>
@@ -105,7 +105,7 @@ to instrument:
     </bindings>
     <services>
       <service>
-        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Shared.IStatusServiceContract" />
+        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Server.NetFramework.IStatusServiceContract" />
         <host>
           <baseAddresses>
             <add baseAddress="net.tcp://localhost:9090/Telemetry" />
@@ -152,7 +152,7 @@ instrument:
     </bindings>
     <services>
       <service name="TestApplication.Wcf.Server.NetFramework.StatusService" behaviorConfiguration="telemetry">
-        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" contract="TestApplication.Wcf.Shared.IStatusServiceContract" />
+        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" contract="TestApplication.Wcf.Server.NetFramework.IStatusServiceContract" />
         <host>
           <baseAddresses>
             <add baseAddress="net.tcp://localhost:9090/Telemetry" />

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
@@ -25,7 +25,11 @@ internal class WcfInitializer : InstrumentationInitializer
     private readonly PluginManager _pluginManager;
 
     public WcfInitializer(PluginManager pluginManager)
+#if NETFRAMEWORK
         : base("System.ServiceModel")
+#else
+        : base("System.ServiceModel.Primitives")
+#endif
     {
         _pluginManager = pluginManager;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
@@ -25,7 +25,7 @@ internal class WcfInitializer : InstrumentationInitializer
     private readonly PluginManager _pluginManager;
 
     public WcfInitializer(PluginManager pluginManager)
-        : base("System.ServiceModel.Primitives")
+        : base("System.ServiceModel")
     {
         _pluginManager = pluginManager;
     }

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/App.config
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/App.config
@@ -26,8 +26,8 @@
       </netTcpBinding>
     </bindings>
     <client>
-      <endpoint address="http://127.0.0.1:9009/Telemetry" binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Shared.IStatusServiceContract" name="StatusService_Http" />
-      <endpoint address="net.tcp://127.0.0.1:9090/Telemetry" binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Shared.IStatusServiceContract" name="StatusService_Tcp" />
+      <endpoint address="http://127.0.0.1:9009/Telemetry" binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Client.NetFramework.IStatusServiceContract" name="StatusService_Http" />
+      <endpoint address="net.tcp://127.0.0.1:9090/Telemetry" binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Client.NetFramework.IStatusServiceContract" name="StatusService_Tcp" />
     </client>
   </system.serviceModel>
   <runtime>

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/IStatusServiceContract.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/IStatusServiceContract.cs
@@ -1,4 +1,4 @@
-// <copyright file="StatusService.cs" company="OpenTelemetry Authors">
+// <copyright file="IStatusServiceContract.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,23 +14,14 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.ServiceModel;
 using System.Threading.Tasks;
 
-namespace TestApplication.Wcf.Server.NetFramework;
+namespace TestApplication.Wcf.Client.NetFramework;
 
-[ServiceBehavior(
-    Namespace = "http://opentelemetry.io/",
-    ConcurrencyMode = ConcurrencyMode.Multiple,
-    InstanceContextMode = InstanceContextMode.Single,
-    UseSynchronizationContext = false,
-    Name = "StatusService")]
-public class StatusService : IStatusServiceContract
+[ServiceContract(Namespace = "http://opentelemetry.io/", Name = "StatusService", SessionMode = SessionMode.Allowed)]
+public interface IStatusServiceContract
 {
-    public Task<StatusResponse> PingAsync(StatusRequest request)
-    {
-        return Task.FromResult(
-            new StatusResponse { ServerTime = DateTimeOffset.UtcNow });
-    }
+    [OperationContract]
+    Task<StatusResponse> PingAsync(StatusRequest request);
 }

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/Program.cs
@@ -17,7 +17,6 @@
 using System;
 using System.ServiceModel;
 using System.Threading.Tasks;
-using TestApplication.Wcf.Shared;
 
 namespace TestApplication.Wcf.Client.NetFramework;
 

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/StatusRequest.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/StatusRequest.cs
@@ -1,0 +1,26 @@
+// <copyright file="StatusRequest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Runtime.Serialization;
+
+namespace TestApplication.Wcf.Client.NetFramework;
+
+[DataContract]
+public class StatusRequest
+{
+    [DataMember]
+    public string Status { get; set; } = string.Empty;
+}

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/StatusResponse.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/StatusResponse.cs
@@ -1,0 +1,27 @@
+// <copyright file="StatusResponse.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Runtime.Serialization;
+
+namespace TestApplication.Wcf.Client.NetFramework;
+
+[DataContract]
+public class StatusResponse
+{
+    [DataMember]
+    public DateTimeOffset ServerTime { get; set; }
+}

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/StatusServiceClient.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/StatusServiceClient.cs
@@ -16,7 +16,6 @@
 
 using System.ServiceModel;
 using System.Threading.Tasks;
-using TestApplication.Wcf.Shared;
 
 namespace TestApplication.Wcf.Client.NetFramework;
 

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Client.NetFramework/TestApplication.Wcf.Client.NetFramework.csproj
@@ -1,12 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\TestApplication.Wcf.Shared\TestApplication.Wcf.Shared.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="System.ServiceModel" />

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/App.config
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/App.config
@@ -27,8 +27,8 @@
     </bindings>
     <services>
       <service name="TestApplication.Wcf.Server.NetFramework.StatusService">
-        <endpoint binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Shared.IStatusServiceContract" />
-        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Shared.IStatusServiceContract" />
+        <endpoint binding="basicHttpBinding" bindingConfiguration="basicHttpConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Server.NetFramework.IStatusServiceContract" />
+        <endpoint binding="netTcpBinding" bindingConfiguration="netTCPConfig" behaviorConfiguration="telemetry" contract="TestApplication.Wcf.Server.NetFramework.IStatusServiceContract" />
         <host>
           <baseAddresses>
             <add baseAddress="http://127.0.0.1:9009/Telemetry" />

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/IStatusServiceContract.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/IStatusServiceContract.cs
@@ -1,4 +1,4 @@
-// <copyright file="StatusService.cs" company="OpenTelemetry Authors">
+// <copyright file="IStatusServiceContract.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,23 +14,14 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.ServiceModel;
 using System.Threading.Tasks;
 
 namespace TestApplication.Wcf.Server.NetFramework;
 
-[ServiceBehavior(
-    Namespace = "http://opentelemetry.io/",
-    ConcurrencyMode = ConcurrencyMode.Multiple,
-    InstanceContextMode = InstanceContextMode.Single,
-    UseSynchronizationContext = false,
-    Name = "StatusService")]
-public class StatusService : IStatusServiceContract
+[ServiceContract(Namespace = "http://opentelemetry.io/", Name = "StatusService", SessionMode = SessionMode.Allowed)]
+public interface IStatusServiceContract
 {
-    public Task<StatusResponse> PingAsync(StatusRequest request)
-    {
-        return Task.FromResult(
-            new StatusResponse { ServerTime = DateTimeOffset.UtcNow });
-    }
+    [OperationContract]
+    Task<StatusResponse> PingAsync(StatusRequest request);
 }

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/StatusRequest.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/StatusRequest.cs
@@ -1,4 +1,4 @@
-// <copyright file="StatusService.cs" company="OpenTelemetry Authors">
+// <copyright file="StatusRequest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,23 +14,13 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.ServiceModel;
-using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace TestApplication.Wcf.Server.NetFramework;
 
-[ServiceBehavior(
-    Namespace = "http://opentelemetry.io/",
-    ConcurrencyMode = ConcurrencyMode.Multiple,
-    InstanceContextMode = InstanceContextMode.Single,
-    UseSynchronizationContext = false,
-    Name = "StatusService")]
-public class StatusService : IStatusServiceContract
+[DataContract]
+public class StatusRequest
 {
-    public Task<StatusResponse> PingAsync(StatusRequest request)
-    {
-        return Task.FromResult(
-            new StatusResponse { ServerTime = DateTimeOffset.UtcNow });
-    }
+    [DataMember]
+    public string Status { get; set; } = string.Empty;
 }

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/StatusResponse.cs
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/StatusResponse.cs
@@ -1,4 +1,4 @@
-// <copyright file="StatusService.cs" company="OpenTelemetry Authors">
+// <copyright file="StatusResponse.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,22 +15,13 @@
 // </copyright>
 
 using System;
-using System.ServiceModel;
-using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace TestApplication.Wcf.Server.NetFramework;
 
-[ServiceBehavior(
-    Namespace = "http://opentelemetry.io/",
-    ConcurrencyMode = ConcurrencyMode.Multiple,
-    InstanceContextMode = InstanceContextMode.Single,
-    UseSynchronizationContext = false,
-    Name = "StatusService")]
-public class StatusService : IStatusServiceContract
+[DataContract]
+public class StatusResponse
 {
-    public Task<StatusResponse> PingAsync(StatusRequest request)
-    {
-        return Task.FromResult(
-            new StatusResponse { ServerTime = DateTimeOffset.UtcNow });
-    }
+    [DataMember]
+    public DateTimeOffset ServerTime { get; set; }
 }

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.NetFramework/TestApplication.Wcf.Server.NetFramework.csproj
@@ -1,12 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\TestApplication.Wcf.Shared\TestApplication.Wcf.Shared.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="System.ServiceModel" />


### PR DESCRIPTION
## Why

We cannot require `System.ServiceModel.Primitives` to be loaded for WCF on .NET Framework, as it is not necessary for .NET Framework implementation.

Fixes #1704

## What

Change assembly required for lazy initialization of WCF on .NET Framework to `System.ServiceModel`.

## Tests

.NET Framework test applications were changed so they don't load `System.ServiceModel.Primitives`, tests were failing after this change: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/3694491904/jobs/6255742173

After changing required assembly tests pass once again: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/3694988032/jobs/6256835895

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
