### PR TITLE
Only embed and use the Loader for .NET Fx

### DIFF
--- a/build/Build.Steps.Linux.cs
+++ b/build/Build.Steps.Linux.cs
@@ -8,7 +8,7 @@ partial class Build
 {
     Target CompileNativeSrcLinux => _ => _
         .Unlisted()
-        .After(CompileManagedSrc)
+        .After(CreateRequiredDirectories)
         .OnlyWhenStatic(() => IsLinux)
         .Executes(() =>
         {

--- a/build/Build.Steps.MacOS.cs
+++ b/build/Build.Steps.MacOS.cs
@@ -8,7 +8,7 @@ partial class Build
 {
     Target CompileNativeSrcMacOs => _ => _
         .Unlisted()
-        .After(CompileManagedSrc)
+        .After(CreateRequiredDirectories)
         .OnlyWhenStatic(() => IsOsx)
         .Executes(() =>
         {

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.NetCore.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.NetCore.cs
@@ -1,4 +1,4 @@
-// <copyright file="Startup.NetCore.cs" company="OpenTelemetry Authors">
+// <copyright file="Loader.NetCore.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ namespace OpenTelemetry.AutoInstrumentation.Loader;
 /// <summary>
 /// A class that attempts to load the OpenTelemetry.AutoInstrumentation .NET assembly.
 /// </summary>
-internal partial class Startup
+internal partial class Loader
 {
     internal static System.Runtime.Loader.AssemblyLoadContext DependencyLoadContext { get; } = new ManagedProfilerAssemblyLoadContext();
 
@@ -61,12 +61,12 @@ internal partial class Startup
         //    load the originally referenced version
         if (assemblyName.Name != null && assemblyName.Name.StartsWith("OpenTelemetry.AutoInstrumentation", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
         {
-            StartupLogger.Debug("Loading {0} with Assembly.LoadFrom", path);
+            LoaderLogger.Debug("Loading {0} with Assembly.LoadFrom", path);
             return Assembly.LoadFrom(path);
         }
         else if (File.Exists(path))
         {
-            StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
+            LoaderLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
             return DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
         }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.NetFramework.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.NetFramework.cs
@@ -1,4 +1,4 @@
-// <copyright file="Startup.NetFramework.cs" company="OpenTelemetry Authors">
+// <copyright file="Loader.NetFramework.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ namespace OpenTelemetry.AutoInstrumentation.Loader;
 /// <summary>
 /// A class that attempts to load the OpenTelemetry.AutoInstrumentation .NET assembly.
 /// </summary>
-internal partial class Startup
+internal partial class Loader
 {
     private static string ResolveManagedProfilerDirectory()
     {
@@ -46,19 +46,19 @@ internal partial class Startup
             return null;
         }
 
-        StartupLogger.Debug("Requester [{0}] requested [{1}]", args?.RequestingAssembly?.FullName ?? "<null>", args?.Name ?? "<null>");
+        LoaderLogger.Debug("Requester [{0}] requested [{1}]", args?.RequestingAssembly?.FullName ?? "<null>", args?.Name ?? "<null>");
         var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName}.dll");
         if (File.Exists(path))
         {
             try
             {
                 var loadedAssembly = Assembly.LoadFrom(path);
-                StartupLogger.Debug("Assembly.LoadFrom(\"{0}\") succeeded={1}", path, loadedAssembly != null);
+                LoaderLogger.Debug("Assembly.LoadFrom(\"{0}\") succeeded={1}", path, loadedAssembly != null);
                 return loadedAssembly;
             }
             catch (Exception ex)
             {
-                StartupLogger.Debug("Assembly.LoadFrom(\"{0}\") Exception: {1}", path, ex);
+                LoaderLogger.Debug("Assembly.LoadFrom(\"{0}\") Exception: {1}", path, ex);
             }
         }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.cs
@@ -1,4 +1,4 @@
-// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// <copyright file="Loader.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,15 +21,15 @@ namespace OpenTelemetry.AutoInstrumentation.Loader;
 /// <summary>
 /// A class that attempts to load the OpenTelemetry.AutoInstrumentation .NET assembly.
 /// </summary>
-internal partial class Startup
+internal partial class Loader
 {
     private static readonly string ManagedProfilerDirectory;
 
     /// <summary>
-    /// Initializes static members of the <see cref="Startup"/> class.
+    /// Initializes static members of the <see cref="Loader"/> class.
     /// This method also attempts to load the OpenTelemetry.AutoInstrumentation .NET assembly.
     /// </summary>
-    static Startup()
+    static Loader()
     {
         ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
 
@@ -39,7 +39,7 @@ internal partial class Startup
         }
         catch (Exception ex)
         {
-            StartupLogger.Log(ex, "Unable to register a callback to the CurrentDomain.AssemblyResolve event.");
+            LoaderLogger.Log(ex, "Unable to register a callback to the CurrentDomain.AssemblyResolve event.");
         }
 
         TryLoadManagedAssembly();
@@ -47,7 +47,7 @@ internal partial class Startup
 
     private static void TryLoadManagedAssembly()
     {
-        StartupLogger.Log("Managed Loader TryLoadManagedAssembly()");
+        LoaderLogger.Log("Managed Loader TryLoadManagedAssembly()");
 
         try
         {
@@ -73,7 +73,7 @@ internal partial class Startup
         }
         catch (Exception ex)
         {
-            StartupLogger.Log(ex, $"Error when loading managed assemblies. {ex.Message}");
+            LoaderLogger.Log(ex, $"Error when loading managed assemblies. {ex.Message}");
             throw;
         }
     }
@@ -86,7 +86,7 @@ internal partial class Startup
         }
         catch (Exception ex)
         {
-            StartupLogger.Log(ex, "Error while loading environment variable " + key);
+            LoaderLogger.Log(ex, "Error while loading environment variable " + key);
         }
 
         return null;

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/LoaderLogger.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/LoaderLogger.cs
@@ -1,4 +1,4 @@
-// <copyright file="StartupLogger.cs" company="OpenTelemetry Authors">
+// <copyright file="LoaderLogger.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ using System.Text;
 
 namespace OpenTelemetry.AutoInstrumentation.Loader;
 
-internal static class StartupLogger
+internal static class LoaderLogger
 {
     private const string NixDefaultDirectory = "/var/log/opentelemetry/dotnet";
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -75,22 +75,14 @@ else()
     message(STATUS "CLANG++ found: ${FOUND_CLANGPP}")
 endif()
 
-if (NOT EXISTS ${CMAKE_SOURCE_DIR}/../bin/ProfilerResources/net6.0)
-    message(FATAL_ERROR "OpenTelemetry.AutoInstrumentation.Loader must be built first.")
-else()
-    message(STATUS "OpenTelemetry.AutoInstrumentation.Loader was found")
-endif()
-
 # ******************************************************
 # Output folders
 # ******************************************************
 
 # Set output folders
 SET(OUTPUT_BIN_DIR ${CMAKE_BINARY_DIR}/bin)
-SET(OUTPUT_TMP_DIR ${CMAKE_BINARY_DIR}/tmp.${CMAKE_SYSTEM_NAME}_${CMAKE_SYSTEM_PROCESSOR})
 SET(OUTPUT_DEPS_DIR ${CMAKE_BINARY_DIR}/deps)
 FILE(MAKE_DIRECTORY ${OUTPUT_BIN_DIR})
-FILE(MAKE_DIRECTORY ${OUTPUT_TMP_DIR})
 FILE(MAKE_DIRECTORY ${OUTPUT_DEPS_DIR})
 
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
@@ -101,72 +93,26 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
 # Dependencies
 # ******************************************************
 
-# Prepare dependencies
-if (NOT EXISTS ${OUTPUT_DEPS_DIR}/json)
-    add_custom_command(
-        OUTPUT ${OUTPUT_DEPS_DIR}/json
-        COMMAND git clone --quiet --depth 1 --branch v3.11.2 https://github.com/nlohmann/json.git
-        WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
-    )
-endif()
-
-if (NOT EXISTS ${OUTPUT_DEPS_DIR}/re2)
-    add_custom_command(
-        OUTPUT ${OUTPUT_DEPS_DIR}/re2
-        COMMAND git clone --quiet --depth 1 --branch 2022-12-01 https://github.com/google/re2.git && cd re2 && env ARFLAGS=\"-r -s -c\" CXXFLAGS=\"-std=c++11 -O3 -g -fPIC\" make
-        WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
-    )
-endif()
-
-if (NOT EXISTS ${OUTPUT_DEPS_DIR}/fmt)
-    add_custom_command(
-        OUTPUT ${OUTPUT_DEPS_DIR}/fmt
-        COMMAND git clone --quiet --depth 1 --branch 9.1.0 https://github.com/fmtlib/fmt.git && cd fmt && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0 . && make
-        WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
-    )
-endif()
-
-# Set Managed Loader folder
-SET(MANAGED_LOADER_DIRECTORY ${CMAKE_SOURCE_DIR}/../bin/ProfilerResources/net6.0)
-
-# Set specific custom commands to embed the loader
-if (ISMACOS)
-    add_custom_command(
-            OUTPUT ${OUTPUT_TMP_DIR}/OpenTelemetry.AutoInstrumentation.Loader.dll.o
-            COMMAND touch stub.c && gcc -o stub.o -c stub.c && cp ${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.dll OpenTelemetry.AutoInstrumentation.Loader.dll && ld -r -o OpenTelemetry.AutoInstrumentation.Loader.dll.o -sectcreate binary dll OpenTelemetry.AutoInstrumentation.Loader.dll stub.o
-            DEPENDS ${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.dll ${OUTPUT_DEPS_DIR}/json ${OUTPUT_DEPS_DIR}/re2 ${OUTPUT_DEPS_DIR}/fmt
-            WORKING_DIRECTORY ${OUTPUT_TMP_DIR}
-    )
-    add_custom_command(
-            OUTPUT ${OUTPUT_TMP_DIR}/OpenTelemetry.AutoInstrumentation.Loader.pdb.o
-            COMMAND touch stub.c && gcc -o stub.o -c stub.c && cp "${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.pdb" OpenTelemetry.AutoInstrumentation.Loader.pdb && ld -r -o OpenTelemetry.AutoInstrumentation.Loader.pdb.o -sectcreate binary pdb OpenTelemetry.AutoInstrumentation.Loader.pdb stub.o
-            DEPENDS ${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.pdb ${OUTPUT_DEPS_DIR}/json ${OUTPUT_DEPS_DIR}/re2 ${OUTPUT_DEPS_DIR}/fmt
-            WORKING_DIRECTORY ${OUTPUT_TMP_DIR}
-    )
-elseif(ISLINUX)
-    add_custom_command(
-            OUTPUT ${OUTPUT_TMP_DIR}/OpenTelemetry.AutoInstrumentation.Loader.dll.o
-            COMMAND cp "${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.dll" OpenTelemetry.AutoInstrumentation.Loader.dll && ld -r -b binary -o OpenTelemetry.AutoInstrumentation.Loader.dll.o OpenTelemetry.AutoInstrumentation.Loader.dll
-            DEPENDS ${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.dll ${OUTPUT_DEPS_DIR}/json ${OUTPUT_DEPS_DIR}/re2 ${OUTPUT_DEPS_DIR}/fmt
-            WORKING_DIRECTORY ${OUTPUT_TMP_DIR}
-    )
-    add_custom_command(
-            OUTPUT ${OUTPUT_TMP_DIR}/OpenTelemetry.AutoInstrumentation.Loader.pdb.o
-            COMMAND cp "${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.pdb" OpenTelemetry.AutoInstrumentation.Loader.pdb && ld -r -b binary -o OpenTelemetry.AutoInstrumentation.Loader.pdb.o OpenTelemetry.AutoInstrumentation.Loader.pdb
-            DEPENDS ${MANAGED_LOADER_DIRECTORY}/OpenTelemetry.AutoInstrumentation.Loader.pdb ${OUTPUT_DEPS_DIR}/json ${OUTPUT_DEPS_DIR}/re2 ${OUTPUT_DEPS_DIR}/fmt
-            WORKING_DIRECTORY ${OUTPUT_TMP_DIR}
-    )
-endif()
-SET(GENERATED_OBJ_FILES
-        ${OUTPUT_TMP_DIR}/OpenTelemetry.AutoInstrumentation.Loader.dll.o
-        ${OUTPUT_TMP_DIR}/OpenTelemetry.AutoInstrumentation.Loader.pdb.o
+# Add custom commands to setup dependencies via git
+add_custom_command(
+    OUTPUT ${OUTPUT_DEPS_DIR}/json/include/nlohmann/json.hpp
+    COMMAND git clone --quiet --depth 1 --branch v3.11.2 https://github.com/nlohmann/json.git
+    WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
 )
-SET_SOURCE_FILES_PROPERTIES(
-        ${GENERATED_OBJ_FILES}
-        PROPERTIES
-        EXTERNAL_OBJECT true
-        GENERATED true
+
+add_custom_command(
+    OUTPUT ${OUTPUT_DEPS_DIR}/re2/obj/libre2.a
+    COMMAND git clone --quiet --depth 1 --branch 2022-12-01 https://github.com/google/re2.git && cd re2 && env ARFLAGS=\"-r -s -c\" CXXFLAGS=\"-std=c++11 -O3 -g -fPIC\" make
+    WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
 )
+
+add_custom_command(
+    OUTPUT ${OUTPUT_DEPS_DIR}/fmt/libfmt.a
+    COMMAND git clone --quiet --depth 1 --branch 9.1.0 https://github.com/fmtlib/fmt.git && cd fmt && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0 . && make
+    WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
+)
+
+
 
 # ******************************************************
 # Compiler options
@@ -233,7 +179,10 @@ add_library("OpenTelemetry.AutoInstrumentation.Native.static" STATIC
         calltarget_tokens.cpp
         rejit_handler.cpp
         lib/coreclr/src/pal/prebuilt/idl/corprof_i.cpp
-        ${GENERATED_OBJ_FILES}
+        # Source dependencies retrievied via additional commands using git
+        ${OUTPUT_DEPS_DIR}/fmt/libfmt.a
+        ${OUTPUT_DEPS_DIR}/json/include/nlohmann/json.hpp
+        ${OUTPUT_DEPS_DIR}/re2/obj/libre2.a
 )
 
 set_target_properties("OpenTelemetry.AutoInstrumentation.Native.static" PROPERTIES PREFIX "")
@@ -276,7 +225,6 @@ if (ISMACOS)
     add_library(${TARGET_NAME} SHARED
         dllmain.cpp
         interop.cpp
-        ${GENERATED_OBJ_FILES}
     )
 else()
     add_library(${TARGET_NAME} SHARED

--- a/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
@@ -17,6 +17,7 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -42,6 +43,7 @@ BEGIN
 END
 
 #endif    // APSTUDIO_INVOKED
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -81,16 +83,26 @@ BEGIN
     END
 END
 
-#endif    // English (United States) resources
-/////////////////////////////////////////////////////////////////////////////
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // ASSEMBLY
 //
 
-NETFRAMEWORK_MANAGED_ENTRYPOINT_DLL ASSEMBLY "..\\bin\\ProfilerResources\\net462\\OpenTelemetry.AutoInstrumentation.Loader.dll"
-NETFRAMEWORK_MANAGED_ENTRYPOINT_SYMBOLS SYMBOLS "..\\bin\\ProfilerResources\\net462\\OpenTelemetry.AutoInstrumentation.Loader.pdb"
+NETFRAMEWORK_MANAGED_ENTRYPOINT_DLL ASSEMBLY                "..\\bin\\ProfilerResources\\net462\\OpenTelemetry.AutoInstrumentation.Loader.dll"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// SYMBOLS
+//
+
+NETFRAMEWORK_MANAGED_ENTRYPOINT_SYMBOLS SYMBOLS                 "..\\bin\\ProfilerResources\\net462\\OpenTelemetry.AutoInstrumentation.Loader.pdb"
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
 
 #ifndef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -98,5 +110,7 @@ NETFRAMEWORK_MANAGED_ENTRYPOINT_SYMBOLS SYMBOLS "..\\bin\\ProfilerResources\\net
 // Generated from the TEXTINCLUDE 3 resource.
 //
 
+
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
+

--- a/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
@@ -89,8 +89,6 @@ END
 // ASSEMBLY
 //
 
-NET_MANAGED_ENTRYPOINT_DLL ASSEMBLY "..\\bin\\ProfilerResources\\net6.0\\OpenTelemetry.AutoInstrumentation.Loader.dll"
-NET_MANAGED_ENTRYPOINT_SYMBOLS SYMBOLS "..\\bin\\ProfilerResources\\net6.0\\OpenTelemetry.AutoInstrumentation.Loader.pdb"
 NETFRAMEWORK_MANAGED_ENTRYPOINT_DLL ASSEMBLY "..\\bin\\ProfilerResources\\net462\\OpenTelemetry.AutoInstrumentation.Loader.dll"
 NETFRAMEWORK_MANAGED_ENTRYPOINT_SYMBOLS SYMBOLS "..\\bin\\ProfilerResources\\net462\\OpenTelemetry.AutoInstrumentation.Loader.pdb"
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -183,8 +183,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
     Logger::Debug("Number of Integrations loaded: ", integration_methods_.size());
 
-    DWORD event_mask = COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST |
-                       COR_PRF_MONITOR_MODULE_LOADS | COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS;
+    DWORD event_mask = COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST | COR_PRF_MONITOR_MODULE_LOADS |
+                       COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS;
 
     Logger::Info("CallTarget instrumentation is enabled.");
     event_mask |= COR_PRF_ENABLE_REJIT;
@@ -625,7 +625,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
         return S_OK;
     }
 
-    // In IIS, the OpenTelemetry.AutoInstrumentation will be inserted into a method in System.Web (which is domain-neutral)
+    // In IIS, the OpenTelemetry.AutoInstrumentation will be inserted into a method in System.Web (which is
+    // domain-neutral)
     // but the OpenTelemetry.AutoInstrumentation.Loader assembly that the CLR profiler loads from a
     // byte array will be loaded into a non-shared AppDomain.
     // In this case, do not insert another Loader into that non-shared AppDomain
@@ -930,7 +931,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITInlining(FunctionID callerId, Function
 }
 
 #ifdef _WIN32
-HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStartedOnNetFramework(FunctionID function_id, BOOL is_safe_to_block)
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStartedOnNetFramework(FunctionID function_id,
+                                                                           BOOL       is_safe_to_block)
 {
     // keep this lock until we are done using the module,
     // to prevent it from unloading while in use
@@ -1006,8 +1008,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStartedOnNetFramework(Funct
     if (is_desktop_iis)
     {
         valid_loader_callsite = module_metadata->assemblyName == WStr("System.Web") &&
-                                      caller.type.name == WStr("System.Web.Compilation.BuildManager") &&
-                                      caller.name == WStr("InvokePreStartInitMethods");
+                                caller.type.name == WStr("System.Web.Compilation.BuildManager") &&
+                                caller.name == WStr("InvokePreStartInitMethods");
     }
     else if (module_metadata->assemblyName == WStr("System") ||
              module_metadata->assemblyName == WStr("System.Net.Http"))
@@ -1022,10 +1024,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStartedOnNetFramework(Funct
     {
         bool domain_neutral_assembly = runtime_information_.is_desktop() && corlib_module_loaded &&
                                        module_metadata->app_domain_id == corlib_app_domain_id;
-        Logger::Info("JITCompilationStarted: Loader registered in function_id=", function_id, " token=",
-                     function_token, " name=", caller.type.name, ".", caller.name, "(), assembly_name=",
-                     module_metadata->assemblyName, " app_domain_id=", module_metadata->app_domain_id,
-                     " domain_neutral=", domain_neutral_assembly);
+        Logger::Info("JITCompilationStarted: Loader registered in function_id=", function_id, " token=", function_token,
+                     " name=", caller.type.name, ".", caller.name, "(), assembly_name=", module_metadata->assemblyName,
+                     " app_domain_id=", module_metadata->app_domain_id, " domain_neutral=", domain_neutral_assembly);
 
         first_jit_compilation_app_domains.insert(module_metadata->app_domain_id);
 
@@ -1392,8 +1393,8 @@ std::string CorProfiler::GetILCodes(const std::string&  title,
 // Loader methods. These are only used on the .NET Framework.
 //
 HRESULT CorProfiler::RunAutoInstrumentationLoader(const ComPtr<IMetaDataEmit2>& metadata_emit,
-                                      const ModuleID                module_id,
-                                      const mdToken                 function_token)
+                                                  const ModuleID                module_id,
+                                                  const mdToken                 function_token)
 {
     mdMethodDef ret_method_token;
     auto        hr = GenerateLoaderMethod(module_id, &ret_method_token);
@@ -1409,7 +1410,8 @@ HRESULT CorProfiler::RunAutoInstrumentationLoader(const ComPtr<IMetaDataEmit2>& 
 
     if (FAILED(hr))
     {
-        Logger::Warn("RunAutoInstrumentationLoader: Call to ILRewriter.Import() failed for ", module_id, " ", function_token);
+        Logger::Warn("RunAutoInstrumentationLoader: Call to ILRewriter.Import() failed for ", module_id, " ",
+                     function_token);
         return hr;
     }
 
@@ -2046,7 +2048,8 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
 
     if (FAILED(hr))
     {
-        Logger::Warn("RunAutoInstrumentationLoader: Call to ILRewriter.Import() failed for ", module_id, " ", function_token);
+        Logger::Warn("RunAutoInstrumentationLoader: Call to ILRewriter.Import() failed for ", module_id, " ",
+                     function_token);
         return hr;
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -59,14 +59,29 @@ private:
     ModuleID managed_profiler_module_id_ = 0;
 
     //
-    // Assembly redirect private members
+    // Methods only for .NET Framework
     //
 #ifdef _WIN32
+    //
+    // Special handler for JITCompilationStarted on .NET Framework.
+    //
+    HRESULT STDMETHODCALLTYPE JITCompilationStartedOnNetFramework(FunctionID function_id, BOOL is_safe_to_block);
+
+    //
+    // Assembly redirect private members.
+    //
     std::unordered_map<WSTRING, AssemblyVersionRedirection> assembly_version_redirect_map_;
     void InitNetFxAssemblyRedirectsMap();
     void RedirectAssemblyReferences(
         const ComPtr<IMetaDataAssemblyImport>& assembly_import,
         const ComPtr<IMetaDataAssemblyEmit>& assembly_emit);
+
+    //
+    // Loader methods. These are only used on the .NET Framework.
+    //
+    HRESULT RunAutoInstrumentationLoader(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token);
+    HRESULT GenerateLoaderMethod(const ModuleID module_id, mdMethodDef* ret_method_token);
+    HRESULT AddIISPreStartInitFlags(const ModuleID module_id, const mdToken function_token);
 #endif
 
     //
@@ -81,13 +96,6 @@ private:
     std::string GetILCodes(const std::string& title, ILRewriter* rewriter, const FunctionInfo& caller,
                            ModuleMetadata* module_metadata);
     //
-    // Startup methods
-    //
-    HRESULT RunILStartupHook(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token);
-    HRESULT GenerateVoidILStartupMethod(const ModuleID module_id, mdMethodDef* ret_method_token);
-    HRESULT AddIISPreStartInitFlags(const ModuleID module_id, const mdToken function_token);
-
-    //
     // CallTarget Methods
     //
     size_t CallTarget_RequestRejitForModule(ModuleID module_id, ModuleMetadata* module_metadata,
@@ -101,8 +109,11 @@ public:
 
     WSTRING GetBytecodeInstrumentationAssembly() const;
 
+#ifdef _WIN32
+    // GetAssemblyAndSymbolsBytes is used when injecting the Loader into a .NET Framework application.
     void GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assemblySize, BYTE** pSymbolsArray,
                                     int* symbolsSize) const;
+#endif
 
     //
     // ICorProfilerCallback methods

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -126,7 +126,10 @@ public:
 
     HRESULT STDMETHODCALLTYPE ModuleUnloadStarted(ModuleID module_id) override;
 
+#ifdef _WIN32
+    // JITCompilationStarted is only needed on .NET Framework, see JITCompilationStartedOnNetFramework.
     HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID function_id, BOOL is_safe_to_block) override;
+#endif
 
     HRESULT STDMETHODCALLTYPE AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus) override;
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/interop.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/interop.cpp
@@ -18,6 +18,8 @@ EXTERN_C BOOL STDAPICALLTYPE IsProfilerAttached()
     return trace::profiler != nullptr && trace::profiler->IsAttached();
 }
 
+#ifdef _WIN32
+// GetAssemblyAndSymbolsBytes is used when injecting the Loader into a .NET Framework application.
 EXTERN_C VOID STDAPICALLTYPE GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray,
                                                         int*   assemblySize,
                                                         BYTE** pSymbolsArray,
@@ -25,6 +27,7 @@ EXTERN_C VOID STDAPICALLTYPE GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray,
 {
     return trace::profiler->GetAssemblyAndSymbolsBytes(pAssemblyArray, assemblySize, pSymbolsArray, symbolsSize);
 }
+#endif
 
 #ifndef _WIN32
 EXTERN_C void* dddlopen(const char* __file, int __mode)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/resource.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/resource.h
@@ -1,8 +1,9 @@
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by Resource.rc
-#define NETFRAMEWORK_MANAGED_ENTRYPOINT_DLL        403
-#define NETFRAMEWORK_MANAGED_ENTRYPOINT_SYMBOLS    404
+//
+#define NETFRAMEWORK_MANAGED_ENTRYPOINT_DLL 403
+#define NETFRAMEWORK_MANAGED_ENTRYPOINT_SYMBOLS 404
 
 // Next default values for new objects
 // 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/resource.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/resource.h
@@ -1,8 +1,6 @@
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by Resource.rc
-#define NET_MANAGED_ENTRYPOINT_DLL      401
-#define NET_MANAGED_ENTRYPOINT_SYMBOLS 402
 #define NETFRAMEWORK_MANAGED_ENTRYPOINT_DLL        403
 #define NETFRAMEWORK_MANAGED_ENTRYPOINT_SYMBOLS    404
 

--- a/test/Benchmarks/LoaderLoggerBenchmarks.cs
+++ b/test/Benchmarks/LoaderLoggerBenchmarks.cs
@@ -1,4 +1,4 @@
-// <copyright file="StartupLoggerBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="LoaderLoggerBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,11 +32,11 @@ Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores
 namespace OpenTelemetry.AutoInstrumentation.Loader.Benchmarks;
 
 [MemoryDiagnoser]
-public class StartupLoggerBenchmarks
+public class LoaderLoggerBenchmarks
 {
     [Benchmark]
     public void SetStartupLogFilePath()
     {
-        var path = StartupLogger.SetStartupLogFilePath();
+        var path = LoaderLogger.SetStartupLogFilePath();
     }
 }

--- a/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/LoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/LoaderTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="StartupTests.cs" company="OpenTelemetry Authors">
+// <copyright file="LoaderTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,11 +19,11 @@ using Xunit.Abstractions;
 
 namespace OpenTelemetry.AutoInstrumentation.Loader.Tests;
 
-public class StartupTests
+public class LoaderTests
 {
     private ITestOutputHelper _testOutput;
 
-    public StartupTests(ITestOutputHelper testOutput)
+    public LoaderTests(ITestOutputHelper testOutput)
     {
         _testOutput = testOutput;
     }
@@ -52,7 +52,7 @@ public class StartupTests
         Environment.SetEnvironmentVariable("OTEL_DOTNET_AUTO_DEBUG", "1");
         Environment.SetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME", profilerDirectory);
 
-        var exception = Record.Exception(() => new AutoInstrumentation.Loader.Startup());
+        var exception = Record.Exception(() => new AutoInstrumentation.Loader.Loader());
 
         // That means the assembly was loaded successfully and Initialize method was called.
         Assert.Null(exception);


### PR DESCRIPTION
## Why

To avoid the JITCompilationStarted callback during execution outside .NET Framework and to avoid embedding a resource in the native CLR profiler outside of Windows (since it is not used).

Part of #244

## What

- Only request the JITCompilation* callbacks on .NET Framework.
- Embed the Loader as a resource of the CLR profiler only for Windows.
- Use the name `Startup` only for StartupHook. This caused a stutter on OpenTelemetry.AutoInstrumentation.Loader.Loader, I'm open to suggestions for naming types/methods. 

## Tests

Already covered by Smoke and the integration tests.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

This change is internal and should be transparent to users, so I'm not adding it to the CHANGELOG.md

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
