### PR TITLE
Boolean values - support only true/false case insensitive

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="cor_profiler.h" />
     <ClInclude Include="cor_profiler_base.h" />
     <ClInclude Include="environment_variables.h" />
+    <ClInclude Include="environment_variables_parser.h" />
     <ClInclude Include="environment_variables_util.h" />
     <ClInclude Include="il_rewriter.h" />
     <ClInclude Include="il_rewriter_wrapper.h" />

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_parser.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_parser.h
@@ -1,0 +1,20 @@
+#ifndef OTEL_CLR_PROFILER_ENVIRONMENT_VARIABLES_PARSER_H_
+#define OTEL_CLR_PROFILER_ENVIRONMENT_VARIABLES_PARSER_H_
+
+#define TrueCondition(EXPR)                      \
+    ((EXPR).size() == 4                          \
+     && ((EXPR)[0] == L't' || (EXPR)[0] == L'T') \
+     && ((EXPR)[1] == L'r' || (EXPR)[1] == L'R') \
+     && ((EXPR)[2] == L'u' || (EXPR)[2] == L'U') \
+     && ((EXPR)[3] == L'e' || (EXPR)[3] == L'E'))
+
+#define FalseCondition(EXPR)                    \
+    ((EXPR).size() == 5                         \
+    && ((EXPR)[0] == L'f' || (EXPR)[0] == L'F') \
+    && ((EXPR)[1] == L'a' || (EXPR)[1] == L'A') \
+    && ((EXPR)[2] == L'l' || (EXPR)[2] == L'L') \
+    && ((EXPR)[3] == L's' || (EXPR)[3] == L'S') \
+    && ((EXPR)[4] == L'e' || (EXPR)[4] == L'E'))
+
+
+#endif  // OTEL_CLR_PROFILER_ENVIRONMENT_VARIABLES_PARSER_H_

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.h
@@ -2,37 +2,38 @@
 #define OTEL_CLR_PROFILER_ENVIRONMENT_VARIABLES_UTIL_H_
 
 #include "environment_variables.h"
+#include "environment_variables_parser.h"
 #include "string.h"
 #include "util.h"
 
-#define CheckIfTrue(EXPR)                                               \
-  static int sValue = -1;                                               \
-  if (sValue == -1) {                                                   \
-    const auto envValue = EXPR;                                         \
-    sValue = envValue == WStr("1") || envValue == WStr("true") ? 1 : 0; \
-  }                                                                     \
+#define CheckIfTrue(EXPR)                                  \
+  static int sValue = -1;                                  \
+  if (sValue == -1) {                                      \
+    const auto envValue = EXPR;                            \
+    sValue              = TrueCondition(envValue) ? 1 : 0; \
+  }                                                        \
   return sValue == 1;
 
-#define CheckIfFalse(EXPR)                                               \
-  static int sValue = -1;                                                \
-  if (sValue == -1) {                                                    \
-    const auto envValue = EXPR;                                          \
-    sValue = envValue == WStr("0") || envValue == WStr("false") ? 1 : 0; \
-  }                                                                      \
+#define CheckIfFalse(EXPR)                                  \
+  static int sValue = -1;                                   \
+  if (sValue == -1) {                                       \
+    const auto envValue = EXPR;                             \
+    sValue              = FalseCondition(envValue) ? 1 : 0; \
+  }                                                         \
   return sValue == 1;
 
-#define ToBooleanWithDefault(EXPR, DEFAULT)                          \
-  static int sValue = -1;                                            \
-  if (sValue == -1) {                                                \
-    const auto envValue = EXPR;                                      \
-    if (envValue == WStr("1") || envValue == WStr("true")) {         \
-      sValue = 1;                                                    \
-    } else if (envValue == WStr("0") || envValue == WStr("false")) { \
-      sValue = 0;                                                    \
-    } else {                                                         \
-      sValue = DEFAULT;                                              \
-    }                                                                \
-  }                                                                  \
+#define ToBooleanWithDefault(EXPR, DEFAULT) \
+  static int sValue = -1;                   \
+  if (sValue == -1) {                       \
+    const auto envValue = EXPR;             \
+    if (TrueCondition(envValue)) {          \
+      sValue = 1;                           \
+    } else if (FalseCondition(envValue)) {  \
+      sValue = 0;                           \
+    } else {                                \
+      sValue = DEFAULT;                     \
+    }                                       \
+  }                                         \
   return sValue == 1;
 
 namespace trace {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "environment_variables_parser.h"
 #include "pal.h"
 #include "string.h"
 
@@ -112,11 +113,11 @@ std::vector<WSTRING> GetEnabledEnvironmentValues(const bool enabled_by_default,
     {
         bool       enabled   = enabled_by_default;
         const auto env_value = GetEnvironmentValue(value.second);
-        if (env_value == WStr("true"))
+        if (TrueCondition(env_value))
         {
             enabled = true;
         }
-        else if (env_value == WStr("false"))
+        else if (FalseCondition(env_value))
         {
             enabled = false;
         }

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="assembly_version_redirection_test.cpp" />
+    <ClCompile Include="environment_variables_parser_test.cpp" />
     <ClCompile Include="integration_loader_test.cpp" />
     <ClCompile Include="integration_test.cpp" />
     <ClCompile Include="clr_helper_test.cpp" />

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/environment_variables_parser_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/environment_variables_parser_test.cpp
@@ -1,6 +1,5 @@
 ﻿#include "pch.h"
 
-
 #include "../../src/OpenTelemetry.AutoInstrumentation.Native/string.h"
 #include "../../src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_parser.h"
 
@@ -23,7 +22,6 @@ TEST(TrueConditionTest, NonTrueValues)
     ASSERT_FALSE(TrueCondition(ToWSTRING("truee")));
     ASSERT_FALSE(TrueCondition(ToWSTRING("TRUEE")));
 }
-
 
 TEST(FalseConditionTest, FalseValues)
 {

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/environment_variables_parser_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/environment_variables_parser_test.cpp
@@ -1,0 +1,45 @@
+﻿#include "pch.h"
+
+
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/string.h"
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_parser.h"
+
+using namespace trace;
+
+TEST(TrueConditionTest, TrueValues)
+{
+    ASSERT_TRUE(TrueCondition(ToWSTRING("true")));
+    ASSERT_TRUE(TrueCondition(ToWSTRING("True")));
+    ASSERT_TRUE(TrueCondition(ToWSTRING("tRue")));
+    ASSERT_TRUE(TrueCondition(ToWSTRING("trUe")));
+    ASSERT_TRUE(TrueCondition(ToWSTRING("truE")));
+    ASSERT_TRUE(TrueCondition(ToWSTRING("TRUE")));
+}
+
+TEST(TrueConditionTest, NonTrueValues)
+{
+    ASSERT_FALSE(TrueCondition(ToWSTRING("")));
+    ASSERT_FALSE(TrueCondition(ToWSTRING("1")));
+    ASSERT_FALSE(TrueCondition(ToWSTRING("truee")));
+    ASSERT_FALSE(TrueCondition(ToWSTRING("TRUEE")));
+}
+
+
+TEST(FalseConditionTest, FalseValues)
+{
+    ASSERT_TRUE(FalseCondition(ToWSTRING("false")));
+    ASSERT_TRUE(FalseCondition(ToWSTRING("False")));
+    ASSERT_TRUE(FalseCondition(ToWSTRING("fAlse")));
+    ASSERT_TRUE(FalseCondition(ToWSTRING("faLse")));
+    ASSERT_TRUE(FalseCondition(ToWSTRING("falSe")));
+    ASSERT_TRUE(FalseCondition(ToWSTRING("falsE")));
+    ASSERT_TRUE(FalseCondition(ToWSTRING("FALSE")));
+}
+
+TEST(FalseConditionTest, NonFalseValues)
+{
+    ASSERT_FALSE(FalseCondition(ToWSTRING("")));
+    ASSERT_FALSE(FalseCondition(ToWSTRING("0")));
+    ASSERT_FALSE(FalseCondition(ToWSTRING("falsee")));
+    ASSERT_FALSE(FalseCondition(ToWSTRING("FALSEE")));
+}


### PR DESCRIPTION
## Why

Fixes #2089

## What

Boolean values - support only true/false case insensitive in native code.
Managed code already covered.

Implementation inspired by managed bool.TryParse internal method.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
