### PR TITLE
Change Instrumentation.Process to 0.5.0-beta.1

### DIFF
--- a/nuget/OpenTelemetry.AutoInstrumentation.nuspec
+++ b/nuget/OpenTelemetry.AutoInstrumentation.nuspec
@@ -24,7 +24,7 @@
         <dependency id="OpenTelemetry.Instrumentation.Http" version="1.0.0-rc9.13" />
         <dependency id="OpenTelemetry.Instrumentation.Quartz" version="1.0.0-alpha.1" />
         <dependency id="OpenTelemetry.Instrumentation.Runtime" version="1.1.0-rc.1" />
-        <dependency id="OpenTelemetry.Instrumentation.Process" version="1.0.0-alpha.6" />
+        <dependency id="OpenTelemetry.Instrumentation.Process" version="0.5.0-beta.1" />
         <dependency id="OpenTelemetry.Instrumentation.SqlClient" version="1.0.0-rc9.13" />
         <dependency id="OpenTelemetry.Instrumentation.Wcf" version="1.0.0-rc.8" />
         <dependency id="OpenTelemetry.Shims.OpenTracing" version="1.0.0-rc9.13" />
@@ -46,7 +46,7 @@
         <dependency id="OpenTelemetry.Instrumentation.Http" version="1.0.0-rc9.13" />
         <dependency id="OpenTelemetry.Instrumentation.Quartz" version="1.0.0-alpha.1" />
         <dependency id="OpenTelemetry.Instrumentation.Runtime" version="1.1.0-rc.1" />
-        <dependency id="OpenTelemetry.Instrumentation.Process" version="1.0.0-alpha.6" />
+        <dependency id="OpenTelemetry.Instrumentation.Process" version="0.5.0-beta.1" />
         <dependency id="OpenTelemetry.Instrumentation.SqlClient" version="1.0.0-rc9.13" />
         <dependency id="OpenTelemetry.Instrumentation.Wcf" version="1.0.0-rc.8" />
         <dependency id="OpenTelemetry.Shims.OpenTracing" version="1.0.0-rc9.13" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.4" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.13" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.5" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.0.0-alpha.6" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.1.0-rc.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.13" />

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -42,7 +42,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule", {1, 0, 0, 7} },
         { L"OpenTelemetry.Instrumentation.GrpcNetClient", {1, 0, 0, 0} },
         { L"OpenTelemetry.Instrumentation.Http", {1, 0, 0, 0} },
-        { L"OpenTelemetry.Instrumentation.Process", {1, 0, 0, 6} },
+        { L"OpenTelemetry.Instrumentation.Process", {0, 5, 0, 1} },
         { L"OpenTelemetry.Instrumentation.Quartz", {1, 0, 0, 1} },
         { L"OpenTelemetry.Instrumentation.Runtime", {1, 1, 0, 1} },
         { L"OpenTelemetry.Instrumentation.SqlClient", {1, 0, 0, 0} },


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Process-0.5.0-beta.1/src/OpenTelemetry.Instrumentation.Process/CHANGELOG.md#050-beta1

## What

Change Instrumentation.Process to 0.5.0-beta.1
> **Note**
> The version number was lowered from 1.0.0 to 0.5.0 to better reflect the
experimental state of Opentelemetry process metrics specification status.
Packages that were older than this release will be delisted to avoid confusion.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
