### PR TITLE
Fix return value in InstrumentationAssemblyRule

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/InstrumentationAssemblyRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/InstrumentationAssemblyRule.cs
@@ -78,7 +78,7 @@ internal class InstrumentationAssemblyRule : Rule
             Logger.Warning($"Rule Engine:Couldn't evaluate OpenTelemetry Instrumentation Evaluation. Exception: {ex}");
         }
 
-        return true;
+        return result;
     }
 
     private class RuleFileInfo


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

`InstrumentationAssemblyRule` always returns true and does not respect result value.

## What

<!-- Describe changes proposed in this pull request. -->

Modify the function to return `result` instead of `true`.

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->
CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
