### PR TITLE
Drop ProfilerAttached functionality

### DIFF
--- a/examples/playground/AspNetCoreMvc/Controllers/HomeController.cs
+++ b/examples/playground/AspNetCoreMvc/Controllers/HomeController.cs
@@ -31,7 +31,6 @@ public class HomeController : Controller
     public IActionResult Index()
     {
         var instrumentationType = Type.GetType("OpenTelemetry.AutoInstrumentation.Instrumentation, OpenTelemetry.AutoInstrumentation");
-        ViewBag.ProfilerAttached = instrumentationType?.GetProperty("ProfilerAttached", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) ?? false;
         ViewBag.TracerAssemblyLocation = Type.GetType("OpenTelemetry.Trace.Tracer, OpenTelemetry.Api")?.Assembly.Location;
         ViewBag.ClrProfilerAssemblyLocation = instrumentationType?.Assembly.Location;
         ViewBag.StackTrace = StackTraceHelper.GetUsefulStack();

--- a/examples/playground/AspNetCoreMvc/Views/Home/Index.cshtml
+++ b/examples/playground/AspNetCoreMvc/Views/Home/Index.cshtml
@@ -17,10 +17,6 @@
                 <td>@(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture)</td>
             </tr>
             <tr>
-                <th scope="row">Profiler attached</th>
-                <td>@ViewBag.ProfilerAttached</td>
-            </tr>
-            <tr>
                 <th scope="row">OpenTelemetry.Api.dll path</th>
                 <td>@(ViewBag.TracerAssemblyLocation ?? "(not found)")</td>
             </tr>

--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.def
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.def
@@ -3,7 +3,6 @@ LIBRARY "OpenTelemetry.AutoInstrumentation.Native.dll"
 EXPORTS
     DllCanUnloadNow PRIVATE
     DllGetClassObject PRIVATE
-    IsProfilerAttached
     GetAssemblyAndSymbolsBytes
     AddInstrumentations
     AddDerivedInstrumentations

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -1336,11 +1336,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStartedOnNetFramework(Funct
 }
 #endif
 
-bool CorProfiler::IsAttached() const
-{
-    return is_attached_;
-}
-
 WSTRING CorProfiler::GetBytecodeInstrumentationAssembly() const
 {
     WSTRING bytecodeInstrumentationAssembly = managed_profiler_full_assembly_version;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -118,8 +118,6 @@ private:
 public:
     CorProfiler() = default;
 
-    bool IsAttached() const;
-
     WSTRING GetBytecodeInstrumentationAssembly() const;
 
 #ifdef _WIN32

--- a/src/OpenTelemetry.AutoInstrumentation.Native/interop.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/interop.cpp
@@ -15,11 +15,6 @@
 #include <dlfcn.h>
 #endif
 
-EXTERN_C BOOL STDAPICALLTYPE IsProfilerAttached()
-{
-    return trace::profiler != nullptr && trace::profiler->IsAttached();
-}
-
 #ifdef _WIN32
 // GetAssemblyAndSymbolsBytes is used when injecting the Loader into a .NET Framework application.
 EXTERN_C VOID STDAPICALLTYPE GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray,

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -43,27 +43,6 @@ internal static class Instrumentation
     private static MeterProvider? _meterProvider;
     private static PluginManager? _pluginManager;
 
-    /// <summary>
-    /// Gets a value indicating whether OpenTelemetry's profiler is attached to the current process.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if the profiler is currently attached; <c>false</c> otherwise.
-    /// </value>
-    public static bool ProfilerAttached
-    {
-        get
-        {
-            try
-            {
-                return NativeMethods.IsProfilerAttached();
-            }
-            catch (DllNotFoundException)
-            {
-                return false;
-            }
-        }
-    }
-
     internal static PluginManager? PluginManager => _pluginManager;
 
     internal static ILifespanManager LifespanManager => LazyInstrumentationLoader.LifespanManager;

--- a/src/OpenTelemetry.AutoInstrumentation/NativeMethods.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/NativeMethods.cs
@@ -22,16 +22,6 @@ internal static class NativeMethods
 {
     private static readonly bool IsWindows = string.Equals(FrameworkDescription.Instance.OSPlatform, "Windows", StringComparison.OrdinalIgnoreCase);
 
-    public static bool IsProfilerAttached()
-    {
-        if (IsWindows)
-        {
-            return Windows.IsProfilerAttached();
-        }
-
-        return NonWindows.IsProfilerAttached();
-    }
-
     public static void AddInstrumentations(string id, NativeCallTargetDefinition[] methodArrays)
     {
         if (methodArrays is null || methodArrays.Length == 0)
@@ -71,9 +61,6 @@ internal static class NativeMethods
     private static class Windows
     {
         [DllImport("OpenTelemetry.AutoInstrumentation.Native.dll")]
-        public static extern bool IsProfilerAttached();
-
-        [DllImport("OpenTelemetry.AutoInstrumentation.Native.dll")]
         public static extern void AddInstrumentations([MarshalAs(UnmanagedType.LPWStr)] string id, [In] NativeCallTargetDefinition[] methodArrays, int size);
 
         [DllImport("OpenTelemetry.AutoInstrumentation.Native.dll")]
@@ -83,9 +70,6 @@ internal static class NativeMethods
     // assume .NET Core if not running on Windows
     private static class NonWindows
     {
-        [DllImport("OpenTelemetry.AutoInstrumentation.Native")]
-        public static extern bool IsProfilerAttached();
-
         [DllImport("OpenTelemetry.AutoInstrumentation.Native")]
         public static extern void AddInstrumentations([MarshalAs(UnmanagedType.LPWStr)] string id, [In] NativeCallTargetDefinition[] methodArrays, int size);
 

--- a/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Views/Home/Index.cshtml
+++ b/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Views/Home/Index.cshtml
@@ -17,10 +17,6 @@
                 <td>@(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture)</td>
             </tr>
             <tr>
-                <th scope="row">Profiler attached</th>
-                <td>@ViewBag.ProfilerAttached</td>
-            </tr>
-            <tr>
                 <th scope="row">*.Tracing.AutoInstrumentation.dll path</th>
                 <td>@(ViewBag.TracerAssemblyLocation ?? "(not found)")</td>
             </tr>


### PR DESCRIPTION
## Why

Inspired by #2563

## What

Drop ProfilerAttached functionality.
It was used only by our example application.

Calling this method could cause similar issue like described in #2563.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
