### PR TITLE
Support OTEL_DOTNET_AUTO_FAIL_FAST_ENABLED in native code

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -38,15 +38,15 @@ using namespace std::chrono_literals;
 #include "netfx_assembly_redirection.h"
 #endif
 
-#define FailProfiler(LEVEL, MESSAGE)    \
-    Logger::LEVEL(MESSAGE);             \
-    if (IsFailFastEnabled())            \
-    {                                   \
-        throw std::exception(MESSAGE);  \
-    }                                   \
-    else                                \
-    {                                   \
-        return E_FAIL;                  \
+#define FailProfiler(LEVEL, MESSAGE)                                                                                   \
+    Logger::LEVEL(MESSAGE);                                                                                            \
+    if (IsFailFastEnabled())                                                                                           \
+    {                                                                                                                  \
+        throw std::exception(MESSAGE);                                                                                 \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        return E_FAIL;                                                                                                 \
     }
 
 namespace trace
@@ -129,7 +129,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     const auto& process_name          = GetCurrentProcessName();
     const auto& exclude_process_names = GetEnvironmentValues(environment::exclude_process_names);
 
-        // attach profiler only if this process's name is NOT on the list
+    // attach profiler only if this process's name is NOT on the list
     if (!exclude_process_names.empty() && Contains(exclude_process_names, process_name))
     {
         Logger::Info("Profiler disabled: ", process_name, " found in ", environment::exclude_process_names, ".");
@@ -163,7 +163,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
         if (app_pool_id_value.size() > 1 && app_pool_id_value.at(0) == '~')
         {
-            Logger::Info("Profiler disabled: ", environment::azure_app_services_app_pool_id, " ", app_pool_id_value, " is recognized as an Azure App Services infrastructure process.");
+            Logger::Info("Profiler disabled: ", environment::azure_app_services_app_pool_id, " ", app_pool_id_value,
+                         " is recognized as an Azure App Services infrastructure process.");
             FailProfiler(Info, "Profiler disabled - Azure App Services infrastructure process.")
         }
 
@@ -172,7 +173,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
         if (cli_telemetry_profile_value == WStr("AzureKudu"))
         {
-            Logger::Info("Profiler disabled: ", app_pool_id_value, " is recognized as Kudu, an Azure App Services reserved process.");
+            Logger::Info("Profiler disabled: ", app_pool_id_value,
+                         " is recognized as Kudu, an Azure App Services reserved process.");
             FailProfiler(Info, "Profiler disabled: - Kudu, an Azure App Services reserved process.")
         }
     }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -42,7 +42,7 @@ using namespace std::chrono_literals;
     Logger::LEVEL(MESSAGE);                                                                                            \
     if (IsFailFastEnabled())                                                                                           \
     {                                                                                                                  \
-        throw std::exception(MESSAGE);                                                                                 \
+        throw std::runtime_error(MESSAGE);                                                                             \
     }                                                                                                                  \
     else                                                                                                               \
     {                                                                                                                  \

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
@@ -90,6 +90,9 @@ const WSTRING clr_enable_ngen = WStr("OTEL_DOTNET_AUTO_CLR_ENABLE_NGEN");
 // Enable the assembly version redirection when running on the .NET Framework.
 const WSTRING netfx_assembly_redirection_enabled = WStr("OTEL_DOTNET_AUTO_NETFX_REDIRECT_ENABLED");
 
+// Enable the fail fast mode.
+const WSTRING fail_fast_enabled = WStr("OTEL_DOTNET_AUTO_FAIL_FAST_ENABLED");
+
 // The list of startup hooks defined for .NET Core 3.1+ applications.
 // This is a .NET runtime environment variable. 
 // See https://github.com/dotnet/runtime/blob/main/docs/design/features/host-startup-hook.md

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables.h
@@ -90,14 +90,6 @@ const WSTRING clr_enable_ngen = WStr("OTEL_DOTNET_AUTO_CLR_ENABLE_NGEN");
 // Enable the assembly version redirection when running on the .NET Framework.
 const WSTRING netfx_assembly_redirection_enabled = WStr("OTEL_DOTNET_AUTO_NETFX_REDIRECT_ENABLED");
 
-// Additional dependencies that are to be lighted up at runtime.
-// See https://github.com/dotnet/runtime/blob/main/docs/design/features/additional-deps.md
-const WSTRING dotnet_additional_deps = WStr("DOTNET_ADDITIONAL_DEPS");
-
-// Runtime package store.
-// See https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-store
-const WSTRING dotnet_shared_store = WStr("DOTNET_SHARED_STORE");
-
 // The list of startup hooks defined for .NET Core 3.1+ applications.
 // This is a .NET runtime environment variable. 
 // See https://github.com/dotnet/runtime/blob/main/docs/design/features/host-startup-hook.md

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.cpp
@@ -33,6 +33,11 @@ bool IsAzureAppServices()
     CheckIfTrue(GetEnvironmentValue(environment::azure_app_services));
 }
 
+bool IsFailFastEnabled()
+{
+    CheckIfTrue(GetEnvironmentValue(environment::fail_fast_enabled));
+}
+
 bool AreTracesEnabled()
 {
     ToBooleanWithDefault(GetEnvironmentValue(environment::traces_enabled), true);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/environment_variables_util.h
@@ -48,6 +48,7 @@ bool EnableInlining();
 bool IsNGENEnabled();
 bool IsDumpILRewriteEnabled();
 bool IsAzureAppServices();
+bool IsFailFastEnabled();
 bool AreTracesEnabled();
 bool AreMetricsEnabled();
 bool AreLogsEnabled();

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -358,7 +358,6 @@ public class SmokeTests : TestHelper
         VerifyTestApplicationNotInstrumented();
     }
 
-#if NET6_0_OR_GREATER
     [Fact]
     [Trait("Category", "EndToEnd")]
     public void ApplicationFailFastEnabled()
@@ -378,7 +377,6 @@ public class SmokeTests : TestHelper
 
         process!.ExitCode.Should().NotBe(0);
     }
-#endif
 
     private void VerifyTestApplicationInstrumented()
     {


### PR DESCRIPTION
## Why

Towards #2480

## What

`OTEL_DOTNET_AUTO_FAIL_FAST_ENABLED` for Native code

## Tests

CI + Manual testing + extended smoke test

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
