### PR TITLE
Fix transient dependencies generator run order

### DIFF
--- a/build/Build.Steps.Windows.cs
+++ b/build/Build.Steps.Windows.cs
@@ -122,7 +122,7 @@ partial class Build
 
     Target GenerateNetFxTransientDependencies => _ => _
         .Unlisted()
-        .After(Clean)
+        .After(Restore)
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
         {

--- a/build/Build.Steps.Windows.cs
+++ b/build/Build.Steps.Windows.cs
@@ -122,6 +122,7 @@ partial class Build
 
     Target GenerateNetFxTransientDependencies => _ => _
         .Unlisted()
+        .After(Clean)
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
         {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -85,6 +85,7 @@ partial class Build : NukeBuild
         .After(Clean)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(Restore)
+        .DependsOn(GenerateNetFxTransientDependencies)
         .DependsOn(CompileManagedSrc)
         .DependsOn(PublishManagedProfiler)
         .DependsOn(GenerateNetFxAssemblyRedirectionSource)

--- a/tools/DependencyListGenerator/DotNetOutdated/Services/DotNetRunner.cs
+++ b/tools/DependencyListGenerator/DotNetOutdated/Services/DotNetRunner.cs
@@ -27,6 +27,9 @@ public class DotNetRunner
 {
     public RunStatus Run(string workingDirectory, string[] arguments)
     {
+        Console.WriteLine("DotNetRunner - WorkingDirectory: {0}", workingDirectory);
+        Console.WriteLine("DotNetRunner - Arguments: {0}", string.Join(" ", arguments));
+
         var psi = new ProcessStartInfo(DotNetExe.FullPathOrDefault(), string.Join(" ", arguments))
         {
             WorkingDirectory = workingDirectory,

--- a/tools/DependencyListGenerator/DotNetOutdated/Services/DotNetRunner.cs
+++ b/tools/DependencyListGenerator/DotNetOutdated/Services/DotNetRunner.cs
@@ -27,9 +27,6 @@ public class DotNetRunner
 {
     public RunStatus Run(string workingDirectory, string[] arguments)
     {
-        Console.WriteLine("DotNetRunner - WorkingDirectory: {0}", workingDirectory);
-        Console.WriteLine("DotNetRunner - Arguments: {0}", string.Join(" ", arguments));
-
         var psi = new ProcessStartInfo(DotNetExe.FullPathOrDefault(), string.Join(" ", arguments))
         {
             WorkingDirectory = workingDirectory,


### PR DESCRIPTION
## Why

Towards #2097 

_(I would like to keep the issue open to track the state for some time, the main flow should not be affected but there could be some corner cases left)_

**Revert this PR if things are going south still.**

## What

* Reverts #2126 
* Orders `GenerateNetFxTransientDependencies` to run after `Restore`

## Tests

Existing.
