### PR TITLE
Detect library versions changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
         with:
           name: bin-${{ matrix.machine }}
           path: bin/tracer-home
+      - name: Regenerate LibraryVersions.g.cs
+        # Regenerate the library versions file to surface any version changes made to the packages being tested.
+        run: ./build.cmd GenerateLibraryVersionFiles
       - name: Generated files unchanged
         shell: bash
         run: |

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="MySqlConnector" Version="2.2.6" />
     <PackageVersion Include="MySql.Data" Version="8.0.32.1" />
-    <PackageVersion Include="NServiceBus" Version="8.1.1" />
+    <PackageVersion Include="NServiceBus" Version="8.0.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="7.0.4" />
     <PackageVersion Include="NuGet.Versioning" Version="6.5.0" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="MySqlConnector" Version="2.2.6" />
     <PackageVersion Include="MySql.Data" Version="8.0.32.1" />
-    <PackageVersion Include="NServiceBus" Version="8.0.3" />
+    <PackageVersion Include="NServiceBus" Version="8.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="7.0.4" />
     <PackageVersion Include="NuGet.Versioning" Version="6.5.0" />


### PR DESCRIPTION
## Why

Fail CI workflow if there are changes to generated source files.

Fixes #2682

## What

Before #2598 the check for source changes was performed after the build and tests since it was a monolithic workflow. After #2598, the test is only being performed on the build workflow and changes to files generated via the `GenerateLibraryVersionFiles` target were not being detected.

I opted to add the target `GenerateLibraryVersionFiles` to the build workflow since it also affects the restore step and it runs quickly. The overall result is that it will fail the build quickly.

## Tests

Manually validated on my fork of the repo: https://github.com/pjanotti/opentelemetry-dotnet-instrumentation/actions/runs/5348477532/jobs/9698396649#step:14:1

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
