### PR TITLE
Release 0.5.1-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.5.1-beta.2...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.5.1-beta.3...HEAD)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.5.1-beta.3](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.5.1-beta.3)
 
 This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
@@ -31,8 +45,6 @@ This beta release is built on top of [OpenTelemetry .NET](https://github.com/ope
 - Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
   [`1.4.0-rc.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.1)
 
-### Deprecated
-
 ### Removed
 
 - Remove support for Jaeger exporter.
@@ -40,8 +52,6 @@ This beta release is built on top of [OpenTelemetry .NET](https://github.com/ope
 ### Fixed
 
 - Fix WCF instrumentation on .NET Framework.
-
-### Security
 
 ## [0.5.1-beta.2](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.5.1-beta.2)
 

--- a/OpenTelemetry.DotNet.Auto.psm1
+++ b/OpenTelemetry.DotNet.Auto.psm1
@@ -197,7 +197,7 @@ function Install-OpenTelemetryCore() {
         [string]$InstallDir = "<auto>"
     )
 
-    $version = "v0.5.1-beta.2"
+    $version = "v0.5.1-beta.3"
     $installDir = Get-CLIInstallDir-From-InstallDir $InstallDir
     $tempDir = Get-Temp-Directory
     $dlPath = $null

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@ and instrument your .NET application using the provided Shell scripts.
 Example usage:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.2/otel-dotnet-auto-install.sh -O
+curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.3/otel-dotnet-auto-install.sh -O
 sh ./otel-dotnet-auto-install.sh
 . $HOME/.otel-dotnet-auto/instrument.sh
 OTEL_SERVICE_NAME=myapp OTEL_RESOURCE_ATTRIBUTES=deployment.environment=staging,service.version=1.0.0 dotnet run
@@ -128,7 +128,7 @@ uses environment variables as parameters:
 | `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
 | `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
 | `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `v0.5.1-beta.2`           |
+| `VERSION`               | Version to download                                              | No       | `v0.5.1-beta.3`           |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -149,7 +149,7 @@ Example usage (run as administrator):
 
 ```powershell
 # Download and import the module
-$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.2/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.3/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path
 Import-Module $download_path

--- a/nuget/OpenTelemetry.AutoInstrumentation.nuspec
+++ b/nuget/OpenTelemetry.AutoInstrumentation.nuspec
@@ -16,7 +16,6 @@
         <dependency id="OpenTelemetry" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Api" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.Console" version="1.4.0-rc.1" />
-        <dependency id="OpenTelemetry.Exporter.Jaeger" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.OpenTelemetryProtocol" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.Prometheus.HttpListener" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.Zipkin" version="1.4.0-rc.1" />
@@ -35,7 +34,6 @@
         <dependency id="OpenTelemetry" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Api" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.Console" version="1.4.0-rc.1" />
-        <dependency id="OpenTelemetry.Exporter.Jaeger" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.OpenTelemetryProtocol" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.Prometheus.HttpListener" version="1.4.0-rc.1" />
         <dependency id="OpenTelemetry.Exporter.Zipkin" version="1.4.0-rc.1" />

--- a/nuget/OpenTelemetry.AutoInstrumentation.nuspec
+++ b/nuget/OpenTelemetry.AutoInstrumentation.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OpenTelemetry.AutoInstrumentation</id>
-    <version>0.5.1-beta.2</version>
+    <version>0.5.1-beta.3</version>
     <description>OpenTelemetry Auto-Instrumentation</description>
     <authors>OpenTelemetry Authors</authors>
     <owners>OpenTelemetry Authors</owners>

--- a/otel-dotnet-auto-install.sh
+++ b/otel-dotnet-auto-install.sh
@@ -31,7 +31,7 @@ esac
 
 test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-test -z "$VERSION" && VERSION="v0.5.1-beta.2"
+test -z "$VERSION" && VERSION="v0.5.1-beta.3"
 
 RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
 ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"

--- a/src/OpenTelemetry.AutoInstrumentation.Native/version.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.5.1-beta.2";
+constexpr auto PROFILER_VERSION = "0.5.1-beta.3";

--- a/src/OpenTelemetry.AutoInstrumentation/Constants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Constants.cs
@@ -20,7 +20,7 @@ internal static class Constants
 {
     public static class Tracer
     {
-        public const string Version = "0.5.1-beta.2";
+        public const string Version = "0.5.1-beta.3";
         public const string AutoInstrumentationVersionName = "telemetry.auto.version";
     }
 


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes N/A.

SIG agreement.

## What

Release 0.5.1-beta.3
## [0.5.1-beta.3](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.5.1-beta.3)

This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):

- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.4.0-rc.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.1)
- `System.Diagnostics.DiagnosticSource`: [`7.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/7.0.0)

### Added

- Add support for NServiceBus metrics and traces instrumentations.
- Add support for Elasticsearch traces instrumentations.
- Add plugin support for
 `ConfigureTracesOptions(StackExchangeRedisCallsInstrumentationOptions options)`.
- Add plugin support for
 `ConfigureMetricsOptions(AspNetCoreMetricsInstrumentationOptions options)`.
- Add automatic assembly redirection for .NET Framework applications. The redirection
 can be enabled or disabled via the
 `OTEL_DOTNET_AUTO_NETFX_REDIRECT_ENABLED` environment variable.
 See the [additional settings](./docs/config.md#additional-settings) table for details.

### Changed

- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.4.0-rc.1`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.1)

### Removed

- Remove support for Jaeger exporter.

### Fixed

- Fix WCF instrumentation on .NET Framework.

## Tests

- [x] CI - validation documentation fail due to lack of tag.
- [x] `nuke Workflow` - MacOS
- [x] `nuke Worklfow` - Windows

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
