### PR TITLE
[WCF] add wait strategy to reduce random test failures

### DIFF
--- a/test/IntegrationTests/WcfIISTests.cs
+++ b/test/IntegrationTests/WcfIISTests.cs
@@ -95,6 +95,8 @@ public class WcfIISTests : TestHelper
             .WithNetwork(networkName)
             .WithPortBinding(netTcpPort, 808)
             .WithPortBinding(httpPort, 80)
+            .WithWaitStrategy(Wait.ForWindowsContainer().UntilHttpRequestIsSucceeded(rq
+                => rq.ForPort(80).ForPath("/StatusService.svc")))
             .WithBindMount(logPath, "c:/inetpub/wwwroot/logs");
 
         foreach (var env in _environmentVariables)
@@ -103,14 +105,15 @@ public class WcfIISTests : TestHelper
         }
 
         var container = builder.Build();
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
         try
         {
-            var wasStarted = container.StartAsync().Wait(TimeSpan.FromMinutes(5));
-            wasStarted.Should().BeTrue($"Container based on {imageName} has to be operational for the test.");
+            await container.StartAsync(cts.Token);
             Output.WriteLine("Container was started successfully.");
         }
         catch
         {
+            Output.WriteLine("Container failed to start in a required time frame.");
             await container.DisposeAsync();
             throw;
         }


### PR DESCRIPTION
## Why

This test failed few times and seems to be flaky.

## What

Add a wait strategy to indicate readiness of a container.

