### PR TITLE
Set TreatWarningAsError to true on vcxproj

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
@@ -96,6 +96,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>SPDLOG_COMPILED_LIB;SPDLOG_FMT_EXTERNAL;BIT64;HOST_64BIT;AMD64;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(LIB_INCLUDES);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib>
       <AdditionalLibraryDirectories>$(LIB_INCLUDES);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -117,6 +118,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>SPDLOG_COMPILED_LIB;SPDLOG_FMT_EXTERNAL;_UNICODE;UNICODE;X86;HOST_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(LIB_INCLUDES);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib>
       <TargetMachine>MachineX86</TargetMachine>
@@ -143,6 +145,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>SPDLOG_COMPILED_LIB;SPDLOG_FMT_EXTERNAL;_TARGET_64BIT;BIT64;HOST_64BIT;AMD64;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(LIB_INCLUDES);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib>
       <AdditionalLibraryDirectories>$(LIB_INCLUDES);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -168,6 +171,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>SPDLOG_COMPILED_LIB;SPDLOG_FMT_EXTERNAL;_UNICODE;UNICODE;X86;HOST_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(LIB_INCLUDES);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Lib>
       <AdditionalLibraryDirectories>$(LIB_INCLUDES);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
@@ -114,12 +114,13 @@ size_t GetConfiguredSize(const WSTRING& name, const size_t default_value)
         {
             return default_value;
         }
-        const auto converted = std::stoll(configured_value);
-        if (converted < 0)
+        const auto converted = std::stoul(configured_value);
+        const size_t max_size_t = (size_t)-1;
+        if (converted > max_size_t)
         {
             return default_value;
         }
-        return converted;
+        return static_cast<size_t>(converted);
     }
     catch (...)
     {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
@@ -114,7 +114,7 @@ size_t GetConfiguredSize(const WSTRING& name, const size_t default_value)
         {
             return default_value;
         }
-        const auto converted = std::stoul(configured_value);
+        const auto   converted  = std::stoul(configured_value);
         const size_t max_size_t = (size_t)-1;
         if (converted > max_size_t)
         {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/util.cpp
@@ -114,9 +114,9 @@ size_t GetConfiguredSize(const WSTRING& name, const size_t default_value)
         {
             return default_value;
         }
-        const auto   converted  = std::stoul(configured_value);
+        const auto   converted  = std::stoll(configured_value);
         const size_t max_size_t = (size_t)-1;
-        if (converted > max_size_t)
+        if (converted < 0 || converted > max_size_t)
         {
             return default_value;
         }


### PR DESCRIPTION
## Why

Avoid warnings being added silently.

## What

Set TreatWarningAsError to true on vcxproj and fix a warning that was being generated.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
