### PR TITLE
Make IDuckType public

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -12,6 +12,10 @@ OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(Sys
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(System.Diagnostics.Activity! activity, object! state, System.DateTimeOffset? startTime) -> void
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(System.Diagnostics.Activity? activity, object! state) -> void
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.State.get -> object?
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Instance.get -> object!
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.ToString() -> string!
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Type.get -> System.Type!
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ExecuteAsyncIntegration
 OpenTelemetry.AutoInstrumentation.Instrumentations.Logger.LoggingBuilderIntegration
 OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration

--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -12,6 +12,10 @@ OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(Sys
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(System.Diagnostics.Activity! activity, object! state, System.DateTimeOffset? startTime) -> void
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.CallTargetState(System.Diagnostics.Activity? activity, object! state) -> void
 OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState.State.get -> object?
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Instance.get -> object!
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.ToString() -> string!
+OpenTelemetry.AutoInstrumentation.DuckTyping.IDuckType.Type.get -> System.Type!
 OpenTelemetry.AutoInstrumentation.Instrumentations.GraphQL.ExecuteAsyncIntegration
 OpenTelemetry.AutoInstrumentation.Instrumentations.Logger.LoggingBuilderIntegration
 OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration

--- a/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IDuckType.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/DuckTyping/IDuckType.cs
@@ -14,12 +14,16 @@
 // limitations under the License.
 // </copyright>
 
+using System.ComponentModel;
+
 namespace OpenTelemetry.AutoInstrumentation.DuckTyping;
 
 /// <summary>
 /// Duck type interface
 /// </summary>
-internal interface IDuckType
+[Browsable(false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IDuckType
 {
     /// <summary>
     /// Gets instance


### PR DESCRIPTION


## Why

<!-- Explain why the changes are needed.  -->

Fixes issue detected by #1994

## What

Make IDuckType public
to be able to run MySqlData Integration for 8.0.31+
8.0.32 is still not working. It requires changes in instrumentation package.

## Tests


Manual tests with   MySql.Data 8.0.31.
CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
