### PR TITLE
Add environment variables dumping filter for native logger

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -71,11 +71,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         const auto env_variables = GetEnvironmentVariables(env_vars_prefixes_to_display);
         Logger::Debug("Environment variables:");
 
+        const auto secrets_pattern = "(?:^|_)(API|TOKEN|SECRET|KEY|PASSWORD|PASS|PWD|HEADER|CREDENTIALS)(?:_|$)";
 #ifdef _WIN32
-        const std::regex secrets_regex("(?:^|_)(API|TOKEN|SECRET|KEY|PASSWORD|PASS|PWD|HEADER|CREDENTIALS)(?:_|$)",
-                                       std::regex_constants::ECMAScript | std::regex_constants::icase);
+        const std::regex secrets_regex(secrets_pattern, std::regex_constants::ECMAScript | std::regex_constants::icase);
 #else
-        static re2::RE2 re("(?:^|_)(API|TOKEN|SECRET|KEY|PASSWORD|PASS|PWD|HEADER|CREDENTIALS)(?:_|$)", RE2::Quiet);
+        static re2::RE2 re(secrets_pattern, RE2::Quiet);
 #endif
 
         for (const auto& env_variable : env_variables)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -67,9 +67,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         const auto env_variables = GetEnvironmentVariables(env_vars_prefixes_to_display);
         Logger::Debug("Environment variables:");
 
-        const std::regex secrets_regex(
-            "(?:^|_)(API|TOKEN|SECRET|KEY|PASSWORD|PASS|PWD|HEADER|CREDENTIALS)(?:_|$)", 
-            std::regex_constants::ECMAScript | std::regex_constants::icase);
+        const std::regex secrets_regex("(?:^|_)(API|TOKEN|SECRET|KEY|PASSWORD|PASS|PWD|HEADER|CREDENTIALS)(?:_|$)",
+                                       std::regex_constants::ECMAScript | std::regex_constants::icase);
 
         for (const auto& env_variable : env_variables)
         {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -88,6 +88,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
             {
                 Logger::Debug("  ", env_variable);
             }
+            else
+            {
+                // Remove secret value and replace with <hidden>
+                Logger::Debug("  ", env_variable.substr(0, env_variable.find_first_of('=')), "=<hidden>");
+            }
         }
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -7,6 +7,7 @@
 #include <corprof.h>
 #include <string>
 #include <typeinfo>
+#include <regex>
 
 #include "clr_helpers.h"
 #include "dllmain.h"
@@ -66,9 +67,16 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         const auto env_variables = GetEnvironmentVariables(env_vars_prefixes_to_display);
         Logger::Debug("Environment variables:");
 
+        const std::regex secrets_regex(
+            "(?:^|_)(API|TOKEN|SECRET|KEY|PASSWORD|PASS|PWD|HEADER|CREDENTIALS)(?:_|$)", 
+            std::regex_constants::ECMAScript | std::regex_constants::icase);
+
         for (const auto& env_variable : env_variables)
         {
-            Logger::Debug("  ", env_variable);
+            if (!std::regex_search(ToString(env_variable), secrets_regex))
+            {
+                Logger::Debug("  ", env_variable);
+            }
         }
     }
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.17.0" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.9.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.24.1" />
     <PackageVersion Include="GraphQL" Version="7.6.1" />
     <PackageVersion Include="GraphQL.MicrosoftDI" Version="7.6.1" />


### PR DESCRIPTION
## Why

Fixes #2871

## What

Does not dump environment variables to native log if specific keywords are detected (list in #2871).

## Tests

locally tested:
- [x] Windows
- [x] Linux

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
