### PR TITLE
Bump cmake package (alpine)

### DIFF
--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -4,7 +4,7 @@ RUN apk update \
     && apk upgrade \
     && apk add --no-cache --update \
         clang=13.0.1-r1 \
-        cmake=3.23.1-r0 \
+        cmake=3.23.5-r0 \
         make=4.3-r0 \
         bash=5.1.16-r2 \
         alpine-sdk=1.0-r1 \


### PR DESCRIPTION
## What

Bump cmake 3.23.1-r0 -> 3.23.5-r0

_FYI: Alpine package manager cannot request specific version. There is only one published version and the configuration only validates the version, if no match then break._
