### PR TITLE
Add merge_group: triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -11,6 +11,7 @@ on:
     paths:
     - '**.cs'
     - '.editorconfig'
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/format-native.yml
+++ b/.github/workflows/format-native.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -17,6 +17,7 @@ on:
     - 'package-lock.json'
     - 'package.json'
     - '.lycheeignore'
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION


## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/discussions/2188

## What

Add merge_group: triggers
It is prerequisite to enabling GH merge queues

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
