### PR TITLE
Automate generation of integrations.json file

### DIFF
--- a/build/Build.Steps.cs
+++ b/build/Build.Steps.cs
@@ -231,10 +231,19 @@ partial class Build
         .DependsOn(PublishNativeProfilerLinux)
         .DependsOn(PublishNativeProfilerMacOs);
 
+    Target GenerateIntegrationsJson => _ => _
+        .After(PublishManagedProfiler)
+        .Executes(() =>
+        {
+            var generatorTool = Solution.GetProject(Projects.Tools.IntegrationsJsonGenerator);
+
+            DotNetRun(s => s
+                .SetProjectFile(generatorTool));
+        });
+
     Target CopyIntegrationsJson => _ => _
         .Unlisted()
-        .After(Clean)
-        .After(CreateRequiredDirectories)
+        .After(GenerateIntegrationsJson)
         .Executes(() =>
         {
             var source = RootDirectory / "integrations.json";

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -89,6 +89,7 @@ partial class Build : NukeBuild
         .DependsOn(GenerateNetFxAssemblyRedirectionSource)
         .DependsOn(CompileNativeSrc)
         .DependsOn(PublishNativeProfiler)
+        .DependsOn(GenerateIntegrationsJson)
         .DependsOn(CopyIntegrationsJson)
         .DependsOn(CopyInstrumentScripts);
 

--- a/build/Projects.cs
+++ b/build/Projects.cs
@@ -7,6 +7,11 @@ public static class Projects
     public const string AutoInstrumentationAdditionalDeps = "OpenTelemetry.AutoInstrumentation.AdditionalDeps";
     public const string AutoInstrumentationAspNetCoreBootstrapper = "OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper";
 
+    public static class Mocks
+    {
+        public const string AutoInstrumentationMock = "OpenTelemetry.AutoInstrumentation.Mock";
+    }
+
     public static class Tests
     {
         public const string AutoInstrumentationNativeTests = "OpenTelemetry.AutoInstrumentation.Native.Tests";
@@ -21,8 +26,9 @@ public static class Projects
         }
     }
 
-    public static class Mocks
+    public static class Tools
     {
-        public const string AutoInstrumentationMock = "OpenTelemetry.AutoInstrumentation.Mock";
+        public const string IntegrationsJsonGenerator = "IntegrationsJsonGenerator";
+
     }
 }

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -95,21 +95,6 @@ nuke MarkdownLintFix
 
 All MarkdownLint tasks require [Node.js](https://nodejs.org/) installed locally.
 
-## Maintain integrations.json
-
-[`integrations.json`](../integrations.json) can be regenerated using
-[`Integrations Json Generator`](../tools/IntegrationsJsonGenerator) project.
-
-To update this file you should
-
-1. Modify bytecode instrumentation (especially [`InstrumentMethodAttribute`](../src/OpenTelemetry.AutoInstrumentation/Instrumentations/InstrumentMethodAttribute.cs)s).
-1. Execute `nuke BuildTracer` to generate auto instrumentation library - source
-   for the generator.
-1. Execute [`Integrations Json Generator`](../tools/IntegrationsJsonGenerator).
-1. Execute `nuke BuildTracer` to apply changes in `integrations.json`.
-
-Remember to commit changes in `integrations.json`.
-
 ## Manual testing
 
 ### Test environment

--- a/tools/IntegrationsJsonGenerator/IntegrationsJsonGenerator.csproj
+++ b/tools/IntegrationsJsonGenerator/IntegrationsJsonGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Why

There is no need for the generation of the integrations.json to be a manual step.

## What

- Include the run of the `IntegrationsJsonGenerator` as part of the `BuildTracer` target.
- Keep the `integrations.json` under version control so any changes to it are visible and reviewed.

## Tests

The test added when doing .NET Framework automatic direction will report any sources changed during the CI run, see https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/7d49514a0d19fb5d164073f58ce8b7661222f97c/.github/workflows/ci.yml#L85

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
- [X] Documentation is updated.
~~- [ ] New features are covered by tests.~~
