### PR TITLE
Skip more assemblies by their prefix

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/otel_profiler_constants.h
@@ -41,6 +41,7 @@ const WSTRING skip_assembly_prefixes[]{
     WStr("Microsoft.Extensions.Primitives"),
     WStr("Microsoft.Extensions.WebEncoders"),
     WStr("Microsoft.Web.Compilation.Snapshots"),
+    WStr("OpenTelemetry"),
     WStr("System.Core"),
     WStr("System.Console"),
     WStr("System.Collections"),
@@ -53,6 +54,18 @@ const WSTRING skip_assembly_prefixes[]{
     WStr("System.Text"),
     WStr("System.Threading"),
     WStr("System.Xml"),
+    // Various assemblies that should never be instrumented:
+    WStr("runtime"),
+    WStr("RefEmit_"),
+    WStr("vstest"),
+    WStr("testhost"),
+    WStr("dotnet"),
+    WStr("SOS"),
+    WStr("NuGet"),
+    WStr("VBCSCompiler"),
+    WStr("csc"),
+    WStr("DuckTypeNotVisibleAssembly"),
+    WStr("Newtonsoft.Json"),
 };
 
 const WSTRING skip_assemblies[]{WStr("mscorlib"),


### PR DESCRIPTION
## Why

Reduce the amount of work done on the `CorProfilerBase::GetAssemblyReferences` callback.

Collateral of #2833

## What

Assemblies that are not going to be instrumented don't need to be internally tracked. This generates a lot of noise on debug logs and waste work on normal operations. Besides `OpenTelemetry` prefix I'm also adding some also from the current upstream: https://github.com/DataDog/dd-trace-dotnet/blob/5292fc6b09b29e924e62eb6c1cb82107b43d4789/tracer/src/Datadog.Tracer.Native/debugger_constants.h#L16

There are more differences with upstream, but, since we are close to GA let's be careful with these changes, so, at least for now not adding `Microsoft` or `System` to skip prefixes.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
