### PR TITLE
Add StartupHook.Tests to RunManagedUnitTests target

### DIFF
--- a/build/Build.Steps.cs
+++ b/build/Build.Steps.cs
@@ -416,6 +416,7 @@ partial class Build
             var unitTestProjects = new[]
             {
                 Solution.GetProjectByName(Projects.Tests.AutoInstrumentationLoaderTests),
+                Solution.GetProjectByName(Projects.Tests.AutoInstrumentationStartupHookTests),
                 Solution.GetProjectByName(Projects.Tests.AutoInstrumentationTests)
             };
 

--- a/build/Projects.cs
+++ b/build/Projects.cs
@@ -18,6 +18,7 @@ public static class Projects
         public const string AutoInstrumentationLoaderTests = "OpenTelemetry.AutoInstrumentation.Loader.Tests";
         public const string AutoInstrumentationBootstrappingTests = "OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests";
         public const string AutoInstrumentationTests = "OpenTelemetry.AutoInstrumentation.Tests";
+        public const string AutoInstrumentationStartupHookTests = "OpenTelemetry.AutoInstrumentation.StartupHook.Tests";
         public const string IntegrationTests = "IntegrationTests";
 
         public static class Applications


### PR DESCRIPTION
## Why

StartupHook.Tests are not running with the other unit tests and as consequence are out of CI.


## What

Add StartupHook.Tests to RunManagedUnitTests target.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
