### PR TITLE
Improve examples/demo

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -4,8 +4,7 @@
 
 On all platforms, the minimum requirements are:
 
-- [Docker](https://docs.docker.com/engine/install/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker](https://www.docker.com/products/docker-desktop)
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
 - [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0)
 
@@ -162,7 +161,7 @@ configuration for running the OpenTelemetry Collector and Jaeger.
 You can run the services using:
 
 ```sh
-docker-compose -f dev/docker-compose.yaml up
+docker compose -f dev/docker-compose.yaml up
 ```
 
 The following Web UI endpoints are exposed:

--- a/examples/demo/Client/Program.cs
+++ b/examples/demo/Client/Program.cs
@@ -31,7 +31,6 @@ var url = args[0];
 using var httpClient = new HttpClient();
 while (true)
 {
-    Thread.Sleep(5000);
     try
     {
         var content = await httpClient.GetStringAsync(url);
@@ -41,4 +40,6 @@ while (true)
     {
         Console.WriteLine(ex.Message);
     }
+
+    Thread.Sleep(5000);
 }

--- a/examples/demo/Client/Program.cs
+++ b/examples/demo/Client/Program.cs
@@ -32,6 +32,13 @@ using var httpClient = new HttpClient();
 while (true)
 {
     Thread.Sleep(5000);
-    var content = await httpClient.GetStringAsync(url);
-    Console.WriteLine(content);
+    try
+    {
+        var content = await httpClient.GetStringAsync(url);
+        Console.WriteLine(content);
+    }
+    catch (HttpRequestException ex)
+    {
+        Console.WriteLine(ex.Message);
+    }
 }

--- a/examples/demo/Makefile
+++ b/examples/demo/Makefile
@@ -2,11 +2,11 @@
 run:
 	mkdir -p log
 	chmod 777 log
-	docker-compose up -d --build
+	docker compose up -d --build
 
 .PHONY: clean
 clean:
-	docker-compose down --remove-orphans
+	docker compose down --remove-orphans
 	rm -rf log
 
 .PHONY: wait

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -25,7 +25,7 @@ It consists of following services:
 Windows (Git Bash):
 
 ```sh
-docker-compose up -d --build
+docker compose up -d --build
 ```
 
 macOS and Linux:
@@ -44,7 +44,7 @@ You can also find the exported telemetry in the `log` directory.
 Windows (Git Bash):
 
 ```sh
-docker-compose down --remove-orphans
+docker compose down --remove-orphans
 rm -rf log
 ```
 

--- a/examples/demo/otel-dotnet.env
+++ b/examples/demo/otel-dotnet.env
@@ -1,7 +1,7 @@
 # enable OpenTelemetry .NET Automatic Instrumentation
 CORECLR_ENABLE_PROFILING="1"
 CORECLR_PROFILER='{918728DD-259F-4A6A-AC2B-B85E1B658318}'
-CORECLR_PROFILER_PATH="/otel-dotnet-auto/OpenTelemetry.AutoInstrumentation.Native.so"
+CORECLR_PROFILER_PATH="/otel-dotnet-auto/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
 DOTNET_ADDITIONAL_DEPS="/otel-dotnet-auto/AdditionalDeps"
 DOTNET_SHARED_STORE="/otel-dotnet-auto/store"
 DOTNET_STARTUP_HOOKS="/otel-dotnet-auto/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll"


### PR DESCRIPTION
## Why

Improve the demo before Warsaw .NET Group meetup.

## What

1. Update to use Docker Compose v2. More: https://docs.docker.com/compose/compose-v2/
2. Add exception handling in `Examples.Client` to avoid crashes during startup
3. Fix `CORECLR_PROFILER_PATH` value
4. Move `Thread.Sleep` after HTTP request so that we have higher chance to see some error spans.