### PR TITLE
Use System.Text.Json.Nodes instead of Regex

### DIFF
--- a/build/Build.Steps.cs
+++ b/build/Build.Steps.cs
@@ -475,8 +475,7 @@ partial class Build
                         var rawJson = File.ReadAllText(file);
                         var depsJson = JsonNode.Parse(rawJson).AsObject();
 
-                        var folderRuntimeName = GetFolderRuntimeName(depsJson);
-
+                        var folderRuntimeName = depsJson.GetFolderRuntimeName();
                         var architectureStores = new List<string>
                         {
                             Path.Combine(StoreDirectory, "x64", folderRuntimeName),
@@ -505,19 +504,6 @@ partial class Build
                 AdditionalDepsDirectory.GlobFiles("**/*.dll", "**/*.pdb", "**/*.xml", "**/*.dylib", "**/*.so").ForEach(DeleteFile);
                 AdditionalDepsDirectory.GlobDirectories("**/runtimes").ForEach(DeleteDirectory);
             });
-
-        string GetFolderRuntimeName(JsonObject jsonDocument)
-        {
-            var runtimeName = jsonDocument["runtimeTarget"]["name"].GetValue<string>();
-            var folderRuntimeName = runtimeName switch
-            {
-                ".NETCoreApp,Version=v6.0" => "net6.0",
-                ".NETCoreApp,Version=v7.0" => "net7.0",
-                _ => throw new ArgumentOutOfRangeException(nameof(runtimeName), runtimeName,
-                    "This value is not supported. You have probably introduced new .NET version to AutoInstrumentation")
-            };
-            return folderRuntimeName;
-        }
     };
 
     Target InstallDocumentationTools => _ => _

--- a/build/Extensions/DepsJsonExtensions.cs
+++ b/build/Extensions/DepsJsonExtensions.cs
@@ -1,0 +1,115 @@
+using Nuke.Common.IO;
+using Nuke.Common.Utilities.Collections;
+using System.Text.Json.Nodes;
+
+using static Nuke.Common.IO.FileSystemTasks;
+
+namespace Extensions;
+
+internal static class DepsJsonExtensions
+{
+    public static void CopyNativeDependenciesToStore(this JsonObject depsJson, AbsolutePath file, IReadOnlyList<string> architectureStores)
+    {
+        var depsDirectory = file.Parent;
+
+        foreach (var targetProperty in depsJson["targets"].AsObject())
+        {
+            var target = targetProperty.Value.AsObject();
+
+            foreach (var packages in target)
+            {
+                if (!packages.Value.AsObject().TryGetPropertyValue("runtimeTargets", out var runtimeTargets))
+                {
+                    continue;
+                }
+
+                foreach (var runtimeDependency in runtimeTargets.AsObject())
+                {
+                    var sourceFileName = Path.Combine(depsDirectory, runtimeDependency.Key);
+
+                    foreach (var architectureStore in architectureStores)
+                    {
+                        var targetFileName = Path.Combine(architectureStore, packages.Key.ToLowerInvariant(), runtimeDependency.Key);
+                        var targetDirectory = Path.GetDirectoryName(targetFileName);
+                        Directory.CreateDirectory(targetDirectory);
+                        File.Copy(sourceFileName, targetFileName);
+                    }
+                }
+            }
+        }
+    }
+
+    public static void RemoveOpenTelemetryLibraries(this JsonObject depsJson)
+    {
+        var dependencies = depsJson.GetDependencies();
+        var runtimeLibraries = depsJson["libraries"].AsObject();
+        var keysToRemove = dependencies
+            .Where(x => x.Key.StartsWith("OpenTelemetry"))
+            .Select(x => x.Key)
+            .ToList();
+
+        foreach (var key in keysToRemove)
+        {
+            dependencies.Remove(key);
+            runtimeLibraries.Remove(key);
+        }
+    }
+
+    public static void RollFrameworkForward(this JsonObject depsJson, string runtime, string rollForwardRuntime, IReadOnlyList<string> architectureStores)
+    {
+        // Update the contents of the json file.
+        foreach (var dep in depsJson.GetDependencies())
+        {
+            var depObject = dep.Value.AsObject();
+            if (depObject.TryGetPropertyValue("runtime", out var runtimeNode))
+            {
+                var runtimeObject = runtimeNode.AsObject();
+                var libKeys = runtimeObject
+                    .Select(x => x.Key)
+                    .Where(x => x.StartsWith($"lib/{runtime}"))
+                    .ToList();
+
+                foreach (var libKey in libKeys)
+                {
+                    var libNode = runtimeObject[libKey];
+                    var newKey = libKey.Replace($"lib/{runtime}", $"lib/{rollForwardRuntime}");
+
+                    runtimeObject.Remove(libKey);
+                    runtimeObject.AddPair(newKey, libNode);
+                }
+            }
+        }
+
+        // Roll forward each architecture by renaming the tfm folder holding the assemblies.
+        foreach (var architectureStore in architectureStores)
+        {
+            var assemblyDirectories = Directory.GetDirectories(architectureStore);
+            foreach (var assemblyDirectory in assemblyDirectories)
+            {
+                var assemblyVersionDirectories = Directory.GetDirectories(assemblyDirectory);
+                if (assemblyVersionDirectories.Length != 1)
+                {
+                    throw new InvalidOperationException(
+                        $"Expected exactly one directory under {assemblyDirectory} but found {assemblyVersionDirectories.Length} instead.");
+                }
+
+                var assemblyVersionDirectory = assemblyVersionDirectories[0];
+                var sourceDir = Path.Combine(assemblyVersionDirectory, "lib", runtime);
+                if (Directory.Exists(sourceDir))
+                {
+                    var destDir = Path.Combine(assemblyVersionDirectory, "lib", rollForwardRuntime);
+
+                    CopyDirectoryRecursively(sourceDir, destDir);
+
+                    // Since the json was also rolled forward the original tfm folder can be deleted.
+                    DeleteDirectory(sourceDir);
+                }
+            }
+        }
+    }
+
+    private static JsonObject GetDependencies(this JsonObject depsJson)
+    {
+        return depsJson["targets"].AsObject().First().Value.AsObject();
+    }
+}

--- a/build/Extensions/DepsJsonExtensions.cs
+++ b/build/Extensions/DepsJsonExtensions.cs
@@ -1,7 +1,6 @@
+using System.Text.Json.Nodes;
 using Nuke.Common.IO;
 using Nuke.Common.Utilities.Collections;
-using System.Text.Json.Nodes;
-
 using static Nuke.Common.IO.FileSystemTasks;
 
 namespace Extensions;

--- a/build/Extensions/DepsJsonExtensions.cs
+++ b/build/Extensions/DepsJsonExtensions.cs
@@ -8,6 +8,20 @@ namespace Extensions;
 
 internal static class DepsJsonExtensions
 {
+    public static string GetFolderRuntimeName(this JsonObject depsJson)
+    {
+        var runtimeName = depsJson["runtimeTarget"]["name"].GetValue<string>();
+        var folderRuntimeName = runtimeName switch
+        {
+            ".NETCoreApp,Version=v6.0" => "net6.0",
+            ".NETCoreApp,Version=v7.0" => "net7.0",
+            _ => throw new ArgumentOutOfRangeException(nameof(runtimeName), runtimeName,
+                "This value is not supported. You have probably introduced new .NET version to AutoInstrumentation")
+        };
+
+        return folderRuntimeName;
+    }
+
     public static void CopyNativeDependenciesToStore(this JsonObject depsJson, AbsolutePath file, IReadOnlyList<string> architectureStores)
     {
         var depsDirectory = file.Parent;


### PR DESCRIPTION
## Why

Towards #1382 

## What

Use writable json tools (System.Text.Json.Nodes) instead of Regex.
This makes future work with json content simpler and less error prone. 

## Tests

Existing.

## Next

Need to analyse packages we instrument. If dependencies contents is the same as instrumented library is already shipping, then we can remove common part from our package.
