### PR TITLE
[Tests] Bump opentelemetry protocol files to v.0.20.0

### DIFF
--- a/test/IntegrationTests/opentelemetry/proto/collector/trace/v1/trace_service_http.yaml
+++ b/test/IntegrationTests/opentelemetry/proto/collector/trace/v1/trace_service_http.yaml
@@ -5,5 +5,5 @@ config_version: 3
 http:
  rules:
  - selector: opentelemetry.proto.collector.trace.v1.TraceService.Export
-   post: /v1/trace
+   post: /v1/traces
    body: "*"

--- a/test/IntegrationTests/opentelemetry/proto/common/v1/common.proto
+++ b/test/IntegrationTests/opentelemetry/proto/common/v1/common.proto
@@ -72,6 +72,10 @@ message InstrumentationScope {
   // An empty instrumentation scope name means the name is unknown.
   string name = 1;
   string version = 2;
+
+  // Additional attributes that describe the scope. [Optional].
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
   repeated KeyValue attributes = 3;
   uint32 dropped_attributes_count = 4;
 }

--- a/test/IntegrationTests/opentelemetry/proto/logs/v1/logs.proto
+++ b/test/IntegrationTests/opentelemetry/proto/logs/v1/logs.proto
@@ -104,10 +104,21 @@ enum SeverityNumber {
   SEVERITY_NUMBER_FATAL4 = 24;
 }
 
-// Masks for LogRecord.flags field.
+// LogRecordFlags is defined as a protobuf 'uint32' type and is to be used as
+// bit-fields. Each non-zero value defined in this enum is a bit-mask.
+// To extract the bit-field, for example, use an expression like:
+//
+//   (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
+//
 enum LogRecordFlags {
-  LOG_RECORD_FLAG_UNSPECIFIED = 0;
-  LOG_RECORD_FLAG_TRACE_FLAGS_MASK = 0x000000FF;
+  // The zero value for the enum. Should not be used for comparisons.
+  // Instead use bitwise "and" with the appropriate mask as shown above.
+  LOG_RECORD_FLAGS_DO_NOT_USE = 0;
+
+  // Bits 0-7 are used for trace flags.
+  LOG_RECORD_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
+
+  // Bits 8-31 are reserved for future use.
 }
 
 // A log record according to OpenTelemetry Log Data Model:
@@ -160,18 +171,33 @@ message LogRecord {
   // defined in W3C Trace Context specification. 24 most significant bits are reserved
   // and must be set to 0. Readers must not assume that 24 most significant bits
   // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
-  // flags & TRACE_FLAGS_MASK). [Optional].
+  // flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK). [Optional].
   fixed32 flags = 8;
 
   // A unique identifier for a trace. All logs from the same trace share
-  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
-  // is considered invalid. Can be set for logs that are part of request processing
-  // and have an assigned trace id. [Optional].
+  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+  // of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is optional.
+  //
+  // The receivers SHOULD assume that the log record is not associated with a
+  // trace if any of the following is true:
+  //   - the field is not present,
+  //   - the field contains an invalid value.
   bytes trace_id = 9;
 
   // A unique identifier for a span within a trace, assigned when the span
-  // is created. The ID is an 8-byte array. An ID with all zeroes is considered
-  // invalid. Can be set for logs that are part of a particular processing span.
-  // If span_id is present trace_id SHOULD be also present. [Optional].
+  // is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+  // other than 8 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
+  //
+  // This field is optional. If the sender specifies a valid span_id then it SHOULD also
+  // specify a valid trace_id.
+  //
+  // The receivers SHOULD assume that the log record is not associated with a
+  // span if any of the following is true:
+  //   - the field is not present,
+  //   - the field contains an invalid value.
   bytes span_id = 10;
 }

--- a/test/IntegrationTests/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/test/IntegrationTests/opentelemetry/proto/metrics/v1/metrics.proto
@@ -316,15 +316,17 @@ enum AggregationTemporality {
 // enum is a bit-mask.  To test the presence of a single flag in the flags of
 // a data point, for example, use an expression like:
 //
-//   (point.flags & FLAG_NO_RECORDED_VALUE) == FLAG_NO_RECORDED_VALUE
+//   (point.flags & DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK) == DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK
 //
 enum DataPointFlags {
-  FLAG_NONE = 0;
+  // The zero value for the enum. Should not be used for comparisons.
+  // Instead use bitwise "and" with the appropriate mask as shown above.
+  DATA_POINT_FLAGS_DO_NOT_USE = 0;
 
   // This DataPoint is valid but has no recorded value.  This value
   // SHOULD be used to reflect explicitly missing data in a series, as
   // for an equivalent to the Prometheus "staleness marker".
-  FLAG_NO_RECORDED_VALUE = 1;
+  DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK = 1;
 
   // Bits 2-31 are reserved for future use.
 }
@@ -501,8 +503,8 @@ message ExponentialHistogramDataPoint {
   //   base = (2^(2^-scale))
   //
   // The histogram bucket identified by `index`, a signed integer,
-  // contains values that are greater than or equal to (base^index) and
-  // less than (base^(index+1)).
+  // contains values that are greater than (base^index) and
+  // less than or equal to (base^(index+1)).
   //
   // The positive and negative ranges of the histogram are expressed
   // separately.  Negative values are mapped by their absolute value
@@ -536,9 +538,9 @@ message ExponentialHistogramDataPoint {
     // Note: This uses a varint encoding as a simple form of compression.
     sint32 offset = 1;
 
-    // Count is an array of counts, where count[i] carries the count
-    // of the bucket at index (offset+i).  count[i] is the count of
-    // values greater than or equal to base^(offset+i) and less than
+    // bucket_counts is an array of count values, where bucket_counts[i] carries
+    // the count of the bucket at index (offset+i). bucket_counts[i] is the count
+    // of values greater than base^(offset+i) and less than or equal to
     // base^(offset+i+1).
     //
     // Note: By contrast, the explicit HistogramDataPoint uses
@@ -561,6 +563,14 @@ message ExponentialHistogramDataPoint {
 
   // max is the maximum value over (start_time, end_time].
   optional double max = 13;
+
+  // ZeroThreshold may be optionally set to convey the width of the zero
+  // region. Where the zero region is defined as the closed interval
+  // [-ZeroThreshold, ZeroThreshold].
+  // When ZeroThreshold is 0, zero count bucket stores values that cannot be
+  // expressed using the standard exponential formula as well as values that
+  // have been rounded to zero.
+  double zero_threshold = 14;
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the

--- a/test/IntegrationTests/opentelemetry/proto/trace/v1/trace.proto
+++ b/test/IntegrationTests/opentelemetry/proto/trace/v1/trace.proto
@@ -79,21 +79,17 @@ message ScopeSpans {
 // The next available field id is 17.
 message Span {
   // A unique identifier for a trace. All spans from the same trace share
-  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
-  // is considered invalid.
-  //
-  // This field is semantically required. Receiver should generate new
-  // random trace_id if empty or invalid trace_id was received.
+  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+  // of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
   //
   // This field is required.
   bytes trace_id = 1;
 
   // A unique identifier for a span within a trace, assigned when the span
-  // is created. The ID is an 8-byte array. An ID with all zeroes is considered
-  // invalid.
-  //
-  // This field is semantically required. Receiver should generate new
-  // random span_id if empty or invalid span_id was received.
+  // is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+  // other than 8 bytes is considered invalid (empty string in OTLP/JSON
+  // is zero-length and thus is also invalid).
   //
   // This field is required.
   bytes span_id = 2;
@@ -176,8 +172,8 @@ message Span {
   //
   //     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
   //     "/http/server_latency": 300
-  //     "abc.com/myattribute": true
-  //     "abc.com/score": 10.239
+  //     "example.com/myattribute": true
+  //     "example.com/score": 10.239
   //
   // The OpenTelemetry API specification further restricts the allowed value types:
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
@@ -268,8 +264,8 @@ message Status {
   enum StatusCode {
     // The default status.
     STATUS_CODE_UNSET               = 0;
-    // The Span has been validated by an Application developers or Operator to have
-    // completed successfully.
+    // The Span has been validated by an Application developer or Operator to 
+    // have completed successfully.
     STATUS_CODE_OK                  = 1;
     // The Span contains an error.
     STATUS_CODE_ERROR               = 2;


### PR DESCRIPTION
## Why

Sync with latest realease.

Fixes #

## What

[Tests] Bump opentelemetry protocol files to v.0.20.0 based on
https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.20.0

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
