### PR TITLE
Remove outdated comment from MongoDB

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -96,7 +96,7 @@ the proper attribute annotation so that the native CLR Profiler implementation
 can inject them at runtime. Some examples include:
 
   - [Logger](../src/OpenTelemetry.AutoInstrumentation/Instrumentations/Logger/)
-  - [MongoDb](../src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDb/)
+  - [MongoDB](../src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDB/)
 
 Both kinds of instrumentation are enabled only when the targeted modules are loaded
 into the targeted application.

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDB/MongoClientIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MongoDB/MongoClientIntegration.cs
@@ -49,9 +49,6 @@ public static class MongoClientIntegration
     internal static CallTargetState OnMethodBegin<TTarget, TMongoClientSettings>(TTarget instance, TMongoClientSettings settings)
         where TMongoClientSettings : notnull
     {
-        // Additional deps doesn't support .NET FX
-        // TODO: Find another way how to ship & load "MongoDB.Driver.Core.Extensions.DiagnosticSources"
-
         var setListenerDelegate = _setActivityListener ??= GetClusterConfiguratorExpression().Compile();
 
         var clusterConfiguratorProperty = settings


### PR DESCRIPTION
## Why

Remove outdated comments.

## What

Remove outdated comments and fix the case of MongoDB in markdown and folder name.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
