### PR TITLE
Fix default value documentation for OTEL_DOTNET_AUTO_FAIL_FAST_ENABLED

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/ConfigurationKeys.FailFast.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/ConfigurationKeys.FailFast.cs
@@ -23,7 +23,7 @@ internal partial class ConfigurationKeys
 {
     /// <summary>
     /// Configuration key to set fail fast behavior.
-    /// Default is <c>"http/protobuf"</c>.
+    /// Default is false.
     /// </summary>
     public const string FailFast = "OTEL_DOTNET_AUTO_FAIL_FAST_ENABLED";
 }


### PR DESCRIPTION
## What

Minor code documentation fix for default value of `OTEL_DOTNET_AUTO_FAIL_FAST_ENABLED`.
