### PR TITLE
Release 0.6.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.6.0-beta.1...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.6.0-beta.2...HEAD)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.6.0-beta.2](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.6.0-beta.2)
 
 This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):
 
@@ -26,8 +40,6 @@ This beta release is built on top of [OpenTelemetry .NET](https://github.com/ope
   [framework roll-forward](https://learn.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward)
   from `net6.0` to `net7.0`.
 
-### Deprecated
-
 ### Removed
 
 - Remove support for plugin method `ConfigureMetricsOptions(OpenTelemetry.Instrumentation.Process.ProcessInstrumentationOptions)`.
@@ -37,8 +49,6 @@ This beta release is built on top of [OpenTelemetry .NET](https://github.com/ope
 - Fix location of `OpenTelemetry.AutoInstrumentation.Native.so` for `linux-musl-x64`.
 - Fix issues when instrumenting `dotnet` CLI
   [#1477](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1744).
-
-### Security
 
 ## [0.6.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.6.0-beta.1)
 

--- a/OpenTelemetry.DotNet.Auto.psm1
+++ b/OpenTelemetry.DotNet.Auto.psm1
@@ -224,7 +224,7 @@ function Install-OpenTelemetryCore() {
         [string]$LocalPath
     )
 
-    $version = "v0.6.0-beta.1"
+    $version = "v0.6.0-beta.2"
     $installDir = Get-CLIInstallDir-From-InstallDir $InstallDir
     $archivePath = $null
     $deleteArchive = $true

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,7 @@ Example usage:
 
 ```sh
 # Download the bash script
-curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0-beta.1/otel-dotnet-auto-install.sh -O
+curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0-beta.2/otel-dotnet-auto-install.sh -O
 
 # Install core files
 sh ./otel-dotnet-auto-install.sh
@@ -159,7 +159,7 @@ uses environment variables as parameters:
 | `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
 | `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
 | `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `v0.6.0-beta.1`           |
+| `VERSION`               | Version to download                                              | No       | `v0.6.0-beta.2`           |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -180,7 +180,7 @@ Example usage (run as administrator):
 
 ```powershell
 # Download the module
-$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0-beta.1/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0-beta.2/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path
 

--- a/nuget/OpenTelemetry.AutoInstrumentation.nuspec
+++ b/nuget/OpenTelemetry.AutoInstrumentation.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OpenTelemetry.AutoInstrumentation</id>
-    <version>0.6.0-beta.1</version>
+    <version>0.6.0-beta.2</version>
     <description>OpenTelemetry Auto-Instrumentation</description>
     <authors>OpenTelemetry Authors</authors>
     <owners>OpenTelemetry Authors</owners>

--- a/otel-dotnet-auto-install.sh
+++ b/otel-dotnet-auto-install.sh
@@ -31,7 +31,7 @@ esac
 
 test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-test -z "$VERSION" && VERSION="v0.6.0-beta.1"
+test -z "$VERSION" && VERSION="v0.6.0-beta.2"
 
 RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
 ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"

--- a/src/OpenTelemetry.AutoInstrumentation.Native/version.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.6.0-beta.1";
+constexpr auto PROFILER_VERSION = "0.6.0-beta.2";

--- a/src/OpenTelemetry.AutoInstrumentation/Constants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Constants.cs
@@ -20,7 +20,7 @@ internal static class Constants
 {
     public static class Tracer
     {
-        public const string Version = "0.6.0-beta.1";
+        public const string Version = "0.6.0-beta.2";
         public const string AutoInstrumentationVersionName = "telemetry.auto.version";
     }
 


### PR DESCRIPTION
## Why

Fixes N/A.

## What

## [0.6.0-beta.2](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.6.0-beta.2)

This beta release is built on top of [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet):

- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.4.0-rc.4`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.4)
- `System.Diagnostics.DiagnosticSource`: [`7.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/7.0.0)
### Added
- Support for systems with glibc versions 2.17-2.29.
### Changed
- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.4.0-rc.4`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0-rc.4).
- Replace `OTEL_DOTNET_AUTO_LEGACY_SOURCES` with `OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_LEGACY_SOURCES`.
- Updated the shared store to correctly support
  [framework roll-forward](https://learn.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward)
  from `net6.0` to `net7.0`.

### Removed

- Remove support for plugin method `ConfigureMetricsOptions(OpenTelemetry.Instrumentation.Process.ProcessInstrumentationOptions)`.
### Fixed
- Fix location of `OpenTelemetry.AutoInstrumentation.Native.so` for `linux-musl-x64`.
- Fix issues when instrumenting `dotnet` CLI
  [#1477](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1744).


## Tests

- [x] CI
- [x] Windows with linux Container
- [x] MacOS

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
