### PR TITLE
Fix cspell issues

### DIFF
--- a/.cspell/other.txt
+++ b/.cspell/other.txt
@@ -6,6 +6,7 @@ bytecode
 cmake
 Codespaces
 coreutils
+corhlpr
 Couchbase
 distro
 Dockerfiles
@@ -17,8 +18,10 @@ envvars
 GRPCNETCLIENT
 HKLM
 HTTPCLIENT
+ifdef
 ILOGGER
 inetsrv
+JIT
 LINQ
 MASSTRANSIT
 metricsexporter
@@ -48,6 +51,7 @@ TMPDIR
 tracesexporter
 unencrypted
 UNENCRYPTEDSUPPORT
+unregistration
 vcpkg
 WCFCLIENT
 WCFSERVICE


### PR DESCRIPTION
Fix the cspell build error after merging #3031 

I *think* I enabled auto-merge and that should have required cspell to be correct. Anyway, fixing it, will look later at what happened.