### PR TITLE
Make .psm1 easier to use with Dockerfiles

### DIFF
--- a/OpenTelemetry.DotNet.Auto.psm1
+++ b/OpenTelemetry.DotNet.Auto.psm1
@@ -63,7 +63,7 @@ function Download-OpenTelemetry([string]$Version, [string]$Path) {
     $dlUrl = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/$Version/$archive"
     $dlPath = Join-Path $Path $archive
 
-    Invoke-WebRequest -Uri $dlUrl -OutFile $dlPath
+    Invoke-WebRequest -Uri $dlUrl -OutFile $dlPath -UseBasicParsing
 
     return $dlPath
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,7 +182,7 @@ Example usage (run as administrator):
 # Download the module
 $module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
-Invoke-WebRequest -Uri $module_url -OutFile $download_path
+Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
 
 # Import the module to use its functions
 Import-Module $download_path


### PR DESCRIPTION
## Why

Very hard (impossible?) to use the powershell module from the collector script due to restrictions on first use of `Invoke-WebRequest`

## What

Adding the `-UseBasicParsing` prevents the issue on the usage of `Invoke-WebRequest`. The web proposes various workarounds and while they work for a script they don't work for the `Invoke-WebRequest` of the imported module - which is very weird since the most straightforward workaround uses the registry. Anyway, adding the parameters prevents the issue.

## Tests

I locally validated the fix in an ltsc2019 `windowsservercore` running IIS.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
