### PR TITLE
Partial revert for #2740

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -130,7 +130,6 @@ public static class LibraryVersion
                 "2.1.50",
                 "2.5.61",
                 "2.6.66",
-                "2.6.116",
                 "2.6.122",
             }
         },

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -50,9 +50,9 @@
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.13.3" />
     <PackageVersion Include="MongoDB.Libmongocrypt" Version="1.2.2" />
     <PackageVersion Include="MySql.Data" Version="6.10.7" />
-    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
+    <PackageVersion Include="Pipelines.Sockets.Unofficial" Version="2.1.16" />
     <PackageVersion Include="SharpCompress" Version="0.23.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.1.58" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.0" />

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -144,7 +144,6 @@ public static class LibraryVersion
         new object[] { "2.1.50" },
         new object[] { "2.5.61" },
         new object[] { "2.6.66" },
-        new object[] { "2.6.116" },
         new object[] { "2.6.122" },
 #endif
     };

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -179,7 +179,6 @@ internal static class PackageVersionDefinitions
                 "2.1.50",
                 "2.5.61",
                 "2.6.66",
-                "2.6.116",
                 "*"
             }
         }


### PR DESCRIPTION
## Why & What

<!-- Explain why the changes are needed.  -->

Partial revert of #2740 
Common exclude section should not be updated and use exactly same versions as in parent packages.

No need to tests with 2.6.116. No breaking change in never version.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
