### PR TITLE
Fix update function in PS install module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,9 +234,9 @@ Get-Help Install-OpenTelemetryCore -Detailed
 Updating OpenTelemetry installation:
 
 ```powershell
-# Import the previously downloaded module.
+# Import the previously downloaded module. After an update the module is found in the default install directory.
 # Note: It's best to use the same version of the module for installation and uninstallation to ensure proper removal.
-Import-Module "path/to/OpenTelemetry.DotNet.Auto.psm1"
+Import-Module "C:\Program Files\OpenTelemetry .NET AutoInstrumentation\OpenTelemetry.DotNet.Auto.psm1"
 
 # If IIS was previously registered, use RegisterIIS = $true.
 Update-OpenTelemetryCore -RegisterIIS $true

--- a/script-templates/OpenTelemetry.DotNet.Auto.psm1.template
+++ b/script-templates/OpenTelemetry.DotNet.Auto.psm1.template
@@ -392,24 +392,29 @@ function Update-OpenTelemetryCore() {
 
     Write-Information -MessageData "Updating OpenTelemetry .NET Automatic Instrumentation from $($currentInstallVersion) to $($newestInstallVersion)." -InformationAction Continue
 
-    $currentInstallPath = Get-Current-InstallDir
+    $installDir = Get-Current-InstallDir
 
     Uninstall-OpenTelemetryCore
     if ($RegisterIIS) {
         Unregister-OpenTelemetryForIIS -NoReset $true
     }
 
-    Prepare-Install-Directory $currentInstallPath
-
-    $modulePath = Download-OpenTelemetry-Install-Module $newestInstallVersion $currentInstallPath
+    $tempDir = Get-Temp-Directory
+    $modulePath = Download-OpenTelemetry-Install-Module $newestInstallVersion $tempDir
 
     Remove-Module OpenTelemetry.Dotnet.Auto
     Import-Module $modulePath
 
-    Install-OpenTelemetryCore
+    Install-OpenTelemetryCore -InstallDir $installDir
     if ($RegisterIIS) {
         Register-OpenTelemetryForIIS
     }
+
+    # Release module
+    Remove-Module OpenTelemetry.Dotnet.Auto
+    
+    # Cache install module
+    Move-Item -Path $modulePath -Destination $installDir
 }
 
 <#


### PR DESCRIPTION
## Why

Follow-up to #3042

## What

Found some issues after playing around with the script.

Fixes:
- Passes along the current install dir (in case it's changed it won't be overridden)
- Removes double prepare dir to cache the psm file (under install dir, currently it was removed)
- Readme to guide to the default psm path
