### PR TITLE
Bump System.ServiceModel.NetTcp and System.ServiceModel.Http from 6.0.0 to 6.1.0

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -146,7 +146,7 @@ public static class LibraryVersion
             new List<PackageBuildInfo>
             {
                 new("4.10.2"),
-                new("6.0.0"),
+                new("6.1.0"),
             }
         },
     };

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -47,7 +47,7 @@
     <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.ServiceModel.Http" Version="6.0.0" />
-    <PackageVersion Include="System.ServiceModel.NetTcp" Version="6.0.0" />
+    <PackageVersion Include="System.ServiceModel.NetTcp" Version="6.1.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Testcontainers" Version="3.5.0" />
     <PackageVersion Include="Verify.Xunit" Version="20.8.2" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="System.Reactive" Version="6.0.0" />
     <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageVersion Include="System.ServiceModel.Http" Version="6.0.0" />
+    <PackageVersion Include="System.ServiceModel.Http" Version="6.1.0" />
     <PackageVersion Include="System.ServiceModel.NetTcp" Version="6.1.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Testcontainers" Version="3.5.0" />

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -160,7 +160,7 @@ public static class LibraryVersion
         new object[] { string.Empty }
 #else
         new object[] { "4.10.2" },
-        new object[] { "6.0.0" },
+        new object[] { "6.1.0" },
 #endif
     };
 }


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Replaces #3020 and #3019

## What

Bump System.ServiceModel.NetTcp and System.ServiceModel.Http from 6.0.0 to 6.1.0

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
