### PR TITLE
Avoid FormatException while parsing configuration

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/LogSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/LogSettings.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using OpenTelemetry.AutoInstrumentation.Logging;
+
 namespace OpenTelemetry.AutoInstrumentation.Configurations;
 
 /// <summary>
@@ -21,6 +23,8 @@ namespace OpenTelemetry.AutoInstrumentation.Configurations;
 /// </summary>
 internal class LogSettings : Settings
 {
+    private static readonly IOtelLogger Logger = OtelLogging.GetLogger();
+
     /// <summary>
     /// Gets a value indicating whether the logs should be loaded by the profiler. Default is true.
     /// </summary>
@@ -76,7 +80,8 @@ internal class LogSettings : Settings
             case Constants.ConfigurationValues.None:
                 return LogExporter.None;
             default:
-                throw new FormatException($"Log exporter '{logExporterEnvVar}' is not supported");
+                Logger.Error($"Log exporter '{logExporterEnvVar}' is not supported. Defaulting to '{Constants.ConfigurationValues.Exporters.Otlp}'.");
+                return LogExporter.Otlp;
         }
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/MetricSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/MetricSettings.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using OpenTelemetry.AutoInstrumentation.Logging;
+
 namespace OpenTelemetry.AutoInstrumentation.Configurations;
 
 /// <summary>
@@ -21,6 +23,8 @@ namespace OpenTelemetry.AutoInstrumentation.Configurations;
 /// </summary>
 internal class MetricSettings : Settings
 {
+    private static readonly IOtelLogger Logger = OtelLogging.GetLogger();
+
     /// <summary>
     /// Gets a value indicating whether the metrics should be loaded by the profiler. Default is true.
     /// </summary>
@@ -87,7 +91,8 @@ internal class MetricSettings : Settings
             case Constants.ConfigurationValues.None:
                 return MetricsExporter.None;
             default:
-                throw new FormatException($"Metric exporter '{metricsExporterEnvVar}' is not supported");
+                Logger.Error($"Metric exporter '{metricsExporterEnvVar}' is not supported. Defaulting to '{Constants.ConfigurationValues.Exporters.Otlp}'.");
+                return MetricsExporter.Otlp;
         }
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using OpenTelemetry.AutoInstrumentation.Logging;
+
 namespace OpenTelemetry.AutoInstrumentation.Configurations;
 
 /// <summary>
@@ -21,6 +23,8 @@ namespace OpenTelemetry.AutoInstrumentation.Configurations;
 /// </summary>
 internal class TracerSettings : Settings
 {
+    private static readonly IOtelLogger Logger = OtelLogging.GetLogger();
+
     /// <summary>
     /// Gets a value indicating whether the tracer should be loaded by the profiler. Default is true.
     /// </summary>
@@ -127,7 +131,8 @@ internal class TracerSettings : Settings
             case Constants.ConfigurationValues.None:
                 return TracesExporter.None;
             default:
-                throw new FormatException($"Traces exporter '{tracesExporterEnvVar}' is not supported");
+                Logger.Error($"Traces exporter '{tracesExporterEnvVar}' is not supported. Defaulting to '{Constants.ConfigurationValues.Exporters.Otlp}'.");
+                return TracesExporter.Otlp;
         }
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Logging/IOtelLogger.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Logging/IOtelLogger.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-
 namespace OpenTelemetry.AutoInstrumentation.Logging;
 
 internal interface IOtelLogger

--- a/src/OpenTelemetry.AutoInstrumentation/Logging/OtelLogging.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Logging/OtelLogging.cs
@@ -14,11 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 
 namespace OpenTelemetry.AutoInstrumentation.Logging;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
@@ -29,14 +29,6 @@ public class SettingsTests : IDisposable
         ClearEnvVars();
     }
 
-    public static IEnumerable<object[]> ExporterEnvVarAndLoadSettingsAction()
-    {
-        yield return new object[] { ConfigurationKeys.Traces.Exporter, new Action(() => Settings.FromDefaultSources<TracerSettings>()) };
-        yield return new object[] { ConfigurationKeys.Metrics.Exporter, new Action(() => Settings.FromDefaultSources<MetricSettings>()) };
-        yield return new object[] { ConfigurationKeys.Logs.Exporter, new Action(() => Settings.FromDefaultSources<LogSettings>()) };
-        yield return new object[] { ConfigurationKeys.Sdk.Propagators, new Action(() => Settings.FromDefaultSources<SdkSettings>()) };
-    }
-
     public void Dispose()
     {
         ClearEnvVars();
@@ -122,6 +114,7 @@ public class SettingsTests : IDisposable
 
     [Theory]
     [InlineData("none", TracesExporter.None)]
+    [InlineData("non-supported", TracesExporter.Otlp)]
     [InlineData("otlp", TracesExporter.Otlp)]
     [InlineData("zipkin", TracesExporter.Zipkin)]
     internal void TracesExporter_SupportedValues(string tracesExporter, TracesExporter expectedTracesExporter)
@@ -135,6 +128,7 @@ public class SettingsTests : IDisposable
 
     [Theory]
     [InlineData("none", MetricsExporter.None)]
+    [InlineData("non-supported", MetricsExporter.Otlp)]
     [InlineData("otlp", MetricsExporter.Otlp)]
     [InlineData("prometheus", MetricsExporter.Prometheus)]
     internal void MetricExporter_SupportedValues(string metricExporter, MetricsExporter expectedMetricsExporter)
@@ -148,6 +142,7 @@ public class SettingsTests : IDisposable
 
     [Theory]
     [InlineData("none", LogExporter.None)]
+    [InlineData("non-supported", LogExporter.Otlp)]
     [InlineData("otlp", LogExporter.Otlp)]
     internal void LogExporter_SupportedValues(string logExporter, LogExporter expectedLogExporter)
     {
@@ -160,10 +155,13 @@ public class SettingsTests : IDisposable
 
     [Theory]
     [InlineData(null, new Propagator[] { })]
+    [InlineData("not-supported", new Propagator[] { })]
+    [InlineData("not-supported1,not-supported2", new Propagator[] { })]
     [InlineData("tracecontext", new[] { Propagator.W3CTraceContext })]
     [InlineData("baggage", new[] { Propagator.W3CBaggage })]
     [InlineData("b3multi", new[] { Propagator.B3Multi })]
     [InlineData("b3", new[] { Propagator.B3Single })]
+    [InlineData("not-supported,b3", new Propagator[] { Propagator.B3Single })]
     [InlineData("tracecontext,baggage,b3multi,b3", new[] { Propagator.W3CTraceContext, Propagator.W3CBaggage, Propagator.B3Multi, Propagator.B3Single })]
     internal void Propagators_SupportedValues(string propagators, Propagator[] expectedPropagators)
     {
@@ -266,14 +264,6 @@ public class SettingsTests : IDisposable
         var settings = Settings.FromDefaultSources<LogSettings>();
 
         settings.IncludeFormattedMessage.Should().Be(expectedValue);
-    }
-
-    [Theory]
-    [MemberData(nameof(ExporterEnvVarAndLoadSettingsAction))]
-    internal void UnsupportedExporterValues(string exporterEnvVar, Action loadSettingsAction)
-    {
-        Environment.SetEnvironmentVariable(exporterEnvVar, "not-existing");
-        loadSettingsAction.Should().Throw<FormatException>();
     }
 
     [Theory]


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #2039

## What

Avoid FormatException while parsing configuration.
Use default values if needed.

## Tests

CI + Unit tests updated

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ Updated features are covered by tests.
