### PR TITLE
Remove obsolete statement in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,18 +108,6 @@ automatically generated in .NET 7.0 whenever the `dotnet publish` or `dotnet bui
 command is used with a Runtime Identifier (RID) parameter, for example when `-r`
 or `--runtime` is used when running the command.
 
-Until version `v0.6.0-beta.1` (inclusive) there were issues instrumenting
-the `dotnet` CLI. To build and launch an instrumented application, take the
-following into account if you are using one of the *affected versions*:
-
-- Don't set the automatic instrumentation environment variables in the same session
-used to run the `dotnet` tool.
-- Don't launch the application to be instrumented using `dotnet run` or
-`dotnet <dll>`. Build the application in an isolated shell, without the
-automatic instrumentation environment variables set, and use a separate
-session with the automatic instrumentation variables to directly launch
-the executable.
-
 ### Install
 
 Download and extract the appropriate binaries from


### PR DESCRIPTION
## Why

Doc cleanup.

## What

Remove obsolete statement in README. We have now GA. I do not see any reason to reference old, beta version.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- ~~[ ] New features are covered by tests.~~
