### PR TITLE
Add smoke test to cover exclude process when CLR profiler is disabled

### DIFF
--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -71,6 +71,31 @@ public class SmokeTests : TestHelper
 #endif
     }
 
+#if !NETFRAMEWORK
+    [Theory]
+    [Trait("Category", "EndToEnd")]
+    [InlineData(TestAppStartupMode.DotnetCLI)]
+    [InlineData(TestAppStartupMode.Exe)]
+    public void WhenClrProfilerIsNotEnabledStartupHookIsEnabledApplicationIsExcluded(TestAppStartupMode testAppStartupMode)
+    {
+        switch (testAppStartupMode)
+        {
+            case TestAppStartupMode.DotnetCLI:
+                SetEnvironmentVariable("OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES", "dotnet,dotnet.exe");
+                break;
+            case TestAppStartupMode.Exe:
+                SetEnvironmentVariable("OTEL_DOTNET_AUTO_EXCLUDE_PROCESSES", $"{EnvironmentHelper.FullTestApplicationName},{EnvironmentHelper.FullTestApplicationName}.exe");
+                break;
+            default:
+                throw new ArgumentException($"{testAppStartupMode} is not supported by this test", nameof(testAppStartupMode));
+        }
+
+        SetEnvironmentVariable("CORECLR_ENABLE_PROFILING", "0");
+
+        VerifyTestApplicationNotInstrumented(testAppStartupMode);
+    }
+#endif
+
     [Fact]
     [Trait("Category", "EndToEnd")]
     public void ApplicationIsNotExcluded()


### PR DESCRIPTION
## Why

Missing test the covers process exclusion when CLR profiler is disabled.
Fix #2771 

## What

Added a smoke test that validates process exclusion when the CLR profiler is not enabled. Notice that this scenario doesn't apply to .NET Framework since there is no StartupHook to instrument applications without the CLR profiler.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
