### PR TITLE
Add before to ConfigureProvider method for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 
+- Added `BeforeConfigureTracerProvider` and `BeforeConfigureMeterProvider` for plugins.
+  See [plugins documentation](/docs/plugins.md) for details.
+
 ### Changed
+
+- In plugins `ConfigureTracerProvider` and `ConfigureMeterProvider` are changed now
+  to `AfterConfigureTracerProvider` and `AfterConfigureMeterProvider`.
+  See [plugins documentation](/docs/plugins.md) for details.
 
 ### Deprecated
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -16,8 +16,16 @@ public class MyPlugin
         // My custom logic here
     }
 
-    // To configure tracing SDK
-    public OpenTelemetry.Trace.TracerProviderBuilder ConfigureTracerProvider(OpenTelemetry.Trace.TracerProviderBuilder builder)
+    // To configure tracing SDK before Auto Instrumentation configured SDK
+    public OpenTelemetry.Trace.TracerProviderBuilder BeforeConfigureTracerProvider(OpenTelemetry.Trace.TracerProviderBuilder builder)
+    {
+        // My custom logic here
+
+        return builder;
+    }
+
+    // To configure tracing SDK after Auto Instrumentation configured SDK
+    public OpenTelemetry.Trace.TracerProviderBuilder AfterConfigureTracerProvider(OpenTelemetry.Trace.TracerProviderBuilder builder)
     {
         // My custom logic here
 
@@ -31,8 +39,16 @@ public class MyPlugin
         // Find supported options below
     }
 
-    // To configure metrics SDK
-    public OpenTelemetry.Metrics.MeterProviderBuilder ConfigureMeterProvider(OpenTelemetry.Metrics.MeterProviderBuilder builder)
+    // To configure metrics SDK before Auto Instrumentation configured SDK
+    public OpenTelemetry.Metrics.MeterProviderBuilder BeforeConfigureMeterProvider(OpenTelemetry.Metrics.MeterProviderBuilder builder)
+    {
+        // My custom logic here
+
+        return builder;
+    }
+
+    // To configure metrics SDK after Auto Instrumentation configured SDK
+    public OpenTelemetry.Metrics.MeterProviderBuilder AfterConfigureMeterProvider(OpenTelemetry.Metrics.MeterProviderBuilder builder)
     {
         // My custom logic here
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/PluginsConfigurationHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/PluginsConfigurationHelper.cs
@@ -23,14 +23,24 @@ namespace OpenTelemetry.AutoInstrumentation.Configurations;
 
 internal static class PluginsConfigurationHelper
 {
-    public static TracerProviderBuilder InvokePlugins(this TracerProviderBuilder builder, PluginManager pluginManager)
+    public static TracerProviderBuilder InvokePluginsBefore(this TracerProviderBuilder builder, PluginManager pluginManager)
     {
-        return pluginManager.ConfigureTracerProviderBuilder(builder);
+        return pluginManager.BeforeConfigureTracerProviderBuilder(builder);
     }
 
-    public static MeterProviderBuilder InvokePlugins(this MeterProviderBuilder builder, PluginManager pluginManager)
+    public static MeterProviderBuilder InvokePluginsBefore(this MeterProviderBuilder builder, PluginManager pluginManager)
     {
-        return pluginManager.ConfigureMeterProviderBuilder(builder);
+        return pluginManager.BeforeConfigureMeterProviderBuilder(builder);
+    }
+
+    public static TracerProviderBuilder InvokePluginsAfter(this TracerProviderBuilder builder, PluginManager pluginManager)
+    {
+        return pluginManager.AfterConfigureTracerProviderBuilder(builder);
+    }
+
+    public static MeterProviderBuilder InvokePluginsAfter(this MeterProviderBuilder builder, PluginManager pluginManager)
+    {
+        return pluginManager.AfterConfigureMeterProviderBuilder(builder);
     }
 
     public static ResourceBuilder InvokePlugins(this ResourceBuilder builder, PluginManager pluginManager)

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentation.cs
@@ -115,9 +115,10 @@ internal static class Instrumentation
                 {
                     var builder = Sdk
                         .CreateTracerProviderBuilder()
+                        .InvokePluginsBefore(_pluginManager)
                         .SetResourceBuilder(ResourceConfigurator.CreateResourceBuilder(GeneralSettings.Value.EnabledResourceDetectors))
                         .UseEnvironmentVariables(LazyInstrumentationLoader, TracerSettings.Value, _pluginManager)
-                        .InvokePlugins(_pluginManager);
+                        .InvokePluginsAfter(_pluginManager);
 
                     _tracerProvider = builder.Build();
                     Logger.Information("OpenTelemetry tracer initialized.");
@@ -135,9 +136,10 @@ internal static class Instrumentation
                 {
                     var builder = Sdk
                         .CreateMeterProviderBuilder()
+                        .InvokePluginsBefore(_pluginManager)
                         .SetResourceBuilder(ResourceConfigurator.CreateResourceBuilder(GeneralSettings.Value.EnabledResourceDetectors))
                         .UseEnvironmentVariables(LazyInstrumentationLoader, MetricSettings.Value, _pluginManager)
-                        .InvokePlugins(_pluginManager);
+                        .InvokePluginsAfter(_pluginManager);
 
                     _meterProvider = builder.Build();
                     Logger.Information("OpenTelemetry meter initialized.");

--- a/src/OpenTelemetry.AutoInstrumentation/Plugins/PluginManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Plugins/PluginManager.cs
@@ -77,14 +77,24 @@ internal class PluginManager
         return payloads;
     }
 
-    public TracerProviderBuilder ConfigureTracerProviderBuilder(TracerProviderBuilder builder)
+    public TracerProviderBuilder BeforeConfigureTracerProviderBuilder(TracerProviderBuilder builder)
     {
-        return ConfigureBuilder(builder, "ConfigureTracerProvider");
+        return ConfigureBuilder(builder, "BeforeConfigureTracerProvider");
     }
 
-    public MeterProviderBuilder ConfigureMeterProviderBuilder(MeterProviderBuilder builder)
+    public MeterProviderBuilder BeforeConfigureMeterProviderBuilder(MeterProviderBuilder builder)
     {
-        return ConfigureBuilder(builder, "ConfigureMeterProvider");
+        return ConfigureBuilder(builder, "BeforeConfigureMeterProvider");
+    }
+
+    public TracerProviderBuilder AfterConfigureTracerProviderBuilder(TracerProviderBuilder builder)
+    {
+        return ConfigureBuilder(builder, "AfterConfigureTracerProvider");
+    }
+
+    public MeterProviderBuilder AfterConfigureMeterProviderBuilder(MeterProviderBuilder builder)
+    {
+        return ConfigureBuilder(builder, "AfterConfigureMeterProvider");
     }
 
     public void ConfigureMetricsOptions<T>(T options)

--- a/test/test-applications/integrations/TestApplication.Plugins/Plugin.cs
+++ b/test/test-applications/integrations/TestApplication.Plugins/Plugin.cs
@@ -28,12 +28,12 @@ public class Plugin
         Console.WriteLine($"{nameof(Plugin)}.{nameof(Initializing)}() invoked.");
     }
 
-    public TracerProviderBuilder ConfigureTracerProvider(TracerProviderBuilder builder)
+    public TracerProviderBuilder BeforeConfigureTracerProvider(TracerProviderBuilder builder)
     {
         return builder.AddSource(TestApplication.Smoke.Program.SourceName);
     }
 
-    public MeterProviderBuilder ConfigureMeterProvider(MeterProviderBuilder builder)
+    public MeterProviderBuilder BeforeConfigureMeterProvider(MeterProviderBuilder builder)
     {
         return builder.AddMeter(TestApplication.Smoke.Program.SourceName);
     }


### PR DESCRIPTION
## Why

Towards #2750

## What

Adds:
- `BeforeConfigureTracerProvider`
- `BeforeConfigureMeterProvider`

Changes:
- `ConfigureTracerProvider` => `AfterConfigureTracerProvider`
- `ConfigureMeterProvider` => `AfterConfigureMeterProvider`

## Tests

Added the new methods.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
