### PR TITLE
Drop date from copyrights

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <PackageTags>APM;AutoInstrumentation;Automatic Instrumentation;Instrumentation;Logs;Metrics;Monitoring;O11y;Observability;OpenTelemetry;OTel;Telemetry;Tracing</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation.git</RepositoryUrl>
-    <Copyright>Copyright 2021 The OpenTelemetry Authors</Copyright>
+    <Copyright>Copyright The OpenTelemetry Authors</Copyright>
     <Company>OpenTelemetry</Company>
     <Authors>OpenTelemetry Authors</Authors>
     <!-- No warning on empty NuGet version suffix even if using pre-release dependencies -->

--- a/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/Resource.rc
@@ -79,7 +79,7 @@ BEGIN
             VALUE "FileDescription", "OpenTelemetry CLR Profiler"
             VALUE "FileVersion", VERSION_4PARTS
             VALUE "InternalName", "OpenTelemetry.AutoInstrumentation.Native.DLL"
-            VALUE "LegalCopyright", "Copyright 2021 The OpenTelemetry Authors"
+            VALUE "LegalCopyright", "Copyright The OpenTelemetry Authors"
             VALUE "OriginalFilename", "OpenTelemetry.AutoInstrumentation.Native.DLL"
             VALUE "ProductName", "OpenTelemetry .NET AutoInstrumentation"
             VALUE "ProductVersion", VERSION_3PARTS


### PR DESCRIPTION
## Why & What

Drop date from copyrights for libraries. Based on recommendation https://github.com/open-telemetry/community/blob/01862046dbaf16e5bb7fad2c3f89f1614772d307/CONTRIBUTING.md?plain=1#L38-L41

We can skip taking care of the updates.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
