### PR TITLE
Standardize conditional compilation

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
@@ -43,7 +43,7 @@ internal static class ContinuationsHelper
         return typeof(object);
     }
 
-#if !NET6_0_OR_GREATER
+#if NETFRAMEWORK
     internal static TTo Convert<TFrom, TTo>(TFrom value)
     {
         return Converter<TFrom, TTo>.Convert(value);

--- a/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetCore.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetCore.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Logger/LoggingBuilderIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Logger/LoggingBuilderIntegration.cs
@@ -43,7 +43,7 @@ public static class LoggingBuilderIntegration
     /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
     internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
     {
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
         if (instance is not null)
         {
             var logBuilderExtensionsType = Type.GetType("OpenTelemetry.AutoInstrumentation.Logger.LogBuilderExtensions, OpenTelemetry.AutoInstrumentation");

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MySqlData/MySqlConnectionStringBuilderIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MySqlData/MySqlConnectionStringBuilderIntegration.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.AutoInstrumentation.Instrumentations.MySqlData;
     type: InstrumentationType.Trace)]
 public static class MySqlConnectionStringBuilderIntegration
 {
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
     private static readonly object TrueAsObject = true;
 #endif
 
@@ -49,7 +49,7 @@ public static class MySqlConnectionStringBuilderIntegration
     internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TReturn returnValue, Exception exception, CallTargetState state)
         where TTarget : struct
     {
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
         var alwaysReturnTrue = (TReturn)TrueAsObject;
 
         return new CallTargetReturn<TReturn>(alwaysReturnTrue);

--- a/src/OpenTelemetry.AutoInstrumentation/Logger/LogBuilderExtensions.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Logger/LogBuilderExtensions.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
 using FluentAssertions;
 using FluentAssertions.Execution;
 using IntegrationTests.Helpers;

--- a/test/IntegrationTests/LogTests.cs
+++ b/test/IntegrationTests/LogTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
 using IntegrationTests.Helpers;
 using Xunit.Abstractions;
 

--- a/test/IntegrationTests/MassTransitTests.cs
+++ b/test/IntegrationTests/MassTransitTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/IntegrationTests/MongoDBCollection.cs
+++ b/test/IntegrationTests/MongoDBCollection.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;

--- a/test/IntegrationTests/MongoDBTests.cs
+++ b/test/IntegrationTests/MongoDBTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NETFRAMEWORK
+#if NET6_0_OR_GREATER
 using IntegrationTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -144,7 +144,7 @@ public class SmokeTests : TestHelper
         collector.ResourceExpector.AssertExpectations();
     }
 
-#if !NETFRAMEWORK // The feature is not supported on .NET Framework
+#if NET6_0_OR_GREATER // The feature is not supported on .NET Framework
     [Fact]
     [Trait("Category", "EndToEnd")]
     public void LogsResource()
@@ -196,7 +196,7 @@ public class SmokeTests : TestHelper
         collector.AssertExpectations();
     }
 
-#if NETFRAMEWORK // The test is flaky on Linux and macOS, becasue of https://github.com/dotnet/runtime/issues/28658#issuecomment-462062760
+#if NETFRAMEWORK // The test is flaky on Linux and macOS, because of https://github.com/dotnet/runtime/issues/28658#issuecomment-462062760
     [Fact]
     [Trait("Category", "EndToEnd")]
     public void PrometheusExporter()
@@ -245,7 +245,7 @@ public class SmokeTests : TestHelper
     }
 #endif
 
-#if !NETFRAMEWORK // The feature is not supported on .NET Framework
+#if NET6_0_OR_GREATER // The feature is not supported on .NET Framework
     [Fact]
     [Trait("Category", "EndToEnd")]
     public void SubmitLogs()

--- a/test/IntegrationTests/WcfNetFrameworkTests.cs
+++ b/test/IntegrationTests/WcfNetFrameworkTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if NET462
+#if NETFRAMEWORK
 using Xunit.Abstractions;
 
 namespace IntegrationTests;


### PR DESCRIPTION
## Why

To have unified code across whole project. 

## What

`NETFRAMEWORK` for .NET Fx.
`NET6_0_OR_GREATER` for .NET.

Few exception like .NET462 for cases where is is really needed (switch to net472 test application path).

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
