### PR TITLE
Release 0.6.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.5.1-beta.3...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.6.0-beta.1...HEAD)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.6.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.6.0-beta.1)
 
 This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
@@ -52,16 +66,10 @@ This beta release is built on top of [OpenTelemetry .NET](https://github.com/ope
 - Change instrumentation id for ASP.NET Core traces and metrics instrumentation
   from `AspNet` to `ASPNETCORE`.
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - Fix console error messages `Log: Exception creating FileSink`
  [#1885](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1885)
-
-### Security
 
 ## [0.5.1-beta.3](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.5.1-beta.3)
 

--- a/OpenTelemetry.DotNet.Auto.psm1
+++ b/OpenTelemetry.DotNet.Auto.psm1
@@ -213,7 +213,7 @@ function Install-OpenTelemetryCore() {
         [string]$LocalPath
     )
 
-    $version = "v0.5.1-beta.3"
+    $version = "v0.6.0-beta.1"
     $installDir = Get-CLIInstallDir-From-InstallDir $InstallDir
     $archivePath = $null
     $deleteArchive = $true

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,7 +138,7 @@ Example usage:
 
 ```sh
 # Download the bash script
-curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.3/otel-dotnet-auto-install.sh -O
+curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0-beta.1/otel-dotnet-auto-install.sh -O
 
 # Install core files
 sh ./otel-dotnet-auto-install.sh
@@ -158,7 +158,7 @@ uses environment variables as parameters:
 | `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
 | `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
 | `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `v0.5.1-beta.3`           |
+| `VERSION`               | Version to download                                              | No       | `v0.6.0-beta.1`           |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -179,7 +179,7 @@ Example usage (run as administrator):
 
 ```powershell
 # Download the module
-$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.5.1-beta.3/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0-beta.1/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path
 

--- a/nuget/OpenTelemetry.AutoInstrumentation.nuspec
+++ b/nuget/OpenTelemetry.AutoInstrumentation.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OpenTelemetry.AutoInstrumentation</id>
-    <version>0.5.1-beta.3</version>
+    <version>0.6.0-beta.1</version>
     <description>OpenTelemetry Auto-Instrumentation</description>
     <authors>OpenTelemetry Authors</authors>
     <owners>OpenTelemetry Authors</owners>

--- a/otel-dotnet-auto-install.sh
+++ b/otel-dotnet-auto-install.sh
@@ -31,7 +31,7 @@ esac
 
 test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-test -z "$VERSION" && VERSION="v0.5.1-beta.3"
+test -z "$VERSION" && VERSION="v0.6.0-beta.1"
 
 RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
 ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
@@ -6,7 +6,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>0.5.1</Version>
+    <Version>0.6.0</Version>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 # Project definition
 # ******************************************************
 
-project("OpenTelemetry.AutoInstrumentation.Native" VERSION 0.5.1)
+project("OpenTelemetry.AutoInstrumentation.Native" VERSION 0.6.0)
 
 # ******************************************************
 # Environment detection

--- a/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
@@ -67,12 +67,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "The OpenTelemetry Authors"
             VALUE "FileDescription", "OpenTelemetry CLR Profiler"
-            VALUE "FileVersion", "0.5.1.0"
+            VALUE "FileVersion", "0.6.0.0"
             VALUE "InternalName", "OpenTelemetry.AutoInstrumentation.Native.DLL"
             VALUE "LegalCopyright", "Copyright 2021 The OpenTelemetry Authors"
             VALUE "OriginalFilename", "OpenTelemetry.AutoInstrumentation.Native.DLL"
             VALUE "ProductName", "OpenTelemetry .NET AutoInstrumentation"
-            VALUE "ProductVersion", "0.5.1"
+            VALUE "ProductVersion", "0.6.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -27,7 +27,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"OpenTelemetry", {1, 0, 0, 0} },
         { L"OpenTelemetry.Api", {1, 0, 0, 0} },
         { L"OpenTelemetry.Api.ProviderBuilderExtensions", {1, 0, 0, 0} },
-        { L"OpenTelemetry.AutoInstrumentation", {0, 5, 1, 0} },
+        { L"OpenTelemetry.AutoInstrumentation", {0, 6, 0, 0} },
         { L"OpenTelemetry.Exporter.Console", {1, 0, 0, 0} },
         { L"OpenTelemetry.Exporter.OpenTelemetryProtocol", {1, 0, 0, 0} },
         { L"OpenTelemetry.Exporter.Prometheus.HttpListener", {1, 0, 0, 0} },

--- a/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
@@ -64,10 +64,10 @@ const WSTRING opentelemetry_autoinstrumentation_loader_assemblyName = WStr("Open
 const WSTRING managed_profiler_name = WStr("OpenTelemetry.AutoInstrumentation");
 
 const WSTRING managed_profiler_full_assembly_version =
-    WStr("OpenTelemetry.AutoInstrumentation, Version=0.5.1.0, Culture=neutral, PublicKeyToken=null");
+    WStr("OpenTelemetry.AutoInstrumentation, Version=0.6.0.0, Culture=neutral, PublicKeyToken=null");
 
 const WSTRING managed_profiler_full_assembly_version_strong_name =
-    WStr("OpenTelemetry.AutoInstrumentation, Version=0.5.1.0, Culture=neutral, PublicKeyToken=c0db600a13f60b51");
+    WStr("OpenTelemetry.AutoInstrumentation, Version=0.6.0.0, Culture=neutral, PublicKeyToken=c0db600a13f60b51");
 
 const WSTRING nonwindows_nativemethods_type = WStr("OpenTelemetry.AutoInstrumentation.NativeMethods+NonWindows");
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/version.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.5.1-beta.3";
+constexpr auto PROFILER_VERSION = "0.6.0-beta.1";

--- a/src/OpenTelemetry.AutoInstrumentation/Constants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Constants.cs
@@ -20,7 +20,7 @@ internal static class Constants
 {
     public static class Tracer
     {
-        public const string Version = "0.5.1-beta.3";
+        public const string Version = "0.6.0-beta.1";
         public const string AutoInstrumentationVersionName = "telemetry.auto.version";
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonExcludedAssets.props" />
 
   <PropertyGroup>
-    <Version>0.5.1</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes N/A.

SIG agreement.

## What

## [0.6.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.6.0-beta.1)

This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):

- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.4.0-rc.3`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.3)
- `System.Diagnostics.DiagnosticSource`: [`7.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/7.0.0)

### Added

- Support configuring `OTEL_*` settings using `App.config` and `Web.config`.
- Add support for Quartz traces instrumentation.
- Add support for EntityFrameworkCore traces instrumentations.
- Add plugin support for
  `ResourceBuilder ConfigureResource(ResourceBuilder builder)`.

### Changed

- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.4.0-rc.3`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.3)
- Move `OpenTelemetry.AutoInstrumentation.Native.so` to `linux-x64` directory
  in `tracer-home` for Linux glibc, `OpenTelemetry.AutoInstrumentation.Native.so`
  to `linux-musl-x64` for Linux musl and
  `OpenTelemetry.AutoInstrumentation.Native.dylib`
  to `osx-x64` for MacOS.
- Change the way to manage enabled instrumentations. The following environmental
  variables:
  - `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS`,
  - `OTEL_DOTNET_AUTO_TRACES_DISABLED_INSTRUMENTATIONS`,
  - `OTEL_DOTNET_AUTO_METRICS_ENABLED_INSTRUMENTATIONS`,
  - `OTEL_DOTNET_AUTO_METRICS_DISABLED_INSTRUMENTATIONS`,
  - `OTEL_DOTNET_AUTO_LOGS_ENABLED_INSTRUMENTATIONS`,
  - `OTEL_DOTNET_AUTO_LOGS_DISABLED_INSTRUMENTATIONS`

  are replaced by:

  - `OTEL_DOTNET_AUTO_INSTRUMENTATION_ENABLED`,
  - `OTEL_DOTNET_AUTO_TRACES_INSTRUMENTATION_ENABLED`,
  - `OTEL_DOTNET_AUTO_TRACES_{0}_INSTRUMENTATION_ENABLED`,
  - `OTEL_DOTNET_AUTO_METRICS_INSTRUMENTATION_ENABLED`,
  - `OTEL_DOTNET_AUTO_METRICS_{0}_INSTRUMENTATION_ENABLED`,
  - `OTEL_DOTNET_AUTO_LOGS_INSTRUMENTATION_ENABLED`,
  - `OTEL_DOTNET_AUTO_LOGS_{0}_INSTRUMENTATION_ENABLED`.

- Change instrumentation id for ASP.NET Core traces and metrics instrumentation
  from `AspNet` to `ASPNETCORE`.

### Fixed

- Fix console error messages `Log: Exception creating FileSink`
 [#1885](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1885)


## Tests

- [x] CI
- [x] Windows with linux Container
- [x] MacOS

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
