### PR TITLE
Fix log template

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -187,7 +187,7 @@ internal static class Instrumentation
                 def.Dispose();
             }
 
-            Logger.Information<int>("The profiler has been initialized with {count} definitions.", payload.Definitions.Length);
+            Logger.Information<int>("The profiler has been initialized with {0} definitions.", payload.Definitions.Length);
         }
         catch (Exception ex)
         {
@@ -204,7 +204,7 @@ internal static class Instrumentation
                 def.Dispose();
             }
 
-            Logger.Information<int>("The profiler has been initialized with {count} derived definitions.", payload.Definitions.Length);
+            Logger.Information<int>("The profiler has been initialized with {0} derived definitions.", payload.Definitions.Length);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Why

avoid exceptions similar to:
```
[2023-05-16T06:55:58.4064750Z] [Error] Input string was not in a correct format.
Exception: Input string was not in a correct format.
System.FormatException: Input string was not in a correct format.
   at System.Text.ValueStringBuilder.ThrowFormatInvalidString()
   at System.Text.ValueStringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at System.String.Format(String format, Object[] args)
   at OpenTelemetry.AutoInstrumentation.Logging.InternalLogger.WriteImpl(LogLevel level, Exception exception, String messageTemplate, Object[] args, Boolean writeToEventLog) in C:\GitHub\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.AutoInstrumentation\Logging\InternalLogger.cs:line 215
   at OpenTelemetry.AutoInstrumentation.Logging.InternalLogger.Write[T](LogLevel level, Exception exception, String messageTemplate, T property, Boolean writeToEventLog) in C:\GitHub\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.AutoInstrumentation\Logging\InternalLogger.cs:line 182
   at OpenTelemetry.AutoInstrumentation.Logging.InternalLogger.Information[T](String messageTemplate, T property, Boolean writeToEventLog) in C:\GitHub\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.AutoInstrumentation\Logging\InternalLogger.cs:line 72
   at OpenTelemetry.AutoInstrumentation.Instrumentation.Initialize() in C:\GitHub\opentelemetry-dotnet-instrumentation\src\OpenTelemetry.AutoInstrumentation\Instrumentation.cs:line 207 
```

## What

Fix log template

## Tests

CI + Manual check.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
