### PR TITLE
Make OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - In plugins `ConfigureTracerProvider` and `ConfigureMeterProvider` are changed now
   to `AfterConfigureTracerProvider` and `AfterConfigureMeterProvider`.
   See [plugins documentation](/docs/plugins.md) for details.
+- Changed `OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES` behavior in case of using
+StartupHook only. Now consistent with native logic by excluding only by
+application module name.
 
 ### Deprecated
 

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/ApplicationInExcludeListRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/ApplicationInExcludeListRule.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.Logging;
 
 namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
@@ -30,23 +31,23 @@ internal class ApplicationInExcludeListRule : Rule
 
     internal override bool Evaluate()
     {
-        var applicationName = GetApplicationName();
+        var processModuleName = GetProcessModuleName();
 
-        if (IsApplicationInExcludeList(applicationName))
+        if (IsProcessInExcludeList(processModuleName))
         {
-            Logger.Information($"Rule Engine: {applicationName} is in the exclusion list. Skipping initialization.");
+            Logger.Information($"Rule Engine: {processModuleName} is in the exclusion list. Skipping initialization.");
             return false;
         }
 
-        Logger.Debug($"Rule Engine: {applicationName} is not in the exclusion list. ApplicationInExcludeListRule evaluation success.");
+        Logger.Debug($"Rule Engine: {processModuleName} is not in the exclusion list. ApplicationInExcludeListRule evaluation success.");
         return true;
     }
 
-    private static string GetApplicationName()
+    private static string GetProcessModuleName()
     {
         try
         {
-            return AppDomain.CurrentDomain.FriendlyName;
+            return Process.GetCurrentProcess().MainModule.ModuleName;
         }
         catch (Exception ex)
         {
@@ -55,12 +56,12 @@ internal class ApplicationInExcludeListRule : Rule
         }
     }
 
-    private static bool IsApplicationInExcludeList(string applicationName)
+    private static bool IsProcessInExcludeList(string processName)
     {
-        return GetExcludedApplicationNames().Contains(applicationName);
+        return GetExcludedProcessNames().Contains(processName);
     }
 
-    private static List<string> GetExcludedApplicationNames()
+    private static List<string> GetExcludedProcessNames()
     {
         var excludedProcesses = new List<string>();
 

--- a/test/IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -159,7 +159,10 @@ public class EnvironmentHelper
             extension = "dll";
         }
 
-        var appFileName = $"{FullTestApplicationName}.{extension}";
+        var appFileName = EnvironmentTools.IsWindows()
+            ? $"{FullTestApplicationName}.{extension}"
+            : FullTestApplicationName;
+
         var testApplicationPath = Path.Combine(GetTestApplicationApplicationOutputDirectory(packageVersion: packageVersion, framework: framework), appFileName);
         return testApplicationPath;
     }

--- a/test/IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -154,7 +154,7 @@ public class EnvironmentHelper
     {
         string extension = "exe";
 
-        if (IsCoreClr() || _testApplicationDirectory.Contains("aspnet"))
+        if (_testApplicationDirectory.Contains("aspnet"))
         {
             extension = "dll";
         }
@@ -162,32 +162,6 @@ public class EnvironmentHelper
         var appFileName = $"{FullTestApplicationName}.{extension}";
         var testApplicationPath = Path.Combine(GetTestApplicationApplicationOutputDirectory(packageVersion: packageVersion, framework: framework), appFileName);
         return testApplicationPath;
-    }
-
-    public string GetTestApplicationExecutionSource()
-    {
-        string executor;
-
-        if (_testApplicationDirectory.Contains("aspnet"))
-        {
-            executor = $"C:\\Program Files{(Environment.Is64BitProcess ? string.Empty : " (x86)")}\\IIS Express\\iisexpress.exe";
-        }
-        else if (IsCoreClr())
-        {
-            executor = EnvironmentTools.IsWindows() ? "dotnet.exe" : "dotnet";
-        }
-        else
-        {
-            var appFileName = $"{FullTestApplicationName}.exe";
-            executor = Path.Combine(GetTestApplicationApplicationOutputDirectory(), appFileName);
-
-            if (!File.Exists(executor))
-            {
-                throw new Exception($"Unable to find executing assembly at {executor}");
-            }
-        }
-
-        return executor;
     }
 
     public string GetTestApplicationBaseBinDirectory()

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -85,6 +85,12 @@ public abstract class TestHelper
         SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", $"http://localhost:{collector.Port}");
     }
 
+    public void DisableBytecodeInstrumentation()
+    {
+        SetEnvironmentVariable("COR_ENABLE_PROFILING", "0");
+        SetEnvironmentVariable("CORECLR_ENABLE_PROFILING", "0");
+    }
+
     public void EnableBytecodeInstrumentation()
     {
         SetEnvironmentVariable("CORECLR_ENABLE_PROFILING", "1");
@@ -138,8 +144,6 @@ public abstract class TestHelper
         }
 
         Output.WriteLine($"Starting Application: {testApplicationPath}");
-        var executable = EnvironmentHelper.IsCoreClr() ? EnvironmentHelper.GetTestApplicationExecutionSource() : testApplicationPath;
-        var args = EnvironmentHelper.IsCoreClr() ? $"{testApplicationPath} {testSettings.Arguments ?? string.Empty}" : testSettings.Arguments;
-        return InstrumentedProcessHelper.Start(executable, args, EnvironmentHelper);
+        return InstrumentedProcessHelper.Start(testApplicationPath, testSettings.Arguments, EnvironmentHelper);
     }
 }

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -61,8 +61,8 @@ public class SmokeTests : TestHelper
     [Trait("Category", "EndToEnd")]
     public void WhenClrProfilerIsNotEnabled()
     {
-        SetEnvironmentVariable("COR_ENABLE_PROFILING", "0");
-        SetEnvironmentVariable("CORECLR_ENABLE_PROFILING", "0");
+        DisableBytecodeInstrumentation();
+
 #if NETFRAMEWORK
         // on .NET Framework it is required to set the CLR .NET Profiler
         VerifyTestApplicationNotInstrumented();
@@ -71,20 +71,42 @@ public class SmokeTests : TestHelper
 #endif
     }
 
-    [Fact]
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     [Trait("Category", "EndToEnd")]
-    public void ApplicationIsNotExcluded()
+    public void ApplicationIsNotExcluded(bool useNativeProfiler)
     {
-        SetEnvironmentVariable("OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES", "dotnet,dotnet.exe");
+        if (useNativeProfiler)
+        {
+            EnableBytecodeInstrumentation();
+        }
+        else
+        {
+            DisableBytecodeInstrumentation();
+        }
+
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES", string.Empty);
 
         VerifyTestApplicationInstrumented();
     }
 
-    [Fact]
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     [Trait("Category", "EndToEnd")]
-    public void ApplicationIsExcluded()
+    public void ApplicationIsExcluded(bool useNativeProfiler)
     {
-        SetEnvironmentVariable("OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES", $"dotnet,dotnet.exe,{EnvironmentHelper.FullTestApplicationName},{EnvironmentHelper.FullTestApplicationName}.exe");
+        if (useNativeProfiler)
+        {
+            EnableBytecodeInstrumentation();
+        }
+        else
+        {
+            DisableBytecodeInstrumentation();
+        }
+
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES", $"{EnvironmentHelper.FullTestApplicationName},{EnvironmentHelper.FullTestApplicationName}.exe");
 
         VerifyTestApplicationNotInstrumented();
     }

--- a/test/test-applications/integrations/TestApplication.Smoke/Properties/launchSettings.json
+++ b/test/test-applications/integrations/TestApplication.Smoke/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "TestApplication.Smoke": {
+      "commandName": "Project",
+      "commandLineArgs": "dotnet TestApplication.Smoke.dll",
+      "workingDirectory": "F:\\Dev\\forks\\rassk\\opentelemetry-dotnet-instrumentation\\test\\test-applications\\integrations\\bin\\TestApplication.Smoke\\x64\\Debug\\net7.0",
+      "environmentVariables": {
+        "DOTNET_SHARED_STORE": "F:\\Dev\\forks\\rassk\\opentelemetry-dotnet-instrumentation\\bin\\tracer-home\\store",
+        "DOTNET_ADDITIONAL_DEPS": "F:\\Dev\\forks\\rassk\\opentelemetry-dotnet-instrumentation\\bin\\tracer-home\\AdditionalDeps",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",
+        "CORECLR_PROFILER_PATH": "F:\\Dev\\forks\\rassk\\opentelemetry-dotnet-instrumentation\\bin\\tracer-home\\win-x64\\OpenTelemetry.AutoInstrumentation.Native.dll",
+        "OTEL_DOTNET_AUTO_HOME": "F:\\Dev\\forks\\rassk\\opentelemetry-dotnet-instrumentation\\bin\\tracer-home\\",
+        "OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES": "TestApplication.*",
+        "OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}


### PR DESCRIPTION
## Why

Fixes #2441

## What

According to https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2441#issuecomment-1635030911

Instead of `Process.GetCurrentProcess().ProcessName` uses `Process.GetCurrentProcess().MainModule.ModuleName` to get module name instead of process name (example: `dotnet.exe` vs `dotnet`).

New behavior (Windows):
dotnet MyApp.dll -> dotnet.exe
MyApp.exe -> MyApp.exe

New behavior (Linux / Mac):
dotnet MyApp.dll -> dotnet
MyApp.exe -> MyApp

## Tests

Existing.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] New features are covered by tests.
