### PR TITLE
Make shell scripts work on sh (Bourne shell)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ else
     # If global.json exists, load expected version
     if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
         DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
-        if [[ "$DOTNET_VERSION" == ""  ]]; then
+        if [[ "$DOTNET_VERSION" = ""  ]]; then
             unset DOTNET_VERSION
         fi
     fi

--- a/instrument.sh
+++ b/instrument.sh
@@ -59,7 +59,7 @@ if [ -z "$(ls -A $OTEL_DOTNET_AUTO_HOME)" ]; then
   return 1
 fi
 # get absulute path
-if [ "$OS_TYPE" == "macos" ]; then
+if [ "$OS_TYPE" = "macos" ]; then
   OTEL_DOTNET_AUTO_HOME=$(greadlink -fn $OTEL_DOTNET_AUTO_HOME)
 else
   OTEL_DOTNET_AUTO_HOME=$(readlink -fn $OTEL_DOTNET_AUTO_HOME)
@@ -69,7 +69,7 @@ if [ -z "$OTEL_DOTNET_AUTO_HOME" ]; then
   return 1
 fi
 # on Windows change to Windows path format
-if [ "$OS_TYPE" == "windows" ]; then
+if [ "$OS_TYPE" = "windows" ]; then
   OTEL_DOTNET_AUTO_HOME=$(cygpath -w $OTEL_DOTNET_AUTO_HOME)
 fi
 if [ -z "$OTEL_DOTNET_AUTO_HOME" ]; then
@@ -78,7 +78,7 @@ if [ -z "$OTEL_DOTNET_AUTO_HOME" ]; then
 fi
 
 # set the platform-specific path separator (; on Windows and : on others)
-if [ "$OS_TYPE" == "windows" ]; then
+if [ "$OS_TYPE" = "windows" ]; then
   SEPARATOR=";"
 else
   SEPARATOR=":"
@@ -129,7 +129,7 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
   esac
 
   # Enable .NET Framework Profiling API
-  if [ "$OS_TYPE" == "windows" ]
+  if [ "$OS_TYPE" = "windows" ]
   then
     export COR_ENABLE_PROFILING="1"
     export COR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
@@ -141,7 +141,7 @@ if [ "$ENABLE_PROFILING" = "true" ]; then
   # Enable .NET Core Profiling API
   export CORECLR_ENABLE_PROFILING="1"
   export CORECLR_PROFILER="{918728DD-259F-4A6A-AC2B-B85E1B658318}"
-  if [ "$OS_TYPE" == "windows" ]
+  if [ "$OS_TYPE" = "windows" ]
   then
     # Set paths for both bitness on Windows, see https://docs.microsoft.com/en-us/dotnet/core/run-time-config/debugging-profiling#profiler-location
     export CORECLR_PROFILER_PATH_64="$OTEL_DOTNET_AUTO_HOME/win-x64/OpenTelemetry.AutoInstrumentation.Native.$SUFIX"

--- a/scripts/download-clang-tools.sh
+++ b/scripts/download-clang-tools.sh
@@ -24,7 +24,7 @@ if [ -z "$OS_TYPE" ]; then
 fi
 
 function DownloadClangTool {
-    if [ "$OS_TYPE" == "windows"  ]; then
+    if [ "$OS_TYPE" = "windows"  ]; then
         FILENAME=$1.exe
     else
         FILENAME=$1

--- a/scripts/format-native.sh
+++ b/scripts/format-native.sh
@@ -24,7 +24,7 @@ if [ -z "$OS_TYPE" ]; then
   esac
 fi
 
-if [ "$OS_TYPE" == "windows"  ]; then
+if [ "$OS_TYPE" = "windows"  ]; then
     EXT=.exe
 else
     EXT=


### PR DESCRIPTION
## Why

`instrument.sh` fails on macOS with 
```terminal
$ . $HOME/.otel-dotnet-auto/instrument.sh
/Users/pjanotti/.otel-dotnet-auto/instrument.sh:62: = not found
```

Related to #2037 

## What

Using the way recommended for POSIX instead of a way that only works on bash. A good explanation can be found [here]( https://stackoverflow.com/a/20449556).

## Tests

Manually checked on macOS, still pending Linux validation.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
