### PR TITLE
[kafka] create `receive` spans when no messages are read

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerConsumeSyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerConsumeSyncIntegration.cs
@@ -59,11 +59,6 @@ public static class ConsumerConsumeSyncIntegration
             consumeResult = response == null ? null : response.DuckAs<IConsumeResult>();
         }
 
-        if (consumeResult is null)
-        {
-            return new CallTargetReturn<TResponse>(response);
-        }
-
         var activity = KafkaInstrumentation.StartConsumerActivity(consumeResult, (DateTimeOffset)state.StartTime!, instance!);
         if (exception is not null)
         {

--- a/test/IntegrationTests/KafkaTests.cs
+++ b/test/IntegrationTests/KafkaTests.cs
@@ -24,7 +24,24 @@ namespace IntegrationTests;
 [Collection(KafkaCollection.Name)]
 public class KafkaTests : TestHelper
 {
+    private const string MessagingPublishOperationAttributeValue = "publish";
+    private const string MessagingReceiveOperationAttributeValue = "receive";
+    private const string MessagingSystemAttributeName = "messaging.system";
+    private const string MessagingOperationAttributeName = "messaging.operation";
+    private const string MessagingDestinationAttributeName = "messaging.destination.name";
+    private const string MessagingClientIdAttributeName = "messaging.client_id";
+
+    private const string KafkaMessageSystemAttributeValue = "kafka";
+    private const string KafkaConsumerGroupAttributeName = "messaging.kafka.consumer.group";
+    private const string KafkaMessageKeyAttributeName = "messaging.kafka.message.key";
+    private const string KafkaMessageKeyAttributeValue = "testkey";
+    private const string KafkaDestinationPartitionAttributeName = "messaging.kafka.destination.partition";
+    private const string KafkaMessageOffsetAttributeName = "messaging.kafka.message.offset";
+    private const string KafkaMessageTombstoneAttributeName = "messaging.kafka.message.tombstone";
     private const string KafkaInstrumentationScopeName = "OpenTelemetry.AutoInstrumentation.Kafka";
+    private const string KafkaProducerClientIdAttributeValue = "rdkafka#producer-1";
+    private const string KafkaConsumerClientIdAttributeValue = "rdkafka#consumer-2";
+
     // https://github.com/confluentinc/confluent-kafka-dotnet/blob/07de95ed647af80a0db39ce6a8891a630423b952/src/Confluent.Kafka/Offset.cs#L36C44-L36C44
     private const int InvalidOffset = -1001;
 
@@ -49,13 +66,16 @@ public class KafkaTests : TestHelper
         collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Producer && ValidateProduceExceptionSpan(span, topicName), "Failed Produce attempt without delivery handler set.");
         collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Producer && ValidateResultProcessingProduceExceptionSpan(span, topicName), "Failed ProduceAsync attempt.");
 
-        // For 1.4.0 null is returned when attempting to read from non-existent topic,
-        // and no exception is thrown,
-        // instrumentation creates no span in such case.
         if (packageVersion == string.Empty || Version.Parse(packageVersion) >= new Version(2, 3, 0))
         {
             // Failed consume attempt.
             collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Consumer && ValidateConsumeExceptionSpan(span, topicName), "Failed Consume attempt.");
+        }
+        else
+        {
+            // For 1.4.0 null is returned when attempting to read from non-existent topic,
+            // and no exception is thrown.
+            collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Consumer && ValidateEmptyReadConsumerSpan(span, topicName), "Successful Consume attempt that returned no message.");
         }
 
         // Successful produce attempts after topic was created with admin client.
@@ -71,6 +91,9 @@ public class KafkaTests : TestHelper
         collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Consumer && ValidateConsumerSpan(span, topicName, 1), "Second successful Consume attempt.");
         collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Consumer && ValidateConsumerSpan(span, topicName, 2), "Third successful Consume attempt.");
 
+        // Consume attempt that returns no message.
+        collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Consumer && ValidateEmptyReadConsumerSpan(span, topicName), "Additional successful attempt after all the produced messages were already read.");
+
         collector.ExpectCollected(collection => ValidatePropagation(collection, topicName));
 
         EnableBytecodeInstrumentation();
@@ -84,75 +107,95 @@ public class KafkaTests : TestHelper
         collector.AssertExpectations();
     }
 
+    private static bool ValidateEmptyReadConsumerSpan(Span span, string topicName)
+    {
+        var consumerGroupId = span.Attributes.Single(kv => kv.Key == KafkaConsumerGroupAttributeName).Value.StringValue;
+        return span.Name == MessagingReceiveOperationAttributeValue &&
+               span.Links.Count == 0 &&
+               ValidateBasicSpanAttributes(span.Attributes, KafkaConsumerClientIdAttributeValue, MessagingReceiveOperationAttributeValue) &&
+               consumerGroupId == GetConsumerGroupIdAttributeValue(topicName);
+    }
+
+    private static string GetConsumerGroupIdAttributeValue(string topicName)
+    {
+        return $"test-consumer-group-{topicName}";
+    }
+
     private static bool ValidateConsumeExceptionSpan(Span span, string topicName)
     {
         return ValidateConsumerSpan(span, topicName, InvalidOffset, null) &&
                span.Status.Code == Status.Types.StatusCode.Error;
     }
 
-    private static bool ValidateConsumerSpan(Span span, string topicName, int messageOffset, string? expectedMessageKey = "testkey")
+    private static bool ValidateConsumerSpan(Span span, string topicName, int messageOffset, string? expectedMessageKey = KafkaMessageKeyAttributeValue)
     {
-        var kafkaMessageOffset = span.Attributes.Single(kv => kv.Key == "messaging.kafka.message.offset").Value.IntValue;
-        var consumerGroupId = span.Attributes.Single(kv => kv.Key == "messaging.kafka.consumer.group").Value.StringValue;
-        return ValidateCommonTags(span.Attributes, topicName, "rdkafka#consumer-2", "receive", 0, expectedMessageKey) &&
+        var kafkaMessageOffset = span.Attributes.SingleOrDefault(kv => kv.Key == KafkaMessageOffsetAttributeName)?.Value.IntValue;
+        var consumerGroupId = span.Attributes.Single(kv => kv.Key == KafkaConsumerGroupAttributeName).Value.StringValue;
+        return ValidateCommonAttributes(span.Attributes, topicName, KafkaConsumerClientIdAttributeValue, MessagingReceiveOperationAttributeValue, 0, expectedMessageKey) &&
                kafkaMessageOffset == messageOffset &&
-               consumerGroupId == $"test-consumer-group-{topicName}";
+               consumerGroupId == GetConsumerGroupIdAttributeValue(topicName);
     }
 
-    private static bool ValidateBasicProduceExceptionSpanExpectations(Span span, string topicName)
+    private static bool ValidateBasicProduceExceptionSpan(Span span, string topicName)
     {
-        return ValidateCommonTags(span.Attributes, topicName, "rdkafka#producer-1", "publish", -1, "testkey") &&
+        return ValidateCommonAttributes(span.Attributes, topicName, KafkaProducerClientIdAttributeValue, MessagingPublishOperationAttributeValue, -1, KafkaMessageKeyAttributeValue) &&
                span.Status.Code == Status.Types.StatusCode.Error;
     }
 
     private static bool ValidateProduceExceptionSpan(Span span, string topicName)
     {
-        return ValidateBasicProduceExceptionSpanExpectations(span, topicName) &&
-               span.Attributes.Count(kv => kv.Key == "messaging.kafka.message.offset") == 0;
+        return ValidateBasicProduceExceptionSpan(span, topicName) &&
+               span.Attributes.Count(kv => kv.Key == KafkaMessageOffsetAttributeName) == 0;
     }
 
     private static bool ValidateResultProcessingProduceExceptionSpan(Span span, string topicName)
     {
         // DeliveryResult processing results in offset being set.
-        var offset = span.Attributes.SingleOrDefault(kv => kv.Key == "messaging.kafka.message.offset")?.Value.IntValue;
-        return ValidateBasicProduceExceptionSpanExpectations(span, topicName) &&
+        var offset = span.Attributes.SingleOrDefault(kv => kv.Key == KafkaMessageOffsetAttributeName)?.Value.IntValue;
+        return ValidateBasicProduceExceptionSpan(span, topicName) &&
                offset == InvalidOffset;
     }
 
     private static bool ValidateProducerSpan(Span span, string topicName, int partition, bool tombstoneExpected = false)
     {
-        var isTombstone = span.Attributes.Single(kv => kv.Key == "messaging.kafka.message.tombstone").Value.BoolValue;
+        var isTombstone = span.Attributes.Single(kv => kv.Key == KafkaMessageTombstoneAttributeName).Value.BoolValue;
 
-        return ValidateCommonTags(span.Attributes, topicName, "rdkafka#producer-1", "publish", partition, "testkey") &&
+        return ValidateCommonAttributes(span.Attributes, topicName, KafkaProducerClientIdAttributeValue, MessagingPublishOperationAttributeValue, partition, KafkaMessageKeyAttributeValue) &&
                isTombstone == tombstoneExpected &&
                span.Status is null;
     }
 
-    private static bool ValidateCommonTags(IReadOnlyCollection<KeyValue> attributes, string topicName, string clientName, string operationName, int partition, string? expectedMessageKey)
+    private static bool ValidateCommonAttributes(IReadOnlyCollection<KeyValue> attributes, string topicName, string clientId, string operationName, int partition, string? expectedMessageKey)
     {
-        var messagingSystem = attributes.Single(kv => kv.Key == "messaging.system").Value.StringValue;
-        var messagingDestinationName = attributes.Single(kv => kv.Key == "messaging.destination.name").Value.StringValue;
-        var messagingOperation = attributes.Single(kv => kv.Key == "messaging.operation").Value.StringValue;
-        var messagingClientId = attributes.Single(kv => kv.Key == "messaging.client_id").Value.StringValue;
-        var kafkaMessageKey = attributes.SingleOrDefault(kv => kv.Key == "messaging.kafka.message.key")?.Value.StringValue;
-        var kafkaPartition = attributes.Single(kv => kv.Key == "messaging.kafka.destination.partition").Value.IntValue;
+        var messagingDestinationName = attributes.SingleOrDefault(kv => kv.Key == MessagingDestinationAttributeName)?.Value.StringValue;
+        var kafkaMessageKey = attributes.SingleOrDefault(kv => kv.Key == KafkaMessageKeyAttributeName)?.Value.StringValue;
+        var kafkaPartition = attributes.SingleOrDefault(kv => kv.Key == KafkaDestinationPartitionAttributeName)?.Value.IntValue;
 
-        return messagingSystem == "kafka" &&
+        return ValidateBasicSpanAttributes(attributes, clientId, operationName) &&
                messagingDestinationName == topicName &&
-               messagingOperation == operationName &&
-               messagingClientId == clientName &&
                kafkaMessageKey == expectedMessageKey &&
                kafkaPartition == partition;
     }
 
+    private static bool ValidateBasicSpanAttributes(IReadOnlyCollection<KeyValue> attributes, string clientId, string operationName)
+    {
+        var messagingSystem = attributes.Single(kv => kv.Key == MessagingSystemAttributeName).Value.StringValue;
+        var messagingOperation = attributes.Single(kv => kv.Key == MessagingOperationAttributeName).Value.StringValue;
+        var messagingClientId = attributes.Single(kv => kv.Key == MessagingClientIdAttributeName).Value.StringValue;
+
+        return messagingSystem == KafkaMessageSystemAttributeValue &&
+               messagingOperation == operationName &&
+               messagingClientId == clientId;
+    }
+
     private static bool ValidatePropagation(ICollection<MockSpansCollector.Collected> collectedSpans, string topicName)
     {
-        var expectedReceiveOperationName = $"{topicName} receive";
-        var expectedPublishOperationName = $"{topicName} publish";
+        var expectedReceiveOperationName = $"{topicName} {MessagingReceiveOperationAttributeValue}";
+        var expectedPublishOperationName = $"{topicName} {MessagingPublishOperationAttributeValue}";
         var producerSpans = collectedSpans
             .Where(span =>
                 span.Span.Name == expectedPublishOperationName &&
-                !span.Span.Attributes.Single(attr => attr.Key == "messaging.kafka.message.tombstone").Value.BoolValue &&
+                !span.Span.Attributes.Single(attr => attr.Key == KafkaMessageTombstoneAttributeName).Value.BoolValue &&
                 span.Span.Status is null);
 
         return producerSpans

--- a/test/test-applications/integrations/TestApplication.Kafka/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Kafka/Program.cs
@@ -87,6 +87,9 @@ internal static class Program
         consumer.Consume(cts.Token);
         consumer.Consume(cts.Token);
 
+        // Additional attempt that returns no message.
+        consumer.Consume(TimeSpan.FromSeconds(5));
+
         // Produce a tombstone.
         producer.Produce(topicName, new Message<string, string> { Key = MessageKey, Value = null! });
         return 0;

--- a/test/test-applications/integrations/TestApplication.Kafka/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Kafka/Program.cs
@@ -156,6 +156,7 @@ internal static class Program
             BootstrapServers = bootstrapServers,
             // https://github.com/confluentinc/confluent-kafka-dotnet/tree/07de95ed647af80a0db39ce6a8891a630423b952#basic-consumer-example
             AutoOffsetReset = AutoOffsetReset.Earliest,
+            CancellationDelayMaxMs = 5000,
             EnableAutoCommit = true
         };
 


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3165#discussion_r1407386453

## What

Create `receive` spans when no messages are returned from `Consume`.

## Tests

Included in PR.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
- [x] New features are covered by tests.
