### PR TITLE
Execute tests under Debian

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,13 @@ jobs:
       matrix:
         include:
           - base-image: alpine
+            build-source: alpine
             os-type: linux-musl
           - base-image: centos
+            build-source: centos
+            os-type: linux-glibc
+          - base-image: debian
+            build-source: centos
             os-type: linux-glibc
     runs-on: ubuntu-20.04
     timeout-minutes: 60
@@ -160,7 +165,7 @@ jobs:
     - name: Download Artifacts from build job
       uses: actions/download-artifact@v3.0.2
       with:
-        name: bin-${{ matrix.base-image }}
+        name: bin-${{ matrix.build-source }}
         path: bin/tracer-home
     - name: Build in Docker container
       run: |

--- a/docker/debian.dockerfile
+++ b/docker/debian.dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0.305-bullseye-slim
+
+RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y dotnet-sdk-6.0
+
+WORKDIR /project


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Towards #2006

## What

Execute tests under Debian Bullseye.
Debian is the cheapest option, as base image should be cached by action runners.

Debian is using artifacts build on Centos which are later published as releases.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.

## Notes

It requires changes in required build steps.