### PR TITLE
Fix MongoDB Server bumping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     directory: /docker
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "mongo"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: docker
     directory: /test/IntegrationTests/docker

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "mongo"
+        versions: ["6.*.*"]
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: docker

--- a/test/IntegrationTests/docker/mongodb.Dockerfile
+++ b/test/IntegrationTests/docker/mongodb.Dockerfile
@@ -1,1 +1,5 @@
+# Dependabot bumps only patch (see ignore in dependabot.yml).
+# Manually update major and minor if supported instrumentation version range changes. (See MongoClientIntegration.cs)
+# See compatibility table at https://www.mongodb.com/docs/drivers/csharp/current/compatibility/
+
 FROM mongo:5.0.6


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/2341

## What

Bumps only MongoDB Server patch version.

## Tests

Existing.
