### PR TITLE
[kafka] set remote context as a parent for some consumer spans

### DIFF
--- a/test/IntegrationTests/KafkaTests.cs
+++ b/test/IntegrationTests/KafkaTests.cs
@@ -44,6 +44,7 @@ public class KafkaTests : TestHelper
 
     // https://github.com/confluentinc/confluent-kafka-dotnet/blob/07de95ed647af80a0db39ce6a8891a630423b952/src/Confluent.Kafka/Offset.cs#L36C44-L36C44
     private const int InvalidOffset = -1001;
+    private const string TestApplicationInstrumentationScopeName = "TestApplication.Kafka";
 
     public KafkaTests(ITestOutputHelper testOutputHelper)
         : base("Kafka", testOutputHelper)
@@ -60,6 +61,8 @@ public class KafkaTests : TestHelper
 
         using var collector = new MockSpansCollector(Output);
         SetExporter(collector);
+
+        collector.Expect(TestApplicationInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Internal);
 
         // Failed produce attempts made before topic is created.
         collector.Expect(KafkaInstrumentationScopeName, span => span.Kind == Span.Types.SpanKind.Producer && ValidateResultProcessingProduceExceptionSpan(span, topicName), "Failed Produce attempt with delivery handler set.");
@@ -198,17 +201,38 @@ public class KafkaTests : TestHelper
                 !span.Span.Attributes.Single(attr => attr.Key == KafkaMessageTombstoneAttributeName).Value.BoolValue &&
                 span.Span.Status is null);
 
-        return producerSpans
+        var consumerSpansWithLinks = producerSpans
             .Select(producerSpan =>
                 GetMatchingConsumerSpan(collectedSpans, producerSpan.Span, expectedReceiveOperationName))
-            .All(matchingConsumerSpan =>
-                matchingConsumerSpan is not null);
+            .ToList();
+
+        var manuallyCreatedSpan = collectedSpans.Single(collectedSpan =>
+            collectedSpan.InstrumentationScopeName == TestApplicationInstrumentationScopeName);
+
+        var consumerSpanWithCustomParent = consumerSpansWithLinks.SingleOrDefault(
+            span =>
+                span.Span.TraceId == manuallyCreatedSpan.Span.TraceId &&
+                span.Span.ParentSpanId == manuallyCreatedSpan.Span.SpanId);
+
+        var consumerSpansHaveCreationContextAsParent =
+            consumerSpansWithLinks
+                .Except(new[] { consumerSpanWithCustomParent })
+                .All(consumerSpan =>
+                    ValidateCreationContextAsParent(consumerSpan));
+
+        return consumerSpanWithCustomParent is not null && consumerSpansHaveCreationContextAsParent;
     }
 
-    private static MockSpansCollector.Collected? GetMatchingConsumerSpan(ICollection<MockSpansCollector.Collected> collectedSpans, Span producerSpan, string expectedReceiveOperationName)
+    private static bool ValidateCreationContextAsParent(MockSpansCollector.Collected? consumerSpan)
+    {
+        return consumerSpan?.Span.TraceId == consumerSpan?.Span.Links[0].TraceId &&
+               consumerSpan?.Span.ParentSpanId == consumerSpan?.Span.Links[0].SpanId;
+    }
+
+    private static MockSpansCollector.Collected GetMatchingConsumerSpan(ICollection<MockSpansCollector.Collected> collectedSpans, Span producerSpan, string expectedReceiveOperationName)
     {
         return collectedSpans
-            .SingleOrDefault(span =>
+            .Single(span =>
             {
                 var parentLinksCount = span.Span.Links.Count(
                     link =>

--- a/test/test-applications/integrations/TestApplication.Kafka/Program.cs
+++ b/test/test-applications/integrations/TestApplication.Kafka/Program.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Diagnostics;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 
@@ -23,6 +24,8 @@ internal static class Program
 {
     private const string MessageKey = "testkey";
     private const string BootstrapServers = "localhost:9092";
+
+    private static readonly ActivitySource Source = new("TestApplication.Kafka");
 
     public static async Task<int> Main(string[] args)
     {
@@ -85,7 +88,11 @@ internal static class Program
         // Consume all the produced messages.
         consumer.Consume(cts.Token);
         consumer.Consume(cts.Token);
-        consumer.Consume(cts.Token);
+
+        using (var activity = Source.StartActivity("ManuallyStarted"))
+        {
+            consumer.Consume(cts.Token);
+        }
 
         // Additional attempt that returns no message.
         consumer.Consume(TimeSpan.FromSeconds(5));

--- a/test/test-applications/integrations/TestApplication.Kafka/Properties/launchSettings.json
+++ b/test/test-applications/integrations/TestApplication.Kafka/Properties/launchSettings.json
@@ -17,7 +17,8 @@
         "OTEL_DOTNET_AUTO_HOME": "$(SolutionDir)bin\\tracer-home",
         "OTEL_SERVICE_NAME": "TestApplication.Kafka",
         "OTEL_LOG_LEVEL": "debug",
-        "OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED": "true"
+        "OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED": "true",
+        "OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES": "TestApplication.Kafka"
       }
     }
   }

--- a/test/test-applications/integrations/TestApplication.Kafka/TestApplication.Kafka.csproj
+++ b/test/test-applications/integrations/TestApplication.Kafka/TestApplication.Kafka.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk"> 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" VersionOverride="$(LibraryVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3055#discussion_r1399520188
@pyohannes PTAL

## What

If consumer span would be a root span of a new trace, use message's creation context as a parent, in addition to linking to it.

## Tests

Included in PR.

## Checklist

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
- [x] New features are covered by tests.
