### PR TITLE
Fix line ending for sh.templates files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 # Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
 # See https://help.github.com/articles/dealing-with-line-endings/
 *.sh text eol=lf
+*.sh.template text eol=lf
 *.bash text eol=lf
 
 ###############################################################################


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes sh file needed for release.
For 1.1.0 I have to manually remove `\r` from the file

## What

Fix line ending for sh.templates files

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
