### PR TITLE
[CI] Publish binaries built on CentOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
           - machine: windows-2022
             containers: windows
             log-dir: "/c/ProgramData/OpenTelemetry .NET AutoInstrumentation/logs"
+          - machine: ubuntu-20.04
+            containers: linux
+            log-dir: "/var/log/opentelemetry/dotnet"
           - machine: macos-11
             containers: none
             log-dir: "/var/log/opentelemetry/dotnet"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
           - machine: windows-2022
             containers: windows
             log-dir: "/c/ProgramData/OpenTelemetry .NET AutoInstrumentation/logs"
-          - machine: ubuntu-20.04
-            containers: linux
-            log-dir: "/var/log/opentelemetry/dotnet"
           - machine: macos-11
             containers: none
             log-dir: "/var/log/opentelemetry/dotnet"
@@ -142,10 +139,10 @@ jobs:
           name: bin-windows-2022
           path: nuget/bin-windows
 
-      - name: Download Ubuntu Artifacts from build job
+      - name: Download CentOS Artifacts from build job
         uses: actions/download-artifact@v3.0.2
         with:
-          name: bin-ubuntu-20.04
+          name: bin-centos
           path: nuget/bin-linux-glibc
 
       - name: Download Alpine Artifacts from build job

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -82,15 +82,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base-image: [ alpine ]
+        base-image: [ alpine, centos ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Test the Shell scripts from README.md in Docker container
         run: |
           set -e
-          docker build -t mybuildimage -f "./docker/${{ matrix.base-image }}.dockerfile" .
-          docker run -e OS_TYPE=linux-musl --rm mybuildimage /bin/sh -c '
+          docker build -t mybuildimage -f "./docker/${{ matrix.base-image }}.dockerfile" ./docker
+          docker run --rm mybuildimage /bin/sh -c '
             set -e
             mkdir testapp
             cd testapp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: [ windows-2022, ubuntu-20.04, macos-11 ]
+        machine: [ windows-2022, macos-11 ]
     runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v3.3.0
@@ -32,7 +32,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base-image: [ alpine ]
+        include:
+          - base-image: alpine
+            os-type: linux-musl
+          - base-image: centos
+            os-type: linux-glibc
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
@@ -42,11 +46,11 @@ jobs:
         docker build \
           --tag otel-dotnet-autoinstrumentation/${{ matrix.base-image }} \
           --file "./docker/${{ matrix.base-image }}.dockerfile" \
-          ./build
+          ./docker
     - name: Build in Docker container
       run: |
         docker run --rm \
-          -e OS_TYPE=linux-musl --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project \
+          -e OS_TYPE=${{ matrix.os-type }} --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project \
           otel-dotnet-autoinstrumentation/${{ matrix.base-image }} \
           ./build.sh
     - name: Upload ${{ matrix.base-image }} binaries
@@ -71,7 +75,7 @@ jobs:
       - name: Install zip
         uses: montudor/action-zip@v1.0.0
       - run: cd bin-alpine ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-musl.zip . * ; cd ..
-      - run: cd bin-ubuntu-20.04 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc.zip . * ; cd ..
+      - run: cd bin-centos ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc.zip . * ; cd ..
       - run: cd bin-windows-2022 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-windows.zip . * ; cd ..
       - run: cd bin-macos-11 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-macos.zip . * ; cd ..
       - name: Create Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This beta release is built on top of [OpenTelemetry .NET](https://github.com/ope
 
 ### Added
 
+- Support for systems with glibc versions 2.17-2.29.
+
 ### Changed
 
 - Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):


### PR DESCRIPTION
## Why

Fixes #2083 

## What

Publish binaries built on CentOS instead of binaries built on Ubuntu for glibc-based distributions.

## Tests

CI.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
