### PR TITLE
IIS-tests remove unneeded bindings

### DIFF
--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -138,8 +138,7 @@ public class AspNetTests
             .WithName($"{imageName}-{webPort}")
             .WithNetwork(networkId, networkName)
             .WithPortBinding(webPort, 80)
-            .WithBindMount(logPath, "c:/inetpub/wwwroot/logs")
-            .WithBindMount(EnvironmentHelper.GetNukeBuildOutput(), "c:/opentelemetry");
+            .WithBindMount(logPath, "c:/inetpub/wwwroot/logs");
 
         foreach (var env in _environmentVariables)
         {

--- a/test/IntegrationTests/WcfIISTests.cs
+++ b/test/IntegrationTests/WcfIISTests.cs
@@ -15,16 +15,11 @@
 // </copyright>
 
 #if NETFRAMEWORK
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using FluentAssertions;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace IntegrationTests;
@@ -95,8 +90,7 @@ public class WcfIISTests : TestHelper
             .WithNetwork(networkId, DockerNetworkHelper.IntegrationTestsNetworkName)
             .WithPortBinding(netTcpPort, 808)
             .WithPortBinding(httpPort, 80)
-            .WithBindMount(logPath, "c:/inetpub/wwwroot/logs")
-            .WithBindMount(EnvironmentHelper.GetNukeBuildOutput(), "c:/opentelemetry");
+            .WithBindMount(logPath, "c:/inetpub/wwwroot/logs");
 
         foreach (var env in _environmentVariables)
         {


### PR DESCRIPTION
## Why & What

Remove not used bindings to NukeBuildOutput.
OpeneTelemetry is added to docker.

## Tests

CI

## Checklist

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
