### PR TITLE
HttpClient Metrics instrumentation for .NET8

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 using OpenTelemetry.AutoInstrumentation.Loading;
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.Plugins;
+using OpenTelemetry.AutoInstrumentation.Util;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.AutoInstrumentation.Configurations;
@@ -103,8 +104,15 @@ internal static class EnvironmentConfigurationMetricHelper
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static MeterProviderBuilder AddHttpClientInstrumentation(MeterProviderBuilder builder, LazyInstrumentationLoader lazyInstrumentationLoader)
         {
-            DelayedInitialization.Metrics.AddHttpClient(lazyInstrumentationLoader);
+#if NET6_0_OR_GREATER
+            if (DotNetVersionHelper.DotNetMajorVersion >= 8)
+            {
+                return builder.AddMeter("System.Net.Http")
+                    .AddMeter("System.Net.NameResolution");
+            }
+#endif
 
+            DelayedInitialization.Metrics.AddHttpClient(lazyInstrumentationLoader);
             return builder.AddMeter("OpenTelemetry.Instrumentation.Http");
         }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
@@ -107,7 +107,9 @@ internal static class EnvironmentConfigurationMetricHelper
 #if NET6_0_OR_GREATER
             if (DotNetVersionHelper.DotNetMajorVersion >= 8)
             {
-                return builder.AddMeter("System.Net.Http")
+                // HTTP has build in support for metrics in .NET8. Executing OpenTelemetry.Instrumentation.Http in this case leads to duplicated metrics.
+                return builder
+                    .AddMeter("System.Net.Http")
                     .AddMeter("System.Net.NameResolution");
             }
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/Util/DotNetVersionHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Util/DotNetVersionHelper.cs
@@ -1,0 +1,24 @@
+// <copyright file="DotNetVersionHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.AutoInstrumentation.Util;
+#if NET6_0_OR_GREATER
+
+internal static class DotNetVersionHelper
+{
+    public static int DotNetMajorVersion { get; } = typeof(object).Assembly.GetName().Version?.Major ?? 0;
+}
+#endif

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -82,8 +82,14 @@ public class HttpTests : TestHelper
     {
         using var collector = new MockMetricsCollector(Output);
         SetExporter(collector);
-        collector.Expect("OpenTelemetry.Instrumentation.Http");
         collector.Expect("OpenTelemetry.Instrumentation.AspNetCore");
+#if NET8_0_OR_GREATER
+        collector.Expect("System.Net.Http");
+        collector.Expect("System.Net.NameResolution");
+        collector.ExpectAdditionalEntries(x => x.All(m => m.InstrumentationScopeName != "OpenTelemetry.Instrumentation.Http"));
+#else
+        collector.Expect("OpenTelemetry.Instrumentation.Http");
+#endif
 
         RunTestApplication();
 

--- a/test/test-applications/integrations/TestApplication.Http/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Http/Program.cs
@@ -37,8 +37,9 @@ public class Program
         var server = (IServer?)host.Services.GetService(typeof(IServer));
         var addressFeature = server?.Features.Get<IServerAddressesFeature>();
         var address = addressFeature?.Addresses.First();
+        var dnsAddress = address?.Replace("127.0.0.1", "localhost"); // needed to force DNS resolution to test metrics
         using var httpClient = new HttpClient();
-        httpClient.GetAsync($"{address}/test").Wait();
+        httpClient.GetAsync($"{dnsAddress}/test").Wait();
     }
 
     public static IHostBuilder CreateHostBuilder(string[] args) =>


### PR DESCRIPTION
## Why


Fixes #3054

## What

Apply changes from https://github.com/open-telemetry/opentelemetry-dotnet/commit/d07d03086ae269174a94552448cfd0bcf11aa37a

Changelog already covered by:
- `OpenTelemetry.Instrumentation.GrpcNetClient`,
  `OpenTelemetry.Instrumentation.Http`,
  and `OpenTelemetry.Instrumentation.SqlClient` updated from `1.5.1-beta.1` to `1.6.0-beta.2`.

## Tests

CI + modify existing tests

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
