### PR TITLE
AspNetCore Metrics instrumentation for .NET8

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
@@ -96,6 +96,18 @@ internal static class EnvironmentConfigurationMetricHelper
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static MeterProviderBuilder AddAspNetCoreInstrumentation(MeterProviderBuilder builder, LazyInstrumentationLoader lazyInstrumentationLoader)
         {
+            if (DotNetVersionHelper.DotNetMajorVersion >= 8)
+            {
+                // AspNetCore has build in support for metrics in .NET8. Executing OpenTelemetry.Instrumentation.AspNetCore in this case leads to duplicated metrics.
+                return builder
+                    .AddMeter("Microsoft.AspNetCore.Hosting")
+                    .AddMeter("Microsoft.AspNetCore.Server.Kestrel")
+                    .AddMeter("Microsoft.AspNetCore.Http.Connections")
+                    .AddMeter("Microsoft.AspNetCore.Routing")
+                    .AddMeter("Microsoft.AspNetCore.Diagnostics")
+                    .AddMeter("Microsoft.AspNetCore.RateLimiting");
+            }
+
             DelayedInitialization.Metrics.AddAspNetCore(lazyInstrumentationLoader);
             return builder.AddMeter("OpenTelemetry.Instrumentation.AspNetCore");
         }

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Build" Version="15.9.20" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.2" />

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -82,18 +82,24 @@ public class HttpTests : TestHelper
     {
         using var collector = new MockMetricsCollector(Output);
         SetExporter(collector);
-        collector.Expect("OpenTelemetry.Instrumentation.AspNetCore");
 #if NET8_0_OR_GREATER
         collector.Expect("System.Net.Http");
         collector.Expect("System.Net.NameResolution");
-        collector.ExpectAdditionalEntries(x => x.All(m => m.InstrumentationScopeName != "OpenTelemetry.Instrumentation.Http"));
+        collector.Expect("Microsoft.AspNetCore.Hosting");
+        collector.Expect("Microsoft.AspNetCore.Server.Kestrel");
+        collector.Expect("Microsoft.AspNetCore.Http.Connections");
+        collector.Expect("Microsoft.AspNetCore.Routing");
+        collector.Expect("Microsoft.AspNetCore.Diagnostics");
+        collector.Expect("Microsoft.AspNetCore.RateLimiting");
+        collector.ExpectAdditionalEntries(x => x.All(m => m.InstrumentationScopeName != "OpenTelemetry.Instrumentation.AspNetCore" && m.InstrumentationScopeName != "OpenTelemetry.Instrumentation.Http"));
 #else
+        collector.Expect("OpenTelemetry.Instrumentation.AspNetCore");
         collector.Expect("OpenTelemetry.Instrumentation.Http");
 #endif
 
         RunTestApplication();
 
-        collector.AssertExpectations();
+        collector.AssertExpectations(TimeSpan.FromSeconds(3));
     }
 }
 #endif

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -99,7 +99,7 @@ public class HttpTests : TestHelper
 
         RunTestApplication();
 
-        collector.AssertExpectations(TimeSpan.FromSeconds(3));
+        collector.AssertExpectations();
     }
 }
 #endif

--- a/test/IntegrationTests/MinimalApiTests.cs
+++ b/test/IntegrationTests/MinimalApiTests.cs
@@ -17,10 +17,8 @@
 #if NET6_0_OR_GREATER
 
 using IntegrationTests.Helpers;
-using OpenTelemetry.AutoInstrumentation;
 using OpenTelemetry.Proto.Logs.V1;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace IntegrationTests;
 

--- a/test/test-applications/integrations/TestApplication.Http/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Http/Program.cs
@@ -45,9 +45,8 @@ public class Program
         var address = addressFeature?.Addresses.First();
         var dnsAddress = address?.Replace("127.0.0.1", "localhost"); // needed to force DNS resolution to test metrics
         using var httpClient = new HttpClient();
-        httpClient.GetAsync($"{dnsAddress}/exception").Wait();
         httpClient.GetAsync($"{dnsAddress}/test").Wait();
-
+        httpClient.GetAsync($"{dnsAddress}/exception").Wait();
 #if NET8_0_OR_GREATER
         var hubConnection = new HubConnectionBuilder().WithUrl($"{dnsAddress}/signalr").Build();
         hubConnection.StartAsync().Wait();

--- a/test/test-applications/integrations/TestApplication.Http/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Http/Program.cs
@@ -16,8 +16,14 @@
 
 using System.Diagnostics;
 using System.Net.Http;
+#if NET8_0_OR_GREATER
+using System.Threading.RateLimiting;
+#endif
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+#if NET8_0_OR_GREATER
+using Microsoft.AspNetCore.SignalR.Client;
+#endif
 
 namespace TestApplication.Http;
 
@@ -39,11 +45,25 @@ public class Program
         var address = addressFeature?.Addresses.First();
         var dnsAddress = address?.Replace("127.0.0.1", "localhost"); // needed to force DNS resolution to test metrics
         using var httpClient = new HttpClient();
+        httpClient.GetAsync($"{dnsAddress}/exception").Wait();
         httpClient.GetAsync($"{dnsAddress}/test").Wait();
+
+#if NET8_0_OR_GREATER
+        var hubConnection = new HubConnectionBuilder().WithUrl($"{dnsAddress}/signalr").Build();
+        hubConnection.StartAsync().Wait();
+        hubConnection.StopAsync().Wait();
+#endif
     }
 
     public static IHostBuilder CreateHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
+#if NET8_0_OR_GREATER
+            .ConfigureServices(
+                services => services
+                .AddRateLimiter(rateLimiterOptions => rateLimiterOptions.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext => RateLimitPartition.GetNoLimiter("1")))
+                .AddConnections()
+                .AddSignalR())
+#endif
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseStartup<Startup>();

--- a/test/test-applications/integrations/TestApplication.Http/Startup.cs
+++ b/test/test-applications/integrations/TestApplication.Http/Startup.cs
@@ -15,11 +15,6 @@
 // </copyright>
 
 using System.Diagnostics;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace TestApplication.Http;
 
@@ -42,16 +37,26 @@ public class Startup
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
-        app.Map(
-            "/test",
-            configuration => configuration.Run(async context =>
-            {
-                using (var activity = MyActivitySource.StartActivity("manual span"))
+        app
+#if NET8_0_OR_GREATER
+            .UseRouting() // enables metrics for Microsoft.AspNetCore.Routing in .NET8+
+            .UseExceptionHandler(new ExceptionHandlerOptions { ExceptionHandler = _ => Task.CompletedTask }) // together with call to /exception enables metrics for Microsoft.AspNetCore.Diagnostics for .NET8+
+            .UseRateLimiter() // enables metrics for Microsoft.AspNetCore.RateLimiting in .NET8+
+            .UseEndpoints(x => x.MapHub<TestHub>("/signalr")) // together with connection to SignalR Hub enables metrics for Microsoft.AspNetCore.Http.Connections for .NET8
+#endif
+            .Map(
+                "/test",
+                configuration => configuration.Run(async context =>
                 {
-                    activity?.SetTag("test_tag", "test_value");
-                }
+                    using (var activity = MyActivitySource.StartActivity("manual span"))
+                    {
+                        activity?.SetTag("test_tag", "test_value");
+                    }
 
-                await context.Response.WriteAsync("Pong");
-            }));
+                    await context.Response.WriteAsync("Pong");
+                }))
+            .Map(
+                "/exception",
+                configuration => configuration.Run(_ => throw new InvalidOperationException("Just to throw something")));
     }
 }

--- a/test/test-applications/integrations/TestApplication.Http/TestApplication.Http.csproj
+++ b/test/test-applications/integrations/TestApplication.Http/TestApplication.Http.csproj
@@ -4,5 +4,9 @@
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsCentos)' == '' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
-  
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Condition=" '$(TargetFramework)' == 'net8.0' " />
+  </ItemGroup>
+
 </Project>

--- a/test/test-applications/integrations/TestApplication.Http/TestHub.cs
+++ b/test/test-applications/integrations/TestApplication.Http/TestHub.cs
@@ -1,0 +1,23 @@
+// <copyright file="TestHub.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace TestApplication.Http;
+
+public class TestHub : Hub
+{
+}


### PR DESCRIPTION
## Why

Fixes #3053

## What

Apply changes from https://github.com/open-telemetry/opentelemetry-dotnet/commit/38e21a99bb083eae0acce02baae19eb06726ceeb

Changelog covered by:
- .NET only, `OpenTelemetry.Instrumentation.AspNetCore` updated
  from `1.5.1-beta.1` to `1.6.0-beta.2`.

## Tests

CI + extended tests.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
