### PR TITLE
Rename build_data dir to test-artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         if: always()
         with:
           name: test-logs-${{ matrix.machine }}-${{ matrix.test-tfm }}-containers-${{ matrix.containers }}
-          path: build_data/
+          path: test-artifacts/
       - name: Delete SQL Server MSI
         if: ${{ runner.os == 'Windows' }}
         shell: bash
@@ -307,7 +307,7 @@ jobs:
         if: always()
         with:
           name: test-logs-${{ matrix.machine }}-containers-${{ matrix.containers }}
-          path: build_data/
+          path: test-artifacts/
 
   test-build-container:
     needs: build-container

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -38,4 +38,4 @@ jobs:
         if: always()
         with:
           name: logs-${{ matrix.machine }}
-          path: build_data/
+          path: test-artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -305,8 +305,8 @@ src/OpenTelemetry.AutoInstrumentation.Native/cmake_install.cmake
 # ignore verify .received files
 *.received.*
 
-# profiler and test logs
-/build_data
+# ignore logs and test results
+/test-artifacts
 
 # install.sh downloaded artifacts
 /otel-dotnet-auto/

--- a/build/Build.Steps.cs
+++ b/build/Build.Steps.cs
@@ -25,8 +25,8 @@ partial class Build
     AbsolutePath TestsDirectory => RootDirectory / "test";
 
     AbsolutePath TracerHomeDirectory => TracerHome ?? (OutputDirectory / "tracer-home");
-    AbsolutePath BuildDataDirectory => RootDirectory / "build_data";
-    AbsolutePath ProfilerTestLogs => BuildDataDirectory / "profiler-logs";
+    AbsolutePath TestArtifactsDirectory => RootDirectory / "test-artifacts";
+    AbsolutePath ProfilerTestLogs => TestArtifactsDirectory / "profiler-logs";
     AbsolutePath AdditionalDepsDirectory => TracerHomeDirectory / "AdditionalDeps";
     AbsolutePath StoreDirectory => TracerHomeDirectory / "store";
 
@@ -58,7 +58,7 @@ partial class Build
         {
             TracerHomeDirectory.CreateDirectory();
             NuGetArtifactsDirectory.CreateDirectory();
-            BuildDataDirectory.CreateDirectory();
+            TestArtifactsDirectory.CreateDirectory();
             ProfilerTestLogs.CreateDirectory();
         });
 
@@ -356,7 +356,7 @@ partial class Build
 
     Target RunManagedTests => _ => _
         .Unlisted()
-        .Produces(BuildDataDirectory / "profiler-logs" / "*")
+        .Produces(TestArtifactsDirectory / "profiler-logs" / "*")
         .After(BuildTracer)
         .After(CompileManagedTests)
         .After(PublishMocks)
@@ -615,7 +615,7 @@ partial class Build
         .DependsOn(MarkdownLint)
         .DependsOn(SpellcheckDocumentation);
 
-    private AbsolutePath GetResultsDirectory(Project proj) => BuildDataDirectory / "results" / proj.Name;
+    private AbsolutePath GetResultsDirectory(Project proj) => TestArtifactsDirectory / "results" / proj.Name;
 
     /// <summary>
     /// Bootstrapping tests require every single test to be run in a separate process

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -75,7 +75,7 @@ partial class Build : NukeBuild
             NuGetArtifactsDirectory.CreateOrCleanDirectory();
             (NativeProfilerProject.Directory / "build").CreateOrCleanDirectory();
             (NativeProfilerProject.Directory / "deps").CreateOrCleanDirectory();
-            BuildDataDirectory.CreateOrCleanDirectory();
+            TestArtifactsDirectory.CreateOrCleanDirectory();
 
             void DeleteReparsePoints(string path)
             {

--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -128,7 +128,7 @@ public class AspNetTests
         string networkId = await DockerNetworkHelper.SetupIntegrationTestsNetworkAsync();
 
         string logPath = EnvironmentHelper.IsRunningOnCI()
-            ? Path.Combine(Environment.GetEnvironmentVariable("GITHUB_WORKSPACE"), "build_data", "profiler-logs")
+            ? Path.Combine(Environment.GetEnvironmentVariable("GITHUB_WORKSPACE"), "test-artifacts", "profiler-logs")
             : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"OpenTelemetry .NET AutoInstrumentation", "logs");
         Directory.CreateDirectory(logPath);
         Output.WriteLine("Collecting docker logs to: " + logPath);

--- a/test/IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -278,7 +278,7 @@ public class EnvironmentHelper
         CustomEnvironmentVariables["COR_PROFILER_PATH"] = profilerPath;
 
         CustomEnvironmentVariables["OTEL_LOG_LEVEL"] = "debug";
-        CustomEnvironmentVariables["OTEL_DOTNET_AUTO_LOG_DIRECTORY"] = Path.Combine(EnvironmentTools.GetSolutionDirectory(), "build_data", "profiler-logs");
+        CustomEnvironmentVariables["OTEL_DOTNET_AUTO_LOG_DIRECTORY"] = Path.Combine(EnvironmentTools.GetSolutionDirectory(), "test-artifacts", "profiler-logs");
         CustomEnvironmentVariables["OTEL_DOTNET_AUTO_HOME"] = GetNukeBuildOutput();
         CustomEnvironmentVariables["OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES"] = "TestApplication.*";
 

--- a/test/IntegrationTests/WcfIISTests.cs
+++ b/test/IntegrationTests/WcfIISTests.cs
@@ -76,7 +76,7 @@ public class WcfIISTests : TestHelper
         var networkId = await DockerNetworkHelper.SetupIntegrationTestsNetworkAsync();
 
         var logPath = EnvironmentHelper.IsRunningOnCI()
-            ? Path.Combine(Environment.GetEnvironmentVariable("GITHUB_WORKSPACE"), "build_data", "profiler-logs")
+            ? Path.Combine(Environment.GetEnvironmentVariable("GITHUB_WORKSPACE"), "test-artifacts", "profiler-logs")
             : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"OpenTelemetry .NET AutoInstrumentation", "logs");
 
         Directory.CreateDirectory(logPath);


### PR DESCRIPTION
## Why

Make the name of the dir match its actual usage.

## What

Renamed `build_data/` to `test-artifacts` to make the name match its purpose. The old name made sense in the context of having the CI job `build`, but, with the changes to reduce CI duration and the breakdown in build and test jobs, the name became really outdated.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
