### PR TITLE
Use Microsoft.Build.Utilities.Core per doc recommendation

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
 
   <!-- Versions from OpenTelemetry.AutoInstrumentation.BuildTasks.csproj -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
     <PackageReference Include="NuGet.Versioning" PrivateAssets="all" Pin="true" />
   </ItemGroup>
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Build" Version="15.9.20" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />

--- a/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests.csproj
+++ b/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <!-- Packages referenced by the BuildTasks are not transferred to the test library so add them here so it can be used by the tests. -->
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
 


### PR DESCRIPTION
## Why

Follow Microsoft.Build.Task.Core package README.md recommendation

## What

Use the package as recommended by https://www.nuget.org/packages/Microsoft.Build.Tasks.Core#readme-body-tab (I didn't notice this on the initial change).

## Tests

Confirmed that this ends up loading the class from the same assembly, so this should be a NOP.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
