### PR TITLE
Grpc.Net.Client - multi library version test

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -38,6 +38,14 @@ public static class LibraryVersion
             }
         },
         {
+            "TestApplication.GrpcNetClient",
+            new List<string>
+            {
+                "2.43.0",
+                "2.52.0",
+            }
+        },
+        {
             "TestApplication.MassTransit",
             new List<string>
             {

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -9,8 +9,8 @@
     <PackageVersion Include="GraphQL.Server.Transports.AspNetCore" Version="3.4.0" />
     <PackageVersion Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />
     <PackageVersion Include="GraphQL.StarWars" Version="1.0.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.43.0" />
-    <PackageVersion Include="Grpc.Net.Client.Web" Version="2.43.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.52.0" />
+    <PackageVersion Include="Grpc.Net.Client.Web" Version="2.52.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.51.0" />
     <PackageVersion Include="MassTransit" Version="8.0.13" />
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />

--- a/test/IntegrationTests/GrpcNetClientTests.cs
+++ b/test/IntegrationTests/GrpcNetClientTests.cs
@@ -26,9 +26,10 @@ public class GrpcNetClientTests : TestHelper
     {
     }
 
-    [Fact]
+    [Theory]
     [Trait("Category", "EndToEnd")]
-    public void SubmitsTraces()
+    [MemberData(nameof(LibraryVersion.GrpcNetClient), MemberType = typeof(LibraryVersion))]
+    public void SubmitsTraces(string packageVersion)
     {
         using var collector = new MockSpansCollector(Output);
         SetExporter(collector);
@@ -38,7 +39,7 @@ public class GrpcNetClientTests : TestHelper
         // Enabling only GrpcNetClient instrumentation to have consistent set of spans.
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_INSTRUMENTATION_ENABLED", "false");
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_GRPCNETCLIENT_INSTRUMENTATION_ENABLED", "true");
-        RunTestApplication();
+        RunTestApplication(new TestSettings { PackageVersion = packageVersion });
 
         collector.AssertExpectations();
     }

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -40,6 +40,15 @@ public static class LibraryVersion
         new object[] { "2.4.0" },
 #endif
     };
+    public static readonly IReadOnlyCollection<object[]> GrpcNetClient = new List<object[]>
+    {
+#if DEFAULT_TEST_PACKAGE_VERSIONS
+        new object[] { string.Empty }
+#else
+        new object[] { "2.43.0" },
+        new object[] { "2.52.0" },
+#endif
+    };
     public static readonly IReadOnlyCollection<object[]> MassTransit = new List<object[]>
     {
 #if DEFAULT_TEST_PACKAGE_VERSIONS

--- a/test/test-applications/integrations/TestApplication.GrpcNetClient/TestApplication.GrpcNetClient.csproj
+++ b/test/test-applications/integrations/TestApplication.GrpcNetClient/TestApplication.GrpcNetClient.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" VersionOverride="3.19.4" />
-    <PackageReference Include="Grpc.Net.Client" />
-    <PackageReference Include="Grpc.Net.Client.Web" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Grpc.Net.Client" VersionOverride="$(LibraryVersion)" />
+    <PackageReference Include="Grpc.Net.Client.Web" Condition="'$(TargetFramework)' == 'net462'" VersionOverride="$(LibraryVersion)" />
     <PackageReference Include="Grpc.Tools" VersionOverride="2.44.0" />
     <!-- Workaround! Microsoft.Extensions.Logging.Abstractions v.3.1.0 is minimal version supported by auto instrumentation.
     Grpc.Net.Client references older version. It prevents to load required version from Additional Dependencies store-->

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -55,6 +55,17 @@ internal static class PackageVersionDefinitions
         },
         new()
         {
+            IntegrationName = "GrpcNetClient",
+            NugetPackageName = "Grpc.Net.Client",
+            TestApplicationName = "TestApplication.GrpcNetClient",
+            Versions = new List<string>
+            {
+                "2.43.0",
+                "*"
+            }
+        },
+        new()
+        {
             IntegrationName = "MassTransit",
             NugetPackageName = "MassTransit",
             TestApplicationName = "TestApplication.MassTransit",


### PR DESCRIPTION
## Why

Leftovers from #2230. Detected by #2320 and #2321 

## What

Grpc.Net.Client - multi library version test


Grpc.Net.Client and Grpc.Net.Client.Web are released together.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
