### PR TITLE
Fix project selection based on directory

### DIFF
--- a/build/ProjectsHelper.cs
+++ b/build/ProjectsHelper.cs
@@ -1,10 +1,9 @@
+using Nuke.Common;
+using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 
 public static class ProjectsHelper
 {
-    private const string SrcDirName = "src";
-    private const string TestDirName = "test";
-
     private const string NativeProjectMarker = "Native"; // Contains word Native
     private const string TestsProjectMarker = "Tests"; // Ends with word Tests
     private const string NetFrameworkMarker = ".NetFramework"; // Ends with word .NetFramework
@@ -13,13 +12,16 @@ public static class ProjectsHelper
     private const string TestApplicationSelector = "TestApplication.*";
     private const string TestLibrarySelector = "TestLibrary.*";
 
+    private readonly static AbsolutePath SrcDirectory = NukeBuild.RootDirectory / "src";
+    private readonly static AbsolutePath TestDirectory = NukeBuild.RootDirectory / "test";
+
     public static IEnumerable<Project> GetManagedSrcProjects(this Solution solution)
     {
         return solution
             .GetProjects(CoreProjectSelector)
             .Where(x =>
                 // Should contain in the src directory
-                x.Directory.ToString().Contains(SrcDirName) &&
+                SrcDirectory.Contains(x.Directory) &&
                 // Should not be native projects
                 !x.Name.Contains(NativeProjectMarker));
     }
@@ -30,7 +32,7 @@ public static class ProjectsHelper
             .GetProjects(CoreProjectSelector)
             .Where(x =>
                 // Should contain in the src directory
-                x.Directory.ToString().Contains(SrcDirName) &&
+                SrcDirectory.Contains(x.Directory) &&
                 // Should be native projects
                 x.Name.Contains(NativeProjectMarker));
     }
@@ -47,7 +49,7 @@ public static class ProjectsHelper
             .GetProjects(CoreProjectSelector)
             .Where(x =>
                 // Should contain in the test directory
-                x.Directory.ToString().Contains(TestDirName) &&
+                TestDirectory.Contains(x.Directory) &&
                 // Should not be native projects
                 !x.Name.Contains(NativeProjectMarker) &&
                 // Should be test projects


### PR DESCRIPTION
## Why

Avoid building test projects if your repo has "repo" in its absolute path

## What

Avoid building test projects due to a false positive selection if the root path contained `src` some where. This can save more than 30 seconds in certain cases.

## Tests

Built locally.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
