### PR TITLE
[CI] Add tests emitting events to one test collection

### DIFF
--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
@@ -22,6 +22,10 @@ using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations;
 
+// use collection to indicate that tests should not be run
+// in parallel
+// see https://xunit.net/docs/running-tests-in-parallel
+[Collection("EventEmittingTests")]
 public class SettingsTests : IDisposable
 {
     public SettingsTests()

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Diagnostics/SdkSelfDiagnosticsEventListenerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Diagnostics/SdkSelfDiagnosticsEventListenerTests.cs
@@ -26,6 +26,10 @@ using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Diagnostics;
 
+// use collection to indicate that tests should not be run
+// in parallel
+// see https://xunit.net/docs/running-tests-in-parallel
+[Collection("EventEmittingTests")]
 public class SdkSelfDiagnosticsEventListenerTests
 {
     [Fact]


### PR DESCRIPTION
## Why

Workaround for failing [tests](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/4444995345/jobs/7803707633?pr=2330).

## What

Put tests that emit events in a same tests collection so they do not run in parallel.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
