### PR TITLE
Temporarily skip flaky test

### DIFF
--- a/test/IntegrationTests/CustomSdkTests.cs
+++ b/test/IntegrationTests/CustomSdkTests.cs
@@ -67,7 +67,7 @@ public class CustomSdkTests : TestHelper
         collector.ResourceExpector.AssertExpectations();
     }
 
-    [Fact]
+    [Fact(Skip = "Flaky, needs investigation.")]
     [Trait("Category", "EndToEnd")]
     [Trait("Containers", "Linux")]
     public void SubmitsMetrics()


### PR DESCRIPTION
## Why

Test added in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/2081 seems to be flaky. Ignore it temporarily.