### PR TITLE
[WCF] Adjustments for changes in OpenTelemetry.Instrumentation.Wcf 1.0.0-rc.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - .NET Framework only, `OpenTelemetry.Instrumentation.AspNet` and
   `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule` updated from
   `1.6.0-beta.1` to `1.6.0-beta.2`.
--  `OpenTelemetry.Instrumentation.Wcf` updated from `1.0.0-rc.12` to `1.0.0-rc.13`.
+- `OpenTelemetry.Instrumentation.Wcf` updated from `1.0.0-rc.12` to `1.0.0-rc.13`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - .NET Framework only, `OpenTelemetry.Instrumentation.AspNet` and
   `OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule` updated from
   `1.6.0-beta.1` to `1.6.0-beta.2`.
+-  `OpenTelemetry.Instrumentation.Wcf` updated from `1.0.0-rc.12` to `1.0.0-rc.13`.
 
 ### Deprecated
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.12" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.13" />
   </ItemGroup>
 </Project>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -119,7 +119,7 @@ public class MyPlugin
 | OpenTelemetry.Instrumentation.Quartz.QuartzInstrumentationOptions                         | OpenTelemetry.Instrumentation.Quartz              | 1.0.0-alpha.3 |
 | OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions                   | OpenTelemetry.Instrumentation.SqlClient           | 1.6.0-beta.2  |
 | OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions | OpenTelemetry.Instrumentation.StackExchangeRedis  | 1.0.0-rc9.12  |
-| OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions                               | OpenTelemetry.Instrumentation.Wcf                 | 1.0.0-rc.12   |
+| OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions                               | OpenTelemetry.Instrumentation.Wcf                 | 1.0.0-rc.13   |
 
 ### Metrics
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -52,7 +52,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"OpenTelemetry.Instrumentation.Quartz", {1, 0, 0, 3} },
         { L"OpenTelemetry.Instrumentation.Runtime", {1, 5, 1, 0} },
         { L"OpenTelemetry.Instrumentation.SqlClient", {1, 0, 0, 0} },
-        { L"OpenTelemetry.Instrumentation.Wcf", {1, 0, 0, 12} },
+        { L"OpenTelemetry.Instrumentation.Wcf", {1, 0, 0, 13} },
         { L"OpenTelemetry.ResourceDetectors.Azure", {1, 0, 0, 3} },
         { L"OpenTelemetry.ResourceDetectors.Container", {1, 0, 0, 4} },
         { L"OpenTelemetry.Shims.OpenTracing", {1, 0, 0, 0} },

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/WcfInitializer.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System.Reflection;
+using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 using OpenTelemetry.Instrumentation.Wcf;
 
@@ -42,5 +44,15 @@ internal class WcfInitializer : InstrumentationInitializer
         var instrumentationType = Type.GetType("OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationActivitySource, OpenTelemetry.Instrumentation.Wcf");
 
         instrumentationType?.GetProperty("Options")?.SetValue(null, options);
+
+#if NETFRAMEWORK
+        var enabledTraceInstrumentations = Instrumentation.TracerSettings.Value.EnabledInstrumentations;
+        if (enabledTraceInstrumentations.Contains(TracerInstrumentation.WcfService) && enabledTraceInstrumentations.Contains(TracerInstrumentation.AspNet))
+        {
+            var aspNetParentSpanCorrectorType = Type.GetType("OpenTelemetry.Instrumentation.Wcf.Implementation.AspNetParentSpanCorrector, OpenTelemetry.Instrumentation.Wcf");
+            var methodInfo = aspNetParentSpanCorrectorType?.GetMethod("Register", BindingFlags.Static | BindingFlags.Public);
+            methodInfo?.Invoke(null, null);
+        }
+#endif
     }
 }


### PR DESCRIPTION
## Why

Replaces https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3056

Update `OpenTelemetry.Instrumentation.Wcf` to `1.0.0-rc.13`.

## What

Initialize `AspNet` parent span correction added in [`1.0.0-rc.13`](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/4c1c089a95446ca45be5c71eb834723c5735a21d/src/OpenTelemetry.Instrumentation.Wcf/CHANGELOG.md#100-rc13).

## Tests

Existing tests adjusted.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
