### PR TITLE
[chore] Bump OTel Collector and Jaeger in dev and demo

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -21,7 +21,5 @@ services:
 
   jaeger:
     image: jaegertracing/all-in-one:1.50.0
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.78.0
+    image: otel/opentelemetry-collector-contrib:0.88.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
       - ./log:/log/otel
@@ -20,6 +20,8 @@ services:
       - jaeger
 
   jaeger:
-    image: jaegertracing/all-in-one:1.46.0
+    image: jaegertracing/all-in-one:1.50.0
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"

--- a/dev/otel-config.yaml
+++ b/dev/otel-config.yaml
@@ -18,7 +18,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     # verbosity: detailed
   file/traces:
     path: /log/otel/traces.log
@@ -41,7 +41,7 @@ service:
         - zipkin
       processors: [batch]
       exporters:
-        - logging 
+        - debug 
         - file/traces
         - otlp
     metrics:
@@ -49,7 +49,7 @@ service:
         - otlp
       processors: [batch]
       exporters:
-        - logging 
+        - debug 
         - file/metrics
         - prometheus
     logs:
@@ -57,7 +57,7 @@ service:
         - otlp
       processors: [batch]
       exporters:
-        - logging 
+        - debug 
         - file/logs
   extensions:
     - health_check

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
 
   # OpenTelemetry Collector
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.78.0
+    image: otel/opentelemetry-collector-contrib:0.88.0
     volumes:
       - ./otel-config.yaml:/etc/otel/config.yaml
       - ./log:/log/otel
@@ -62,7 +62,7 @@ services:
       - loki
 
   jaeger:
-    image: jaegertracing/all-in-one:1.46.0
+    image: jaegertracing/all-in-one:1.50.0
     ports:
       - "16686:16686" # Jaeger Web UI
 

--- a/examples/demo/otel-config.yaml
+++ b/examples/demo/otel-config.yaml
@@ -14,7 +14,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     # verbosity: detailed
   file/traces:
     path: /log/otel/traces.log
@@ -41,7 +41,7 @@ service:
         - zipkin
       processors: [batch]
       exporters:
-        - logging 
+        - debug 
         - file/traces
         - otlp
     metrics:
@@ -49,7 +49,7 @@ service:
         - otlp
       processors: [batch]
       exporters:
-        - logging 
+        - debug 
         - file/metrics
         - prometheus
     logs:
@@ -57,7 +57,7 @@ service:
         - otlp
       processors: [batch]
       exporters:
-        - logging 
+        - debug 
         - file/logs
         - loki
   extensions:


### PR DESCRIPTION
## Why

`logging` exporter is deprecated in OTel Collector in favor of `debug`.

https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md

## What

1. Bump OTel Collector and use `debug` exporter
2. Bump Jaeger

## Tests

I was testing by following https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/tree/main/examples/demo

1. The collector logs had output from the debug exporters.
2. Jaeger was collecting spans

