### PR TITLE
Make the ReJIT call from the ModuleLoadFinished callback a blocking call

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
@@ -412,6 +412,11 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejitForLoadedModu
 
     if (modulesVector.size() == 0 || definitions.size() == 0)
     {
+        if (promise != nullptr)
+        {
+            promise->set_value(0);
+        }
+
         return;
     }
 


### PR DESCRIPTION
## Why

In the recent native code update (https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/2280), there was a large amount of restructuring of code that organizes the `CorProfiler` and the ReJIT requests. One change was that the ReJIT call from the ModuleLoadFinished callback was no longer blocking. This PR ensures that it blocks (with a reasonable timeout) so that target methods will receive bytecode instrumentation on their first (and later) invocations.

Fixes #2452

## What

Updates the ModuleLoadFinished callback to invoke the `EnqueueRequestRejitForLoadedModules` API, which accepts a promise that will be completed when the ReJIT is finished.

## Tests

Uses the existing integration tests to validate the instrumentation

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~[ ] `CHANGELOG.md` is updated.~
- ~[ ] Documentation is updated.~
- ~[ ] New features are covered by tests.~
