### PR TITLE
Bump core-instrumentation packages to 1.6.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Removed
 
-- Plugins, removed supported for `OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetricsInstrumentationOptions`.
+- Removed support for `OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetricsInstrumentationOptions`
+  for plugins.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - .NET Framework only, `Grpc.Core.Api` updated from `2.57.0` to `2.58.0`.
 - .NET only, `OpenTelemetry.Instrumentation.EntityFrameworkCore` updated
   from `1.0.0-beta.7` to `1.0.0-beta.8`.
+- .NET only, `OpenTelemetry.Instrumentation.AspNetCore` updated
+  from `1.5.1-beta.1` to `1.6.0-beta.2`.
+- `OpenTelemetry.Instrumentation.GrpcNetClient`,
+  `OpenTelemetry.Instrumentation.Http`,
+  and `OpenTelemetry.Instrumentation.SqlClient` updated from `1.5.1-beta.1` to `1.6.0-beta.2`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Removed
 
+- Plugins, removed supported for `OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetricsInstrumentationOptions`.
+
 ### Fixed
 
 ## [1.1.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.1.0)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="OpenTelemetry.Api" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.12" />
   </ItemGroup>
 </Project>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -129,7 +129,6 @@ public class MyPlugin
 | OpenTelemetry.Exporter.ConsoleExporterOptions                                    | OpenTelemetry.Exporter.Console                 | 1.6.0         |
 | OpenTelemetry.Exporter.PrometheusExporterOptions                                 | OpenTelemetry.Exporter.Prometheus.HttpListener | 1.6.0-rc.1    |
 | OpenTelemetry.Exporter.OtlpExporterOptions                                       | OpenTelemetry.Exporter.OpenTelemetryProtocol   | 1.6.0         |
-| OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetricsInstrumentationOptions | OpenTelemetry.Instrumentation.AspNetCore       | 1.6.0-beta.2  |
 | OpenTelemetry.Instrumentation.Runtime.RuntimeInstrumentationOptions              | OpenTelemetry.Instrumentation.Runtime          | 1.5.1         |
 
 ### Logs

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -112,12 +112,12 @@ public class MyPlugin
 | OpenTelemetry.Exporter.ZipkinExporterOptions                                              | OpenTelemetry.Exporter.Zipkin                     | 1.6.0         |
 | OpenTelemetry.Exporter.OtlpExporterOptions                                                | OpenTelemetry.Exporter.OpenTelemetryProtocol      | 1.6.0         |
 | OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions                         | OpenTelemetry.Instrumentation.AspNet              | 1.6.0-beta.1  |
-| OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions                 | OpenTelemetry.Instrumentation.AspNetCore          | 1.5.1-beta.1  |
+| OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions                 | OpenTelemetry.Instrumentation.AspNetCore          | 1.6.0-beta.2  |
 | OpenTelemetry.Instrumentation.EntityFrameworkCore.EntityFrameworkInstrumentationOptions   | OpenTelemetry.Instrumentation.EntityFrameworkCore | 1.0.0-beta.8  |
-| OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientInstrumentationOptions              | OpenTelemetry.Instrumentation.GrpcNetClient       | 1.5.1-beta.1  |
-| OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions                       | OpenTelemetry.Instrumentation.Http                | 1.5.1-beta.1  |
+| OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientInstrumentationOptions              | OpenTelemetry.Instrumentation.GrpcNetClient       | 1.6.0-beta.2  |
+| OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions                       | OpenTelemetry.Instrumentation.Http                | 1.6.0-beta.2  |
 | OpenTelemetry.Instrumentation.Quartz.QuartzInstrumentationOptions                         | OpenTelemetry.Instrumentation.Quartz              | 1.0.0-alpha.3 |
-| OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions                   | OpenTelemetry.Instrumentation.SqlClient           | 1.5.1-beta.1  |
+| OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions                   | OpenTelemetry.Instrumentation.SqlClient           | 1.6.0-beta.2  |
 | OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions | OpenTelemetry.Instrumentation.StackExchangeRedis  | 1.0.0-rc9.10  |
 | OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions                               | OpenTelemetry.Instrumentation.Wcf                 | 1.0.0-rc.12   |
 
@@ -129,7 +129,7 @@ public class MyPlugin
 | OpenTelemetry.Exporter.ConsoleExporterOptions                                    | OpenTelemetry.Exporter.Console                 | 1.6.0         |
 | OpenTelemetry.Exporter.PrometheusExporterOptions                                 | OpenTelemetry.Exporter.Prometheus.HttpListener | 1.6.0-rc.1    |
 | OpenTelemetry.Exporter.OtlpExporterOptions                                       | OpenTelemetry.Exporter.OpenTelemetryProtocol   | 1.6.0         |
-| OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetricsInstrumentationOptions | OpenTelemetry.Instrumentation.AspNetCore       | 1.5.1-beta.1  |
+| OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetricsInstrumentationOptions | OpenTelemetry.Instrumentation.AspNetCore       | 1.6.0-beta.2  |
 | OpenTelemetry.Instrumentation.Runtime.RuntimeInstrumentationOptions              | OpenTelemetry.Instrumentation.Runtime          | 1.5.1         |
 
 ### Logs

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,13 +17,13 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNet" Version="1.6.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.8" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.5.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.5.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.10" />
     <PackageVersion Include="OpenTelemetry.Shims.OpenTracing" Version="1.6.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.3" />

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreMetricsInitializer.cs
@@ -17,7 +17,6 @@
 #if NET6_0_OR_GREATER
 
 using System.Reflection;
-using OpenTelemetry.Instrumentation.AspNetCore;
 
 namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
@@ -30,13 +29,12 @@ internal class AspNetCoreMetricsInitializer : InstrumentationInitializer
 
     public override void Initialize(ILifespanManager lifespanManager)
     {
+        var metricOptionsType = Type.GetType("OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetricsInstrumentationOptions, OpenTelemetry.Instrumentation.AspNetCore")!;
+        var optionsConstructor = metricOptionsType.GetConstructor(Type.EmptyTypes)!;
+        var aspNetCoreMetricsInstrumentationOptions = optionsConstructor.Invoke(Array.Empty<object?>());
+
         var metricsType = Type.GetType("OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreMetrics, OpenTelemetry.Instrumentation.AspNetCore")!;
-
-        var aspNetCoreMetricsInstrumentationOptions = new AspNetCoreMetricsInstrumentationOptions();
-
-        Instrumentation.PluginManager?.ConfigureMetricsOptions(aspNetCoreMetricsInstrumentationOptions);
-
-        var constructor = metricsType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, new[] { typeof(AspNetCoreMetricsInstrumentationOptions) })!;
+        var constructor = metricsType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, new[] { metricOptionsType })!;
         var aspNetCoreMetrics = constructor.Invoke(new object?[] { aspNetCoreMetricsInstrumentationOptions });
 
         lifespanManager.Track(aspNetCoreMetrics);

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
@@ -50,7 +50,7 @@ internal class HttpClientInitializer
 #if NETFRAMEWORK
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Http.Implementation.HttpWebRequestActivitySource, OpenTelemetry.Instrumentation.Http")!;
 
-        instrumentationType.GetProperty("Options", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, options);
+        instrumentationType.GetProperty("TracingOptions", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, options);
 #else
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Http.HttpClientInstrumentation, OpenTelemetry.Instrumentation.Http")!;
         var instrumentation = Activator.CreateInstance(instrumentationType, options)!;

--- a/test/IntegrationTests/HttpNetFrameworkTests.cs
+++ b/test/IntegrationTests/HttpNetFrameworkTests.cs
@@ -16,7 +16,6 @@
 
 #if NETFRAMEWORK
 using IntegrationTests.Helpers;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace IntegrationTests;


### PR DESCRIPTION
## Why

Handles https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.6.0-beta.2
ref: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4981

## What

- .NET only, `OpenTelemetry.Instrumentation.AspNetCore` updated from `1.5.1-beta.1` to `1.6.0-beta.2`.
- `OpenTelemetry.Instrumentation.GrpcNetClient`,  `OpenTelemetry.Instrumentation.Http`,  and `OpenTelemetry.Instrumentation.SqlClient` updated from `1.5.1-beta.1` to `1.6.0-beta.2`.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.

## Future changes

* #3053 
* #3054 
