### PR TITLE
Restore assembly redirection for .NET Framework

### DIFF
--- a/OpenTelemetry.AutoInstrumentation.sln
+++ b/OpenTelemetry.AutoInstrumentation.sln
@@ -184,7 +184,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.SelfContain
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.EntityFrameworkCore.Pomelo.MySql", "test\test-applications\integrations\TestApplication.EntityFrameworkCore.Pomelo.MySql\TestApplication.EntityFrameworkCore.Pomelo.MySql.csproj", "{1D7E11AA-27B6-4863-B5EC-1F0ECC6979B2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.AutoInstrumentation.StartupHook.Tests", "test\OpenTelemetry.AutoInstrumentation.StartupHook.Tests\OpenTelemetry.AutoInstrumentation.StartupHook.Tests.csproj", "{0077F121-DC2B-425E-A2F4-DEAC2A566E14}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.AutoInstrumentation.StartupHook.Tests", "test\OpenTelemetry.AutoInstrumentation.StartupHook.Tests\OpenTelemetry.AutoInstrumentation.StartupHook.Tests.csproj", "{0077F121-DC2B-425E-A2F4-DEAC2A566E14}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.AssemblyRedirection.NetFramework", "test\test-applications\integrations\TestApplication.AssemblyRedirection.NetFramework\TestApplication.AssemblyRedirection.NetFramework.csproj", "{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -862,6 +864,18 @@ Global
 		{0077F121-DC2B-425E-A2F4-DEAC2A566E14}.Release|x64.Build.0 = Release|Any CPU
 		{0077F121-DC2B-425E-A2F4-DEAC2A566E14}.Release|x86.ActiveCfg = Release|Any CPU
 		{0077F121-DC2B-425E-A2F4-DEAC2A566E14}.Release|x86.Build.0 = Release|Any CPU
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Debug|Any CPU.Build.0 = Debug|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Debug|x64.ActiveCfg = Debug|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Debug|x64.Build.0 = Debug|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Debug|x86.ActiveCfg = Debug|x86
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Debug|x86.Build.0 = Debug|x86
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Release|Any CPU.ActiveCfg = Release|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Release|Any CPU.Build.0 = Release|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Release|x64.ActiveCfg = Release|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Release|x64.Build.0 = Release|x64
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Release|x86.ActiveCfg = Release|x86
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -928,6 +942,7 @@ Global
 		{25ED93D0-A70C-4A07-84D9-EF94115259C9} = {2EF2F7CE-E56F-4B81-A5A5-277693529D43}
 		{1D7E11AA-27B6-4863-B5EC-1F0ECC6979B2} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 		{0077F121-DC2B-425E-A2F4-DEAC2A566E14} = {5C915382-C886-457D-8641-9E766D8E5A17}
+		{66FB648E-7FAF-418B-B2F6-B7CB9EE579CA} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/test/IntegrationTests/AssemblyRedirectionOnNetFrameworkTests.cs
+++ b/test/IntegrationTests/AssemblyRedirectionOnNetFrameworkTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="AssemblyRedirectionOnNetFrameworkTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+using FluentAssertions;
+using IntegrationTests.Helpers;
+using Xunit.Abstractions;
+
+namespace IntegrationTests;
+
+public class AssemblyRedirectionOnNetFrameworkTests : TestHelper
+{
+    public AssemblyRedirectionOnNetFrameworkTests(ITestOutputHelper output)
+        : base("AssemblyRedirection.NetFramework", output)
+    {
+    }
+
+    [Fact]
+    public void SubmitsTraces()
+    {
+        using var collector = new MockSpansCollector(Output);
+        SetExporter(collector);
+
+        const string TestApplicationActivitySource = "AssemblyRedirection.NetFramework.ActivitySource";
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES", TestApplicationActivitySource);
+        collector.Expect(TestApplicationActivitySource);
+
+        RunTestApplication();
+
+        collector.AssertExpectations();
+    }
+}
+#endif

--- a/test/test-applications/integrations/TestApplication.AssemblyRedirection.NetFramework/Program.cs
+++ b/test/test-applications/integrations/TestApplication.AssemblyRedirection.NetFramework/Program.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using System.Reflection;
+
+using var activitySource = new ActivitySource("AssemblyRedirection.NetFramework.ActivitySource");
+using var activity = activitySource.StartActivity("AssemblyRedirection.Activity");
+
+Console.WriteLine($"Running {Assembly.GetExecutingAssembly()?.Location}");
+
+var loadedAssemblyNames = new HashSet<string>();
+var hasMultipleInstancesOfSingleAssembly = false;
+var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+Array.Sort<Assembly>(assemblies, (l, r) => l.FullName?.CompareTo(r.FullName) ?? -1);
+Console.WriteLine("Loaded assemblies:");
+foreach (var assembly in assemblies)
+{
+    var location = assembly.IsDynamic ? "<dynamic>" : assembly.Location;
+    Console.WriteLine($" + {assembly.FullName}\n\t{location} ");
+    var assemblyName = assembly.GetName()?.Name ?? string.Empty;
+    if (!string.IsNullOrWhiteSpace(assemblyName) && !loadedAssemblyNames.Add(assemblyName))
+    {
+        hasMultipleInstancesOfSingleAssembly = true;
+        Console.WriteLine($"\n * WARNING: {assemblyName} loaded more than once.\n");
+    }
+}
+
+Console.WriteLine();
+return hasMultipleInstancesOfSingleAssembly ? -1 : 0;

--- a/test/test-applications/integrations/TestApplication.AssemblyRedirection.NetFramework/TestApplication.AssemblyRedirection.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.AssemblyRedirection.NetFramework/TestApplication.AssemblyRedirection.NetFramework.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- In order to test assembly redirection this project will force the use of specific versions -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/test/test-applications/integrations/TestApplication.AssemblyRedirection.NetFramework/TestApplication.AssemblyRedirection.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.AssemblyRedirection.NetFramework/TestApplication.AssemblyRedirection.NetFramework.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- WARNING: Keep this version of System.Diagnostics.DiagnosticSource to ensure the test is validating the actual scenario. -->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

To restore assembly redirection for .NET Framework.

Fixes #2466 

## What

* Add a dedicated test to ensure that .NET Framework redirection is working as intended.
* Put the call to redirection back in the native code.

## Pending

* Find a way for `dependabot` to ignore the test project: it needs to use an old version that we shouldn't upgrade. The initial search doesn't look promising: https://github.com/dependabot/dependabot-core/issues/4364

## Tests

Smoke and new test validated locally.

## Checklist

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
