### PR TITLE
Add Rule Engine to the StartupHook

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/DiagnosticSourceRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/DiagnosticSourceRule.cs
@@ -1,0 +1,26 @@
+// <copyright file="DiagnosticSourceRule.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
+
+internal class DiagnosticSourceRule : Rule
+{
+    internal override bool Evaluate()
+    {
+        // TODO: implement checking logic
+        return true;
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/InstrumentationAssemblyRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/InstrumentationAssemblyRule.cs
@@ -1,0 +1,26 @@
+// <copyright file="InstrumentationAssemblyRule.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
+
+internal class InstrumentationAssemblyRule : Rule
+{
+    internal override bool Evaluate()
+    {
+        // TODO: implement checking logic
+        return true;
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/OpenTelemetrySdkMinimumVersionRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/OpenTelemetrySdkMinimumVersionRule.cs
@@ -1,4 +1,4 @@
-// <copyright file="OpenTelemetrySdkRule.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetrySdkMinimumVersionRule.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,9 +20,15 @@ using OpenTelemetry.AutoInstrumentation.Logging;
 
 namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
 
-internal class OpenTelemetrySdkRule : Rule
+internal class OpenTelemetrySdkMinimumVersionRule : Rule
 {
     private static readonly IOtelLogger Logger = OtelLogging.GetLogger("StartupHook");
+
+    public OpenTelemetrySdkMinimumVersionRule()
+    {
+        Name = "OpenTelemetry SDK Validator";
+        Description = "Ensure that the OpenTelemetry SDK version is not older than the version used by the Auto-Instrumentation";
+    }
 
     internal override bool Evaluate()
     {

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/OpenTelemetrySdkRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/OpenTelemetrySdkRule.cs
@@ -1,0 +1,64 @@
+// <copyright file="OpenTelemetrySdkRule.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using System.Reflection;
+using OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
+
+internal class OpenTelemetrySdkRule : Rule
+{
+    private static readonly IOtelLogger Logger = OtelLogging.GetLogger("StartupHook");
+
+    internal override bool Evaluate()
+    {
+        string? oTelPackageVersion = null;
+
+        try
+        {
+            var openTelemetryType = Type.GetType("OpenTelemetry.Sdk, OpenTelemetry");
+            if (openTelemetryType != null)
+            {
+                var loadedOTelAssembly = Assembly.GetAssembly(openTelemetryType);
+                var loadedOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(loadedOTelAssembly?.Location);
+                var loadedOTelFileVersion = new Version(loadedOTelFileVersionInfo.FileVersion);
+
+                var autoInstrumentationOTelLocation = Path.Combine(StartupHook.LoaderAssemblyLocation ?? string.Empty, "OpenTelemetry.dll");
+                var autoInstrumentationOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(autoInstrumentationOTelLocation);
+                var autoInstrumentationOTelFileVersion = new Version(autoInstrumentationOTelFileVersionInfo.FileVersion);
+
+                if (loadedOTelFileVersion < autoInstrumentationOTelFileVersion)
+                {
+                    oTelPackageVersion = loadedOTelFileVersionInfo.FileVersion;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Exception in evaluation should not throw or crash the process.
+            Logger.Information($"Couldn't evaluate reference to OpenTelemetry Sdk in an app. Exception: {ex}");
+        }
+
+        if (oTelPackageVersion != null)
+        {
+            Logger.Error($"Application has direct or indirect reference to older version of OpenTelemetry package {oTelPackageVersion}.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/Rule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/Rule.cs
@@ -1,0 +1,26 @@
+// <copyright file="Rule.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
+
+internal abstract class Rule
+{
+    internal string? Name { get; set; }
+
+    internal string? Description { get; set; }
+
+    internal abstract bool Evaluate();
+}

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/Rule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/Rule.cs
@@ -18,9 +18,9 @@ namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
 
 internal abstract class Rule
 {
-    internal string? Name { get; set; }
+    public string Name { get; protected set; } = string.Empty;
 
-    internal string? Description { get; set; }
+    public string Description { get; protected set; } = string.Empty;
 
     internal abstract bool Evaluate();
 }

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuleEngine.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuleEngine.cs
@@ -24,21 +24,9 @@ internal class RuleEngine
 
     private readonly List<Rule> _rules = new()
     {
-        new OpenTelemetrySdkRule
-        {
-            Name = "OpenTelemetry SDK Validator",
-            Description = "Ensure that the OpenTelemetry SDK version is not older than the version used by the Auto-Instrumentation"
-        },
-        new DiagnosticSourceRule
-        {
-            Name = "System.Diagnostics.DiagnosticsSource Validator",
-            Description = "TODO"
-        },
-        new InstrumentationAssemblyRule
-        {
-            Name = "Instrumentation Library Validator",
-            Description = "TODO"
-        },
+        new OpenTelemetrySdkMinimumVersionRule(),
+        new DiagnosticSourceRule(),
+        new InstrumentationAssemblyRule()
     };
 
     internal bool Validate()

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuleEngine.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuleEngine.cs
@@ -1,0 +1,67 @@
+// <copyright file="RuleEngine.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
+
+internal class RuleEngine
+{
+    private static readonly IOtelLogger Logger = OtelLogging.GetLogger("StartupHook");
+
+    private readonly List<Rule> _rules = new()
+    {
+        new OpenTelemetrySdkRule
+        {
+            Name = "OpenTelemetry SDK Validator",
+            Description = "Ensure that the OpenTelemetry SDK version is not older than the version used by the Auto-Instrumentation"
+        },
+        new DiagnosticSourceRule
+        {
+            Name = "System.Diagnostics.DiagnosticsSource Validator",
+            Description = "TODO"
+        },
+        new InstrumentationAssemblyRule
+        {
+            Name = "Instrumentation Library Validator",
+            Description = "TODO"
+        },
+    };
+
+    internal bool Validate()
+    {
+        var result = true;
+
+        foreach (var rule in _rules)
+        {
+            try
+            {
+                if (!rule.Evaluate())
+                {
+                    Logger.Error($"Rule '{rule.Name}' failed: {rule.Description}");
+                    result = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error evaluating rule '{rule.Name}': {ex.Message}");
+                result = false;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
@@ -28,6 +28,7 @@ internal class StartupHook
 {
     private static readonly IOtelLogger Logger = OtelLogging.GetLogger("StartupHook");
 
+    // This property must be initialized before any rule is evaluated since it may be used during rule evaluation.
     internal static string? LoaderAssemblyLocation { get; set; }
 
     /// <summary>
@@ -70,7 +71,7 @@ internal class StartupHook
             var ruleEngine = new RuleEngine();
             if (!ruleEngine.Validate())
             {
-                Logger.Error("Rule Engine Failure: One or more rules failed validation");
+                Logger.Error("Rule Engine Failure: One or more rules failed validation. Auto-Instrumentation won't be loaded.");
                 return;
             }
 

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/StartupHook.cs
@@ -19,6 +19,7 @@ using System.Reflection;
 using System.Runtime.Versioning;
 using OpenTelemetry.AutoInstrumentation;
 using OpenTelemetry.AutoInstrumentation.Logging;
+using OpenTelemetry.AutoInstrumentation.RulesEngine;
 
 /// <summary>
 /// Dotnet StartupHook
@@ -26,6 +27,8 @@ using OpenTelemetry.AutoInstrumentation.Logging;
 internal class StartupHook
 {
     private static readonly IOtelLogger Logger = OtelLogging.GetLogger("StartupHook");
+
+    internal static string? LoaderAssemblyLocation { get; set; }
 
     /// <summary>
     /// Load and initialize OpenTelemetry.AutoInstrumentation assembly to bring OpenTelemetry SDK
@@ -60,15 +63,20 @@ internal class StartupHook
 
         Logger.Information("Attempting initialization.");
 
-        string loaderAssemblyLocation = GetLoaderAssemblyLocation();
+        LoaderAssemblyLocation = GetLoaderAssemblyLocation();
 
         try
         {
-            ThrowIfReferenceIncorrectOpenTelemetryVersion(loaderAssemblyLocation);
+            var ruleEngine = new RuleEngine();
+            if (!ruleEngine.Validate())
+            {
+                Logger.Error("Rule Engine Failure: One or more rules failed validation");
+                return;
+            }
 
             // Creating an instance of OpenTelemetry.AutoInstrumentation.Loader.Startup
             // will initialize Instrumentation through its static constructor.
-            string loaderFilePath = Path.Combine(loaderAssemblyLocation, "OpenTelemetry.AutoInstrumentation.Loader.dll");
+            string loaderFilePath = Path.Combine(LoaderAssemblyLocation, "OpenTelemetry.AutoInstrumentation.Loader.dll");
             Assembly loaderAssembly = Assembly.LoadFrom(loaderFilePath);
             var loaderInstance = loaderAssembly.CreateInstance("OpenTelemetry.AutoInstrumentation.Loader.Loader");
             if (loaderInstance is null)
@@ -82,7 +90,7 @@ internal class StartupHook
         }
         catch (Exception ex)
         {
-            Logger.Error($"Error in StartupHook initialization: LoaderFolderLocation: {loaderAssemblyLocation}, Error: {ex}");
+            Logger.Error($"Error in StartupHook initialization: LoaderFolderLocation: {LoaderAssemblyLocation}, Error: {ex}");
             throw;
         }
     }
@@ -160,43 +168,6 @@ internal class StartupHook
         {
             Logger.Error($"Error getting environment variable {variableName}: {ex}");
             return null;
-        }
-    }
-
-    private static void ThrowIfReferenceIncorrectOpenTelemetryVersion(string loaderAssemblyLocation)
-    {
-        string? oTelPackageVersion = null;
-
-        try
-        {
-            // Look up for type with an assembly name, will load the library.
-            // OpenTelemetry assembly load happens only if app has reference to the package.
-            var openTelemetryType = Type.GetType("OpenTelemetry.Sdk, OpenTelemetry");
-            if (openTelemetryType != null)
-            {
-                var loadedOTelAssembly = Assembly.GetAssembly(openTelemetryType);
-                var loadedOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(loadedOTelAssembly?.Location);
-                var loadedOTelFileVersion = new Version(loadedOTelFileVersionInfo.FileVersion);
-
-                var autoInstrumentationOTelLocation = Path.Combine(loaderAssemblyLocation, "OpenTelemetry.dll");
-                var autoInstrumentationOTelFileVersionInfo = FileVersionInfo.GetVersionInfo(autoInstrumentationOTelLocation);
-                var autoInstrumentationOTelFileVersion = new Version(autoInstrumentationOTelFileVersionInfo.FileVersion);
-
-                if (loadedOTelFileVersion < autoInstrumentationOTelFileVersion)
-                {
-                    oTelPackageVersion = loadedOTelFileVersionInfo.FileVersion;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            // Exception in evaluation should not throw or crash the process.
-            Logger.Information($"Couldn't evaluate reference to OpenTelemetry Sdk in an app. Exception: {ex}");
-        }
-
-        if (oTelPackageVersion != null)
-        {
-            throw new NotSupportedException($"Application has direct or indirect reference to older version of OpenTelemetry package {oTelPackageVersion}.");
         }
     }
 }


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #2392

## What

<!-- Describe changes proposed in this pull request. -->

This PR adds a rule engine to the StartupHook. The rule engine is designed to validate all OpenTelemetry assemblies and ensures that it backs off in unsupported scenarios instead of crashing. It validates all the rules and logs error to logger.

Implemented one of the rule, want to follow up other rules in a follow up PR.  Verified with manual test, it works as expected. CI results should confirm that it does not change behavior. 

**Follow-up items**
* Add implementation of other rules
* Add tests to validate rules
* Update changelog

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
