### PR TITLE
Remove reference to nlohman/json in native code

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -97,11 +97,6 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
 # ******************************************************
 
 # Add custom commands to setup dependencies via git
-add_custom_command(
-    OUTPUT ${OUTPUT_DEPS_DIR}/json/include/nlohmann/json.hpp
-    COMMAND git clone -c advice.detachedHead=false --quiet --depth 1 --branch v3.11.2 https://github.com/nlohmann/json.git
-    WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
-)
 
 add_custom_command(
     OUTPUT ${OUTPUT_DEPS_DIR}/re2/obj/libre2.a
@@ -187,7 +182,6 @@ add_library("OpenTelemetry.AutoInstrumentation.Native.static" STATIC
         lib/coreclr/src/pal/prebuilt/idl/corprof_i.cpp
         # Source dependencies retrievied via additional commands using git
         ${OUTPUT_DEPS_DIR}/fmt/libfmt.a
-        ${OUTPUT_DEPS_DIR}/json/include/nlohmann/json.hpp
         ${OUTPUT_DEPS_DIR}/re2/obj/libre2.a
 )
 

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
@@ -104,7 +104,6 @@
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets" Condition="Exists('..\..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets')" />
     <Import Project="..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets" Condition="Exists('..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -198,7 +197,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets'))" />
   </Target>
 </Project>

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/packages.config
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.1.7" targetFramework="native" />
-  <package id="nlohmann.json" version="3.11.2" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Why

Remove unused dependency.

Fixes #

## What

Remove reference to nlohman/json in native code
Probably lefrover from parsing instrumentation.json.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
