### PR TITLE
[CI] Workflow to build and push centos build image

### DIFF
--- a/.github/workflows/push_centos_build_image.yml
+++ b/.github/workflows/push_centos_build_image.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-push-image:
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: centos7-build-image
+      IMAGE_NAME: ${{ github.repository }}-centos7-build-image
     runs-on: ubuntu-20.04
     permissions:
       contents: read

--- a/.github/workflows/push_centos_build_image.yml
+++ b/.github/workflows/push_centos_build_image.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: ./docker
-          file: centos.dockerfile
+          file: ./docker/centos.dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push_centos_build_image.yml
+++ b/.github/workflows/push_centos_build_image.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/push_centos_build_image.yml
+++ b/.github/workflows/push_centos_build_image.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -28,12 +28,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4.3.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4.0.0
         with:
           context: ./docker
           file: centos.dockerfile

--- a/.github/workflows/push_centos_build_image.yml
+++ b/.github/workflows/push_centos_build_image.yml
@@ -1,0 +1,42 @@
+name: Build and push centos7 base image
+
+# workflow based on https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-centos7-build-image
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./docker
+          file: centos.dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/push_centos_build_image.yml
+++ b/.github/workflows/push_centos_build_image.yml
@@ -4,12 +4,11 @@ name: Build and push centos7 base image
 on:
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-centos7-build-image
-
 jobs:
   build-and-push-image:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: centos7-build-image
     runs-on: ubuntu-20.04
     permissions:
       contents: read
@@ -35,7 +34,6 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4.0.0
         with:
-          context: ./docker
           file: ./docker/centos.dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/docker/centos.dockerfile
+++ b/docker/centos.dockerfile
@@ -23,4 +23,6 @@ RUN git clone --depth 1 --branch release/12.x https://github.com/llvm/llvm-proje
     # use gcc_install_prefix to tell clang where gcc containing required libstdc++ is installed
     && scl enable devtoolset-9 -- cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -DGCC_INSTALL_PREFIX=/opt/rh/devtoolset-9/root/usr/ -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=1 -G "Unix Makefiles" ../llvm \
     && make install \
+    && cd ../../ \
     && rm -rf llvm-project
+


### PR DESCRIPTION
## Why

Towards #2083 
## What

Manually triggered CI workflow to build and publish centos base build image.
Workflow based on https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages

## Tests

Tested on [fork](https://github.com/lachmatt/opentelemetry-dotnet-instrumentation/actions/runs/4112657059)

## Checklist

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
