### PR TITLE
nit: dispose CancellationTokenSource on tests

### DIFF
--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -102,7 +102,7 @@ public class MockLogsCollector : IDisposable
         var additionalEntries = new List<LogRecord>();
 
         timeout ??= TestTimeout.Expectation;
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         try
         {

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -81,7 +81,7 @@ public class MockMetricsCollector : IDisposable
         var additionalEntries = new List<Collected>();
 
         timeout ??= TestTimeout.Expectation;
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         try
         {

--- a/test/IntegrationTests/Helpers/MockSpansCollector.cs
+++ b/test/IntegrationTests/Helpers/MockSpansCollector.cs
@@ -88,7 +88,7 @@ public class MockSpansCollector : IDisposable
         var additionalEntries = new List<Collected>();
 
         timeout ??= TestTimeout.Expectation;
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         try
         {

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -81,7 +81,7 @@ public class MockZipkinCollector : IDisposable
         var additionalEntries = new List<ZSpanMock>();
 
         timeout ??= TestTimeout.Expectation;
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
         try
         {

--- a/test/IntegrationTests/WcfIISTests.cs
+++ b/test/IntegrationTests/WcfIISTests.cs
@@ -105,7 +105,7 @@ public class WcfIISTests : TestHelper
         }
 
         var container = builder.Build();
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
         try
         {
             await container.StartAsync(cts.Token);


### PR DESCRIPTION
## Why

It is a nit :) just good practice, no actual difference for test results. Noticed on https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/2915/files

## What

Dispose `CancellationTokenSource` objects created during tests.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests~~.
