### PR TITLE
Test nuget on Windows in separate step

### DIFF
--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -66,9 +66,6 @@ jobs:
       - name: Build NuGet packages
         run: ./build.cmd BuildNuGetPackages
 
-      - name: Test NuGet Packages
-        run: ./build.cmd TestNuGetPackages
-
       - name: Upload Nuget Artifacts
         uses: actions/upload-artifact@v3.1.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
         include:
           - machine: ubuntu-20.04
           - machine: macos-11
+          - machine: windows-2022
     runs-on: ${{ matrix.machine }}
     steps:
       - uses: actions/checkout@v3.5.3


### PR DESCRIPTION
## Why & What

Test nuget on Windows in separate step
It should minimally reduce total time in CI (macos and ubuntu test can be executed in parrarel to windows).

## Tests

CI
## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~

## Notes

If merged, we should add one more required step:  `test-nuget-packages (windows-2022)`
