### PR TITLE
Add NuGet Version and Download Badges to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # OpenTelemetry .NET Automatic Instrumentation
 
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel--dotnet--auto--instr-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01NR1YLSE7)
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.AutoInstrumentation.svg)](https://www.nuget.org/packages/OpenTelemetry.AutoInstrumentation)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.AutoInstrumentation.svg)](https://www.nuget.org/packages/OpenTelemetry.AutoInstrumentation)
 
 This project adds [OpenTelemetry instrumentation](https://opentelemetry.io/docs/concepts/instrumenting/#automatic-instrumentation)
 to .NET applications without having to modify their source code.


### PR DESCRIPTION
## Why

Add two NuGet badges to the README file for the `OpenTelemetry.AutoInstrumentation` package. These badges provide quick access to package information and enhance the visibility of the package's current version and download statistics.

![image](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/assets/9479006/5d548b17-4a13-4206-ac69-9c59ada81a10)

## What

<!-- Describe changes proposed in this pull request. -->

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
