### PR TITLE
Bump .NET SDK to 7.0.401/6.0.414

### DIFF
--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
 
       - name: Check for NuGet packages cache

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
 
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
         id: nuget-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
         id: nuget-cache
@@ -95,7 +95,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
         id: nuget-cache
@@ -126,7 +126,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
         id: nuget-cache
@@ -200,7 +200,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - name: Check for NuGet packages cache
         uses: actions/cache@v3.3.1
         id: nuget-cache

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET 7.0
       uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: 7.0.400
+        dotnet-version: 7.0.401
 
     - name: dotnet format
       run: dotnet format .\OpenTelemetry.AutoInstrumentation.sln --no-restore --verify-no-changes

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - name: Test the PowerShell module instructions from README.md
         shell: powershell
         run: |
@@ -56,7 +56,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - run: brew install coreutils
         if: ${{ runner.os == 'macOS' }}
       - name: Create test directory

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - name: Test the PowerShell module instructions from README.md
         shell: powershell
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - run: brew install coreutils
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.414
-            7.0.400
+            7.0.401
       - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project "${{ github.event.inputs.testProject }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}
       - name: Upload logs
         uses: actions/upload-artifact@v3.1.3

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: | 
-            6.0.413
+            6.0.414
             7.0.400
       - run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project "${{ github.event.inputs.testProject }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}
       - name: Upload logs

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -22,7 +22,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
     && echo "3ad581871b6fe9558520769c04981eb0317865d5303b932ac7b4af0a32498ff0  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 6.0.413 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 6.0.414 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 WORKDIR /project

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0.400-alpine3.17
+FROM mcr.microsoft.com/dotnet/sdk:7.0.401-alpine3.17
 
 RUN apk update \
     && apk upgrade \

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -20,7 +20,7 @@ ENV gRPC_PluginFullPath=/usr/bin/grpc_csharp_plugin
 # Install older sdks using the install script
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "3ad581871b6fe9558520769c04981eb0317865d5303b932ac7b4af0a32498ff0  dotnet-install.sh" | sha256sum -c \
+    && echo "8262a34469d0fc23a1262ec8bad014cf5af40ee93aa7656529115abf3760fe76  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 6.0.414 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -1,17 +1,17 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0.401-alpine3.17
+FROM mcr.microsoft.com/dotnet/sdk:7.0.401-alpine3.18
 
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache --update \
-        clang=15.0.7-r0 \
-        cmake=3.24.4-r0 \
-        make=4.3-r1 \
-        bash=5.2.15-r0 \
+        clang=16.0.6-r1 \
+        cmake=3.26.5-r0 \
+        make=4.4.1-r1 \
+        bash=5.2.15-r5 \
         alpine-sdk=1.0-r1 \
-        protobuf=3.21.9-r0 \
-        protobuf-dev=3.21.9-r0 \
-        grpc=1.50.1-r0 \
-        grpc-plugins=1.50.1-r0
+        protobuf=3.21.12-r2 \
+        protobuf-dev=3.21.12-r2 \
+        grpc=1.54.2-r0 \
+        grpc-plugins=1.54.2-r0
 
 ENV IsAlpine=true
 ENV PROTOBUF_PROTOC=/usr/bin/protoc

--- a/docker/centos.dockerfile
+++ b/docker/centos.dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/open-telemetry/opentelemetry-dotnet-instrumentation-centos7-build-image:main
 
 RUN rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
-RUN yum -y install dotnet-sdk-6.0-6.0.414-1 dotnet-sdk-7.0-7.0.400-1
+RUN yum -y install dotnet-sdk-6.0-6.0.414-1 dotnet-sdk-7.0-7.0.401-1
 
 WORKDIR /project
 COPY ./docker-entrypoint.sh /

--- a/docker/centos.dockerfile
+++ b/docker/centos.dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/open-telemetry/opentelemetry-dotnet-instrumentation-centos7-build-image:main
 
 RUN rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
-RUN yum -y install dotnet-sdk-6.0-6.0.413-1 dotnet-sdk-7.0-7.0.400-1
+RUN yum -y install dotnet-sdk-6.0-6.0.414-1 dotnet-sdk-7.0-7.0.400-1
 
 WORKDIR /project
 COPY ./docker-entrypoint.sh /

--- a/docker/debian.dockerfile
+++ b/docker/debian.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0.400-bullseye-slim
+FROM mcr.microsoft.com/dotnet/sdk:7.0.401-bullseye-slim
 
 RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \


### PR DESCRIPTION
## Why

Security fix release

## What

Bump .NET SDK to 7.0.401/6.0.414
Sha update for dotnet-install.sh

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
