### PR TITLE
Document the required PowerShell version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -177,6 +177,9 @@ Get-Command -Module OpenTelemetry.DotNet.Auto
 Get-Help Install-OpenTelemetryCore -Detailed
 ```
 
+⚠️ The PowerShell module works only on PowerShell 5.1 which
+is the one installed by default on Windows.
+
 ⚠️ Register for IIS and Windows Service performs a service restart.
 
 ## Instrument a container

--- a/docs/README.md
+++ b/docs/README.md
@@ -177,8 +177,8 @@ Get-Command -Module OpenTelemetry.DotNet.Auto
 Get-Help Install-OpenTelemetryCore -Detailed
 ```
 
-⚠️ The PowerShell module works only on PowerShell 5.1 which
-is the one installed by default on Windows.
+⚠️ The PowerShell module works only on PowerShell 5.1
+which is the one installed by default on Windows.
 
 ⚠️ Register for IIS and Windows Service performs a service restart.
 


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2018

## What

Document the required PowerShell version

We could also consider creating a `.psd1` file and mark that the module requires `Desktop` edition and `5.1` version. Even if we do it I think it is good to have the info in the docs. I have created https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2079
