### PR TITLE
Improve MinSupportedFrameworkRule

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/MinSupportedFrameworkRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/MinSupportedFrameworkRule.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Reflection;
-using System.Runtime.Versioning;
 using OpenTelemetry.AutoInstrumentation.Logging;
 
 namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
@@ -32,20 +30,12 @@ internal class MinSupportedFrameworkRule : Rule
 
     internal override bool Evaluate()
     {
-        var minSupportedFramework = new FrameworkName(".NETCoreApp,Version=v6.0");
-        var appTargetFramework = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
-        // This is the best way to identify application's target framework.
-        // If entry assembly framework is null, StartupHook should continue its execution.
-        if (appTargetFramework != null)
+        Version minRequiredFrameworkVersion = new(6, 0);
+        var frameworkVersion = Environment.Version;
+        if (frameworkVersion < minRequiredFrameworkVersion)
         {
-            var appTargetFrameworkName = new FrameworkName(appTargetFramework);
-            var appTargetFrameworkVersion = appTargetFrameworkName.Version;
-
-            if (appTargetFrameworkVersion < minSupportedFramework.Version)
-            {
-                Logger.Information($"Rule Engine: Error in StartupHook initialization: {appTargetFramework} is not supported");
-                return false;
-            }
+            Logger.Information($"Rule Engine: Error in StartupHook initialization: {frameworkVersion} is not supported");
+            return false;
         }
 
         Logger.Information("Rule Engine: MinSupportedFrameworkRule evaluation success.");


### PR DESCRIPTION
## Why

The entry assembly attribute TargetFrameworkVersion doesn't necessarily reflects the actual framework at runtime. While not typical it is possible to have an assembly built against an old version capable of running against the latest.

## What

Use `Environment.Version` instead to determine the runtime: this is the standard way to do that since behind the scenes it checks the version of the assembly defining the `object` type.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
