### PR TITLE
telemetry.distro.name and telemetry.distro.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Added support for `Elastic.Transport` traces instrumentation 0.4.16+.
   `Elastic.Clients.Elasticsearch` 8.10.0+ traces instrumentation is covered by
   `Elastic.Transport` traces instrumentation.
+- Added `telemetry.distro.name` resource attribute. The value is set to `opentelemetry-dotnet-instrumentation`.
 
 ### Changed
+
+- Change telemetry resource attribute name from `telemetry.auto.version` to `telemetry.distro.version`.
 
 #### Dependency updates
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/ResourceConfigurator.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/ResourceConfigurator.cs
@@ -33,7 +33,8 @@ internal static class ResourceConfigurator
             .AddTelemetrySdk()
             .AddAttributes(new KeyValuePair<string, object>[]
             {
-                new(Constants.Tracer.AutoInstrumentationVersionName, AutoInstrumentationVersion.Version)
+                new(Constants.DistributionAttributes.TelemetryDistroNameAttributeName, Constants.DistributionAttributes.TelemetryDistroNameAttributeValue),
+                new(Constants.DistributionAttributes.TelemetryDistroVersionAttributeName, AutoInstrumentationVersion.Version)
             });
 
         foreach (var enabledResourceDetector in enabledResourceDetectors)

--- a/src/OpenTelemetry.AutoInstrumentation/Constants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Constants.cs
@@ -18,9 +18,11 @@ namespace OpenTelemetry.AutoInstrumentation;
 
 internal static class Constants
 {
-    public static class Tracer
+    public static class DistributionAttributes
     {
-        public const string AutoInstrumentationVersionName = "telemetry.auto.version";
+        public const string TelemetryDistroNameAttributeName = "telemetry.distro.name";
+        public const string TelemetryDistroNameAttributeValue = "opentelemetry-dotnet-instrumentation";
+        public const string TelemetryDistroVersionAttributeName = "telemetry.distro.version";
     }
 
     public static class ConfigurationValues

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -494,7 +494,8 @@ public class SmokeTests : TestHelper
         resourceExpector.Expect("telemetry.sdk.name", "opentelemetry");
         resourceExpector.Expect("telemetry.sdk.language", "dotnet");
         resourceExpector.Expect("telemetry.sdk.version", typeof(OpenTelemetry.Resources.Resource).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0]);
-        resourceExpector.Expect("telemetry.auto.version", typeof(OpenTelemetry.AutoInstrumentation.Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0]);
+        resourceExpector.Expect("telemetry.distro.name", "opentelemetry-dotnet-instrumentation");
+        resourceExpector.Expect("telemetry.distro.version", typeof(OpenTelemetry.AutoInstrumentation.Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0]);
     }
 
     private void VerifyTestApplicationInstrumented(TestAppStartupMode startupMode = TestAppStartupMode.Auto)


### PR DESCRIPTION
## Why

Fixes #2993 and the new sem. conv. version is released https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.22.0

## What

From sem-conv:
```
**[1]:** Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
```
## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
