### PR TITLE
Do not break on multiple runs of Loader tests

### DIFF
--- a/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/LoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/LoaderTests.cs
@@ -38,16 +38,15 @@ public class LoaderTests
 #if NETFRAMEWORK
         var srcDir = Path.Combine(profilerDirectory, "net462");
         var dstDir = Path.Combine(profilerDirectory, "netfx");
+#else
+        var srcDir = Path.Combine(profilerDirectory, "net6.0");
+        var dstDir = Path.Combine(profilerDirectory, "net");
+#endif
+
         if (Directory.Exists(srcDir) && !Directory.Exists(dstDir))
         {
             Directory.Move(srcDir, dstDir);
         }
-#else
-        if (Directory.Exists(Path.Combine(profilerDirectory, "net6.0")))
-        {
-            Directory.Move(Path.Combine(profilerDirectory, "net6.0"), Path.Combine(profilerDirectory, "net"));
-        }
-#endif
 
         Environment.SetEnvironmentVariable("OTEL_LOG_LEVEL", "debug");
         Environment.SetEnvironmentVariable("OTEL_DOTNET_AUTO_HOME", profilerDirectory);


### PR DESCRIPTION
## Why

Loader `Ctor_LoadsManagedAssembly` test fails on consecutive runs.

## What

Use the same conditional already in place for .NET Framework for the test TFMs.

## Tests

Locally ran the tests multiple times.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
