### PR TITLE
Fix bug in OpenTelemetry SDK version validation code in StartupHook

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
@@ -167,43 +167,33 @@ internal class StartupHook
 
     private static void ThrowIfReferenceIncorrectOpenTelemetryVersion(string loaderAssemblyLocation)
     {
-        var appReferenceAssemblies = Assembly.GetEntryAssembly()?.GetReferencedAssemblies();
-        if (appReferenceAssemblies == null)
-        {
-            return;
-        }
-
-        var index = Array.FindIndex(appReferenceAssemblies, assembly => assembly.Name == "OpenTelemetry");
         string? oTelPackageVersion = null;
 
-        if (index != -1)
+        try
         {
-            try
+            // Look up for type with an assembly name, will load the library.
+            // OpenTelemetry assembly load happens only if app has reference to the package.
+            var openTelemetryType = Type.GetType("OpenTelemetry.Sdk, OpenTelemetry");
+            if (openTelemetryType != null)
             {
-                // Look up for type with an assembly name, will load the library.
-                // OpenTelemetry assembly load happens only if app has reference to the package.
-                var openTelemetryType = Type.GetType("OpenTelemetry.Sdk, OpenTelemetry");
-                if (openTelemetryType != null)
+                var loadedOTelAssembly = Assembly.GetAssembly(openTelemetryType);
+                var loadedOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(loadedOTelAssembly?.Location);
+                var loadedOTelFileVersion = new Version(loadedOTelFileVersionInfo.FileVersion);
+
+                var autoInstrumentationOTelLocation = Path.Combine(loaderAssemblyLocation, "OpenTelemetry.dll");
+                var autoInstrumentationOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(autoInstrumentationOTelLocation);
+                var autoInstrumentationOTelFileVersion = new Version(autoInstrumentationOTelFileVersionInfo.FileVersion);
+
+                if (loadedOTelFileVersion < autoInstrumentationOTelFileVersion)
                 {
-                    var loadedOTelAssembly = Assembly.GetAssembly(openTelemetryType);
-                    var loadedOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(loadedOTelAssembly?.Location);
-                    var loadedOTelfileVersion = new Version(loadedOTelFileVersionInfo.FileVersion);
-
-                    var autoInstrumentationOTelLocation = Path.Combine(loaderAssemblyLocation, "OpenTelemetry.dll");
-                    var autoInstrumentationOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(autoInstrumentationOTelLocation);
-                    var autoInstrumentationOTelFileVersion = new Version(autoInstrumentationOTelFileVersionInfo.FileVersion);
-
-                    if (loadedOTelfileVersion < autoInstrumentationOTelFileVersion)
-                    {
-                        oTelPackageVersion = loadedOTelFileVersionInfo.FileVersion;
-                    }
+                    oTelPackageVersion = loadedOTelFileVersionInfo.FileVersion;
                 }
             }
-            catch (Exception ex)
-            {
-                // Exception in evaluation should not throw or crash the process.
-                Logger.LogInformation($"Couldn't evaluate reference to OpenTelemetry Sdk in an app. Exception: {ex}");
-            }
+        }
+        catch (Exception ex)
+        {
+            // Exception in evaluation should not throw or crash the process.
+            Logger.LogInformation($"Couldn't evaluate reference to OpenTelemetry Sdk in an app. Exception: {ex}");
         }
 
         if (oTelPackageVersion != null)


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes a special case that #1692 didn't cover.

If the customer included the OpenTelemetry SDK with `PackageReference` in the csproj file but didn't have C# code calling OpenTelemetry APIs, the app will crash with a `System.Reflection.TargetInvocationException` which doesn't have the helpful `System.NotSupportedException`.

This is because `Assembly.GetEntryAssembly()?.GetReferencedAssemblies()`'s return value doesn't contain `OpenTelemetry` assembly unless it's invoked in C# code.

## What

<!-- Describe changes proposed in this pull request. -->

Rely on `Type.GetType` to check whether customer's app has dependency on OpenTelemetry.

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

### Case 1

Add `<PackageReference Include="OpenTelemetry" VersionOverride="1.4.0-rc.2" />` in the `<ItemGroup>` tag of `examples\playground\AspNetCoreMvc\Examples.AspNetCoreMvc.csproj`.

```
Unhandled exception. System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.NotSupportedException: Application has direct or indirect reference to older version of OpenTelemetry package 1.4.0.753.
   at StartupHook.ThrowIfReferenceIncorrectOpenTelemetryVersion(String loaderAssemblyLocation) in C:\c\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.AutoInstrumentation.StartupHook\StartupHook.cs:line 201
   at StartupHook.Initialize() in C:\c\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.AutoInstrumentation.StartupHook\StartupHook.cs:line 70
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.StartupHookProvider.CallStartupHook(StartupHookNameOrPath startupHook)
   at System.StartupHookProvider.ProcessStartupHooks()
```

### Case 2

`examples\playground\AspNetCoreMvc\Examples.AspNetCoreMvc.csproj` works fine.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
