### PR TITLE
Use default dotnet format

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -27,8 +27,5 @@ jobs:
       with:
         dotnet-version: 7.0.304
 
-    - name: Install format tool
-      run: dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
-
     - name: dotnet format
       run: dotnet-format .\OpenTelemetry.AutoInstrumentation.sln --no-restore --verify-no-changes

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -28,4 +28,4 @@ jobs:
         dotnet-version: 7.0.304
 
     - name: dotnet format
-      run: dotnet-format .\OpenTelemetry.AutoInstrumentation.sln --no-restore --verify-no-changes
+      run: dotnet format .\OpenTelemetry.AutoInstrumentation.sln --no-restore --verify-no-changes


### PR DESCRIPTION
## Why

No need for devs or CI to install it as a tool since `dotnet format` is part of the SDK, see https://github.com/dotnet/format#how-to-use

## What

Removed tool installation step

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
