### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.6.0...HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v0.7.0...HEAD)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.7.0)
 
 ### Added
 
@@ -27,19 +41,11 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `OTEL_DOTNET_AUTO_RESOURCE_DETECTOR_ENABLED`
   - `OTEL_DOTNET_AUTO_{0}_RESOURCE_DETECTOR_ENABLED`.
 
-### Changed
-
-### Deprecated
-
 ### Removed
 
 - Remove support for enabling debugging mode with `OTEL_DOTNET_AUTO_DEBUG`.
 - Removed `OTEL_DOTNET_AUTO_INTEGRATIONS_FILE` as a required environment
   variable for bytecode instrumentation setup
-
-### Fixed
-
-### Security
 
 ## [0.6.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.6.0)
 

--- a/OpenTelemetry.DotNet.Auto.psm1
+++ b/OpenTelemetry.DotNet.Auto.psm1
@@ -222,7 +222,7 @@ function Install-OpenTelemetryCore() {
         [string]$LocalPath
     )
 
-    $version = "v0.6.0"
+    $version = "v0.7.0"
     $installDir = Get-CLIInstallDir-From-InstallDir $InstallDir
     $archivePath = $null
     $deleteArchive = $true

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -43,8 +43,8 @@ partial class Build : NukeBuild
     [Parameter("The location to restore NuGet packages. Optional")]
     readonly AbsolutePath NuGetPackagesDirectory;
 
-    [Parameter("Version number of the NuGet packages built from the project. Default is '0.6.0'")]
-    string NuGetBaseVersionNumber = "0.6.0";
+    [Parameter("Version number of the NuGet packages built from the project. Default is '0.7.0'")]
+    string NuGetBaseVersionNumber = "0.7.0";
 
     [Parameter("Version suffix added to the NuGet packages built from the project. Default is '-local.1'")]
     string NuGetVersionSuffix = "-local.1";

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,14 +10,14 @@ to .NET applications without having to modify their source code.
 > **Warning**
 > The following documentation refers to the in-development version
 of OpenTelemetry .NET Automatic Instrumentation. Docs for the latest version
-([0.6.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
-can be found [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.6.0/docs/README.md).
+([0.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
+can be found [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.7.0/docs/README.md).
 
 ---
 
 ## Quick start
 
-If you'd like to try the instrumentation on an existing application before 
+If you'd like to try the instrumentation on an existing application before
 learning more about the configuration options and the project, follow
 these instructions:
 
@@ -166,7 +166,7 @@ Example usage:
 
 ```sh
 # Download the bash script
-curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0/otel-dotnet-auto-install.sh -O
+curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.7.0/otel-dotnet-auto-install.sh -O
 
 # Install core files
 sh ./otel-dotnet-auto-install.sh
@@ -189,7 +189,7 @@ uses environment variables as parameters:
 | `OTEL_DOTNET_AUTO_HOME` | Location where binaries are to be installed                      | No       | `$HOME/.otel-dotnet-auto` |
 | `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
 | `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `v0.6.0`                  |
+| `VERSION`               | Version to download                                              | No       | `v0.7.0`                  |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -208,7 +208,7 @@ Example usage (run as administrator):
 
 ```powershell
 # Download the module
-$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.6.0/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v0.7.0/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
 

--- a/examples/demo/Dockerfile
+++ b/examples/demo/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0-jammy
 
 # install OpenTelemetry .NET Automatic Instrumentation
-ARG OTEL_VERSION=0.6.0
+ARG OTEL_VERSION=0.7.0
 ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${OTEL_VERSION}/otel-dotnet-auto-install.sh otel-dotnet-auto-install.sh
 RUN apt-get update && apt-get install -y unzip && \
     OTEL_DOTNET_AUTO_HOME="/otel-dotnet-auto" sh otel-dotnet-auto-install.sh

--- a/otel-dotnet-auto-install.sh
+++ b/otel-dotnet-auto-install.sh
@@ -31,7 +31,7 @@ esac
 
 test -z "$OTEL_DOTNET_AUTO_HOME" && OTEL_DOTNET_AUTO_HOME="$HOME/.otel-dotnet-auto"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-test -z "$VERSION" && VERSION="v0.6.0"
+test -z "$VERSION" && VERSION="v0.7.0"
 
 RELEASES_URL="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases"
 ARCHIVE="opentelemetry-dotnet-instrumentation-$OS_TYPE.zip"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <EnablePublicApi>true</EnablePublicApi>
 
     <!-- NuGet packages -->
-    <Version>0.6.0$(VersionSuffix)</Version>
+    <Version>0.7.0$(VersionSuffix)</Version>
     <IsPackable>true</IsPackable>
     <PackageIconUrl>https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/raw/main/opentelemetry-logo-64x64.png</PackageIconUrl>
     <PackageIcon>packageIcon.png</PackageIcon>

--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0015 NEW)
 # Project definition
 # ******************************************************
 
-project("OpenTelemetry.AutoInstrumentation.Native" VERSION 0.6.0)
+project("OpenTelemetry.AutoInstrumentation.Native" VERSION 0.7.0)
 
 # ******************************************************
 # Environment detection

--- a/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,2,0,0
- PRODUCTVERSION 0,2,0,0
+ FILEVERSION 0,7,0,0
+ PRODUCTVERSION 0,7,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "The OpenTelemetry Authors"
             VALUE "FileDescription", "OpenTelemetry CLR Profiler"
-            VALUE "FileVersion", "0.6.0.0"
+            VALUE "FileVersion", "0.7.0.0"
             VALUE "InternalName", "OpenTelemetry.AutoInstrumentation.Native.DLL"
             VALUE "LegalCopyright", "Copyright 2021 The OpenTelemetry Authors"
             VALUE "OriginalFilename", "OpenTelemetry.AutoInstrumentation.Native.DLL"
             VALUE "ProductName", "OpenTelemetry .NET AutoInstrumentation"
-            VALUE "ProductVersion", "0.6.0"
+            VALUE "ProductVersion", "0.7.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -33,7 +33,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"OpenTelemetry", {1, 0, 0, 0} },
         { L"OpenTelemetry.Api", {1, 0, 0, 0} },
         { L"OpenTelemetry.Api.ProviderBuilderExtensions", {1, 0, 0, 0} },
-        { L"OpenTelemetry.AutoInstrumentation", {0, 6, 0, 0} },
+        { L"OpenTelemetry.AutoInstrumentation", {0, 7, 0, 0} },
         { L"OpenTelemetry.Exporter.Console", {1, 0, 0, 0} },
         { L"OpenTelemetry.Exporter.OpenTelemetryProtocol", {1, 0, 0, 0} },
         { L"OpenTelemetry.Exporter.Prometheus.HttpListener", {1, 0, 0, 0} },

--- a/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
@@ -69,13 +69,13 @@ const WSTRING opentelemetry_autoinstrumentation_loader_assemblyName = WStr("Open
 const WSTRING managed_profiler_name = WStr("OpenTelemetry.AutoInstrumentation");
 
 const WSTRING managed_profiler_full_assembly_version =
-    WStr("OpenTelemetry.AutoInstrumentation, Version=0.6.0.0, Culture=neutral, PublicKeyToken=null");
+    WStr("OpenTelemetry.AutoInstrumentation, Version=0.7.0.0, Culture=neutral, PublicKeyToken=null");
 
 const WSTRING nonwindows_nativemethods_type = WStr("OpenTelemetry.AutoInstrumentation.NativeMethods+NonWindows");
 const WSTRING windows_nativemethods_type = WStr("OpenTelemetry.AutoInstrumentation.NativeMethods+Windows");
 
 const WSTRING managed_profiler_full_assembly_version_strong_name =
-    WStr("OpenTelemetry.AutoInstrumentation, Version=0.6.0.0, Culture=neutral, PublicKeyToken=c0db600a13f60b51");
+    WStr("OpenTelemetry.AutoInstrumentation, Version=0.7.0.0, Culture=neutral, PublicKeyToken=c0db600a13f60b51");
 
 } // namespace trace
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/version.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/version.h
@@ -5,4 +5,4 @@
 
 #pragma once
 
-constexpr auto PROFILER_VERSION = "0.6.0";
+constexpr auto PROFILER_VERSION = "0.7.0";

--- a/src/OpenTelemetry.AutoInstrumentation/Constants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Constants.cs
@@ -20,7 +20,7 @@ internal static class Constants
 {
     public static class Tracer
     {
-        public const string Version = "0.6.0";
+        public const string Version = "0.7.0";
         public const string AutoInstrumentationVersionName = "telemetry.auto.version";
     }
 


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #2465

## What

Release 0.7.0.
Skipped part of config.md modification. Metrics documentation for packages link still to main due to lack of releases of packages.

## Tests

* [x] CI, except the demo due to lack of 0.7.0 release.
* [x] MacOS with Linux Containers
* [x] Windows with Linux Containers

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
