### PR TITLE
Descriptions for nuget packages

### DIFF
--- a/nuget/OpenTelemetry.AutoInstrumentation.Runtime.Native/OpenTelemetry.AutoInstrumentation.Runtime.Native.nuspec
+++ b/nuget/OpenTelemetry.AutoInstrumentation.Runtime.Native/OpenTelemetry.AutoInstrumentation.Runtime.Native.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OpenTelemetry.AutoInstrumentation.Runtime.Native</id>
-    <description>Native runtime components used by the OpenTelmetry.AutoInstrumentation project.</description>
+    <description>Native runtime components used by the OpenTelemetry.AutoInstrumentation project.</description>
     <icon>images\opentelemetry-icon-color.png</icon>
 
     <!-- Common properties expected to be defined at build time -->

--- a/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+    <Description>ASP.NET Core Bootstrapper used by the OpenTelmetry.AutoInstrumentation project.</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <Description>ASP.NET Core Bootstrapper used by the OpenTelmetry.AutoInstrumentation project.</Description>
+    <Description>ASP.NET Core Bootstrapper used by the OpenTelemetry.AutoInstrumentation project.</Description>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Target only netstandard2.0 so there is a single path in the .targets using build tasks from this package. -->
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Description>Build tasks used by the OpenTelmetry.AutoInstrumentation project.</Description>
+    <Description>Build tasks used by the OpenTelemetry.AutoInstrumentation project.</Description>
 
     <!-- The assembly DLL needs to be under the build folder for proper packing. -->
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>

--- a/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Target only netstandard2.0 so there is a single path in the .targets using build tasks from this package. -->
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Description>Build tasks used by the OpenTelmetry.AutoInstrumentation project.</Description>
 
     <!-- The assembly DLL needs to be under the build folder for proper packing. -->
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <Description>Loader used by the OpenTelmetry.AutoInstrumentation project.</Description>
+    <Description>Loader used by the OpenTelemetry.AutoInstrumentation project.</Description>
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/OpenTelemetry.AutoInstrumentation.Loader.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <Description>Loader used by the OpenTelmetry.AutoInstrumentation project.</Description>
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/OpenTelemetry.AutoInstrumentation.StartupHook.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/OpenTelemetry.AutoInstrumentation.StartupHook.csproj
@@ -5,6 +5,7 @@
          this project should target netcoreapp3.1.
          Reference: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1644 -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <Description>StartupHook used by the OpenTelmetry.AutoInstrumentation project.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/OpenTelemetry.AutoInstrumentation.StartupHook.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/OpenTelemetry.AutoInstrumentation.StartupHook.csproj
@@ -5,7 +5,7 @@
          this project should target netcoreapp3.1.
          Reference: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1644 -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <Description>StartupHook used by the OpenTelmetry.AutoInstrumentation project.</Description>
+    <Description>StartupHook used by the OpenTelemetry.AutoInstrumentation project.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <PackageId>OpenTelemetry.AutoInstrumentation.Runtime.Managed</PackageId>
-    <Description>Mangaed components used by the OpenTelmetry.AutoInstrumentation project.</Description>
+    <Description>Managed components used by the OpenTelemetry.AutoInstrumentation project.</Description>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <GeneratedFolder>Generated</GeneratedFolder>
     <CompilerGeneratedFilesOutputPath>$(GeneratedFolder)\$(TargetFramework)</CompilerGeneratedFilesOutputPath>

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <PackageId>OpenTelemetry.AutoInstrumentation.Runtime.Managed</PackageId>
+    <Description>Mangaed components used by the OpenTelmetry.AutoInstrumentation project.</Description>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <GeneratedFolder>Generated</GeneratedFolder>
     <CompilerGeneratedFilesOutputPath>$(GeneratedFolder)\$(TargetFramework)</CompilerGeneratedFilesOutputPath>


### PR DESCRIPTION
## Why

Towards #2717

## What

Missing description for nuget packages.
Text based on what we have for native package
`Native runtime components used by the OpenTelmetry.AutoInstrumentation project`

Fixes from `meziantou.validate-nuget-package`

```json
        {
          "ErrorCode": 43,
          "Message": "The package description is not set"
        }
```

## Tests

Local check if description is in place

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
