### PR TITLE
Add NET FX MongoDb integration tests

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -150,6 +150,6 @@ partial class Build : NukeBuild
 
     static string AndFilter(params string[] args)
     {
-        return string.Join("&", args);
+        return string.Join("&", args.Where(s => !string.IsNullOrEmpty(s)));
     }
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,6 +19,7 @@ partial class Build : NukeBuild
     readonly string Containers = ContainersLinux;
 
     const string ContainersNone = "none";
+    const string ContainersAny = "any";
     const string ContainersLinux = "linux";
     const string ContainersWindows = "windows";
 
@@ -125,13 +126,15 @@ partial class Build : NukeBuild
         switch (Containers)
         {
             case ContainersNone:
-                return "Containers!=Linux&Containers!=Windows";
+                return "Containers!=Linux&Containers!=Windows&Containers!=Any";
             case ContainersLinux:
                 return "Containers!=Windows";
             case ContainersWindows:
                 return "Containers!=Linux";
+            case ContainersAny:
+                throw new InvalidOperationException($"Containers={ContainersAny} is not supported directly. Specify concrete value, either Containers={ContainersLinux} or Containers={ContainersWindows}.");
             default:
-                throw new InvalidOperationException($"Container={Containers} is not supported");
+                throw new InvalidOperationException($"Containers={Containers} is not supported");
         }
     }
 
@@ -145,28 +148,8 @@ partial class Build : NukeBuild
         return "FullyQualifiedName~" + TestName;
     }
 
-    string AndFilter(params string[] args)
+    static string AndFilter(params string[] args)
     {
-        var result = string.Empty;
-        var first = true;
-
-        foreach (var arg in args)
-        {
-            if (string.IsNullOrEmpty(arg))
-            {
-                continue;
-            }
-
-            if (first)
-            {
-                result = arg;
-                first = false;
-                continue;
-            }
-
-            result += "&" + arg;
-        }
-
-        return result;
+        return string.Join("&", args);
     }
 }

--- a/test/IntegrationTests/MongoDBCollection.cs
+++ b/test/IntegrationTests/MongoDBCollection.cs
@@ -56,11 +56,18 @@ public class MongoDBFixture : IAsyncLifetime
 
     private async Task<IContainer> LaunchMongoContainerAsync(int port)
     {
+        var waitForOs =
+#if _WINDOWS
+         Wait.ForWindowsContainer();
+#else
+         Wait.ForUnixContainer();
+#endif
+
         var mongoContainersBuilder = new ContainerBuilder()
             .WithImage(MongoDBImage)
             .WithName($"mongo-db-{port}")
             .WithPortBinding(port, MongoDBPort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MongoDBPort));
+            .WithWaitStrategy(waitForOs.UntilPortIsAvailable(MongoDBPort));
 
         var container = mongoContainersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/MongoDBTests.cs
+++ b/test/IntegrationTests/MongoDBTests.cs
@@ -32,7 +32,7 @@ public class MongoDBTests : TestHelper
 
     [Theory]
     [Trait("Category", "EndToEnd")]
-    [Trait("Containers", "Linux")]
+    [Trait("Containers", "Any")]
     [MemberData(nameof(LibraryVersion.MongoDB), MemberType = typeof(LibraryVersion))]
     public void SubmitsTraces(string packageVersion)
     {


### PR DESCRIPTION
## Why

Fixes #2451

## What

Makes MongoDb integration tests to run also on Windows with Windows containers.

## Tests

Existing, running also on GH windows machine.

## Checklist

- [x] New features are covered by tests.
