### PR TITLE
Update native code to upstream tag v2.4.0

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -183,6 +183,7 @@ add_library("OpenTelemetry.AutoInstrumentation.Native.static" STATIC
         rejit_work_offloader.cpp
         environment_variables_util.cpp
         method_rewriter.cpp
+        tracer_tokens.cpp
         lib/coreclr/src/pal/prebuilt/idl/corprof_i.cpp
         # Source dependencies retrievied via additional commands using git
         ${OUTPUT_DEPS_DIR}/fmt/libfmt.a

--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
@@ -212,6 +212,7 @@
     <ClInclude Include="startup_hook.h" />
     <ClInclude Include="stats.h" />
     <ClInclude Include="string.h" />
+    <ClInclude Include="tracer_tokens.h" />
     <ClInclude Include="util.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>
@@ -232,6 +233,7 @@
     <ClCompile Include="rejit_preprocessor.cpp" />
     <ClCompile Include="rejit_work_offloader.cpp" />
     <ClCompile Include="string.cpp" />
+    <ClCompile Include="tracer_tokens.cpp" />
     <ClCompile Include="util.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenTelemetry.AutoInstrumentation.Native/calltarget_tokens.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/calltarget_tokens.cpp
@@ -22,9 +22,9 @@ const int signatureBufferSize = 500;
  * CALLTARGET CONSTANTS
  **/
 
-static const WSTRING managed_profiler_calltarget_getdefaultvalue_name = WStr("GetDefaultValue");
-static const WSTRING managed_profiler_calltarget_statetype_getdefault_name = WStr("GetDefault");
-static const WSTRING managed_profiler_calltarget_returntype_getdefault_name = WStr("GetDefault");
+static const WSTRING managed_profiler_calltarget_getdefaultvalue_name           = WStr("GetDefaultValue");
+static const WSTRING managed_profiler_calltarget_statetype_getdefault_name      = WStr("GetDefault");
+static const WSTRING managed_profiler_calltarget_returntype_getdefault_name     = WStr("GetDefault");
 static const WSTRING managed_profiler_calltarget_returntype_getreturnvalue_name = WStr("GetReturnValue");
 
 /**
@@ -167,8 +167,8 @@ mdTypeRef CallTargetTokens::GetTargetVoidReturnTypeRef()
     // *** Ensure calltargetreturn void type ref
     if (callTargetReturnVoidTypeRef == mdTypeRefNil)
     {
-        hr = module_metadata->metadata_emit->DefineTypeRefByName(
-            profilerAssemblyRef, GetCallTargetReturnType().data(), &callTargetReturnVoidTypeRef);
+        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef, GetCallTargetReturnType().data(),
+                                                                 &callTargetReturnVoidTypeRef);
         if (FAILED(hr))
         {
             Logger::Warn("Wrapper callTargetReturnVoidTypeRef could not be defined.");
@@ -178,7 +178,6 @@ mdTypeRef CallTargetTokens::GetTargetVoidReturnTypeRef()
 
     return callTargetReturnVoidTypeRef;
 }
-
 
 mdMemberRef CallTargetTokens::GetCallTargetStateDefaultMemberRef()
 {
@@ -343,15 +342,15 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(TypeSignature
     return getDefaultMethodSpec;
 }
 
-HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter*             reWriter,
+HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter*    reWriter,
                                          TypeSignature* methodReturnValue,
-                                         ULONG*                  callTargetStateIndex,
-                                         ULONG*                  exceptionIndex,
-                                         ULONG*                  callTargetReturnIndex,
-                                         ULONG*                  returnValueIndex,
-                                         mdToken*                callTargetStateToken,
-                                         mdToken*                exceptionToken,
-                                         mdToken*                callTargetReturnToken)
+                                         ULONG*         callTargetStateIndex,
+                                         ULONG*         exceptionIndex,
+                                         ULONG*         callTargetReturnIndex,
+                                         ULONG*         returnValueIndex,
+                                         mdToken*       callTargetStateToken,
+                                         mdToken*       exceptionToken,
+                                         mdToken*       callTargetReturnToken)
 {
     auto hr = EnsureBaseCalltargetTokens();
     if (FAILED(hr))
@@ -408,7 +407,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter*             reWriter,
     unsigned        callTargetReturnBuffer;
     ULONG           callTargetReturnSize;
     ULONG           callTargetReturnSizeForNewSignature = 0;
-    const auto [retTypeElementType, retTypeFlags] = methodReturnValue->GetElementTypeAndFlags();
+    const auto[retTypeElementType, retTypeFlags] = methodReturnValue->GetElementTypeAndFlags();
 
     if (retTypeFlags != TypeFlagVoid)
     {
@@ -540,7 +539,6 @@ ModuleMetadata* CallTargetTokens::GetMetadata()
 {
     return module_metadata_ptr;
 }
-
 
 HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
 {
@@ -728,8 +726,7 @@ mdToken CallTargetTokens::GetCurrentTypeRef(const TypeInfo* currentType, bool& i
     }
 }
 
-CallTargetTokens::CallTargetTokens(ModuleMetadata* moduleMetadataPtr)
-    : module_metadata_ptr(moduleMetadataPtr)
+CallTargetTokens::CallTargetTokens(ModuleMetadata* moduleMetadataPtr) : module_metadata_ptr(moduleMetadataPtr)
 {
 }
 /**

--- a/src/OpenTelemetry.AutoInstrumentation.Native/calltarget_tokens.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/calltarget_tokens.cpp
@@ -22,33 +22,14 @@ const int signatureBufferSize = 500;
  * CALLTARGET CONSTANTS
  **/
 
-static const WSTRING managed_profiler_calltarget_type =
-    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker");
-static const WSTRING managed_profiler_calltarget_beginmethod_name     = WStr("BeginMethod");
-static const WSTRING managed_profiler_calltarget_endmethod_name       = WStr("EndMethod");
-static const WSTRING managed_profiler_calltarget_logexception_name    = WStr("LogException");
 static const WSTRING managed_profiler_calltarget_getdefaultvalue_name = WStr("GetDefaultValue");
-
-static const WSTRING managed_profiler_calltarget_statetype =
-    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState");
 static const WSTRING managed_profiler_calltarget_statetype_getdefault_name = WStr("GetDefault");
-
-static const WSTRING managed_profiler_calltarget_returntype =
-    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn");
 static const WSTRING managed_profiler_calltarget_returntype_getdefault_name = WStr("GetDefault");
-
-static const WSTRING managed_profiler_calltarget_returntype_generics =
-    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn`1");
 static const WSTRING managed_profiler_calltarget_returntype_getreturnvalue_name = WStr("GetReturnValue");
 
 /**
  * PRIVATE
  **/
-
-ModuleMetadata* CallTargetTokens::GetMetadata()
-{
-    return module_metadata_ptr;
-}
 
 HRESULT CallTargetTokens::EnsureCorLibTokens()
 {
@@ -163,116 +144,6 @@ HRESULT CallTargetTokens::EnsureCorLibTokens()
     return S_OK;
 }
 
-HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
-{
-    auto hr = EnsureCorLibTokens();
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    ModuleMetadata* module_metadata = GetMetadata();
-
-    // *** Ensure profiler assembly ref
-    if (profilerAssemblyRef == mdAssemblyRefNil)
-    {
-        const auto bytecode_instrumentation_name = trace::profiler->GetBytecodeInstrumentationAssembly();
-        Logger::Debug("CallTargetTokens::EnsureBaseCalltargetTokens() Bytecode "
-                      "Instrumentation Assembly: ",
-                      bytecode_instrumentation_name);
-        const AssemblyReference assemblyReference =
-            *trace::AssemblyReference::GetFromCache(bytecode_instrumentation_name);
-        ASSEMBLYMETADATA assembly_metadata{};
-
-        assembly_metadata.usMajorVersion   = assemblyReference.version.major;
-        assembly_metadata.usMinorVersion   = assemblyReference.version.minor;
-        assembly_metadata.usBuildNumber    = assemblyReference.version.build;
-        assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
-        if (assemblyReference.locale == WStr("neutral"))
-        {
-            assembly_metadata.szLocale = const_cast<WCHAR*>(WStr("\0"));
-            assembly_metadata.cbLocale = 0;
-        }
-        else
-        {
-            assembly_metadata.szLocale = const_cast<WCHAR*>(assemblyReference.locale.c_str());
-            assembly_metadata.cbLocale = (DWORD)(assemblyReference.locale.size());
-        }
-
-        DWORD public_key_size = 8;
-        if (assemblyReference.public_key == trace::PublicKey())
-        {
-            public_key_size = 0;
-        }
-
-        hr = module_metadata->assembly_emit->DefineAssemblyRef(&assemblyReference.public_key.data, public_key_size,
-                                                               assemblyReference.name.data(), &assembly_metadata, NULL,
-                                                               0, 0, &profilerAssemblyRef);
-
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper profilerAssemblyRef could not be defined.");
-            return hr;
-        }
-    }
-
-    // *** Ensure calltarget type ref
-    if (callTargetTypeRef == mdTypeRefNil)
-    {
-        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef,
-                                                                 managed_profiler_calltarget_type.data(),
-                                                                 &callTargetTypeRef);
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper callTargetTypeRef could not be defined.");
-            return hr;
-        }
-    }
-
-    // *** Ensure calltargetstate type ref
-    if (callTargetStateTypeRef == mdTypeRefNil)
-    {
-        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef,
-                                                                 managed_profiler_calltarget_statetype.data(),
-                                                                 &callTargetStateTypeRef);
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper callTargetStateTypeRef could not be defined.");
-            return hr;
-        }
-    }
-
-    // *** Ensure CallTargetState.GetDefault() member ref
-    if (callTargetStateTypeGetDefault == mdMemberRefNil)
-    {
-        unsigned callTargetStateTypeBuffer;
-        auto     callTargetStateTypeSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateTypeBuffer);
-
-        const ULONG   signatureLength = 3 + callTargetStateTypeSize;
-        COR_SIGNATURE signature[signatureBufferSize];
-        unsigned      offset = 0;
-
-        signature[offset++] = IMAGE_CEE_CS_CALLCONV_DEFAULT;
-        signature[offset++] = 0x00;
-
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-        memcpy(&signature[offset], &callTargetStateTypeBuffer, callTargetStateTypeSize);
-        offset += callTargetStateTypeSize;
-
-        auto hr =
-            module_metadata->metadata_emit
-                ->DefineMemberRef(callTargetStateTypeRef, managed_profiler_calltarget_statetype_getdefault_name.data(),
-                                  signature, signatureLength, &callTargetStateTypeGetDefault);
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper callTargetStateTypeGetDefault could not be defined.");
-            return hr;
-        }
-    }
-
-    return S_OK;
-}
-
 mdTypeRef CallTargetTokens::GetTargetStateTypeRef()
 {
     auto hr = EnsureBaseCalltargetTokens();
@@ -296,9 +167,8 @@ mdTypeRef CallTargetTokens::GetTargetVoidReturnTypeRef()
     // *** Ensure calltargetreturn void type ref
     if (callTargetReturnVoidTypeRef == mdTypeRefNil)
     {
-        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef,
-                                                                 managed_profiler_calltarget_returntype.data(),
-                                                                 &callTargetReturnVoidTypeRef);
+        hr = module_metadata->metadata_emit->DefineTypeRefByName(
+            profilerAssemblyRef, GetCallTargetReturnType().data(), &callTargetReturnVoidTypeRef);
         if (FAILED(hr))
         {
             Logger::Warn("Wrapper callTargetReturnVoidTypeRef could not be defined.");
@@ -309,58 +179,6 @@ mdTypeRef CallTargetTokens::GetTargetVoidReturnTypeRef()
     return callTargetReturnVoidTypeRef;
 }
 
-mdTypeSpec CallTargetTokens::GetTargetReturnValueTypeRef(FunctionMethodArgument* returnArgument)
-{
-    auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr))
-    {
-        return mdTypeSpecNil;
-    }
-
-    ModuleMetadata* module_metadata     = GetMetadata();
-    mdTypeSpec      returnValueTypeSpec = mdTypeSpecNil;
-
-    // *** Ensure calltargetreturn type ref
-    if (callTargetReturnTypeRef == mdTypeRefNil)
-    {
-        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef,
-                                                                 managed_profiler_calltarget_returntype_generics.data(),
-                                                                 &callTargetReturnTypeRef);
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper callTargetReturnTypeRef could not be defined.");
-            return mdTypeSpecNil;
-        }
-    }
-
-    PCCOR_SIGNATURE returnSignatureBuffer;
-    auto            returnSignatureLength = returnArgument->GetSignature(returnSignatureBuffer);
-
-    // Get The base calltargetReturnTypeRef Buffer and Size
-    unsigned callTargetReturnTypeRefBuffer;
-    auto     callTargetReturnTypeRefSize = CorSigCompressToken(callTargetReturnTypeRef, &callTargetReturnTypeRefBuffer);
-
-    auto          signatureLength = 3 + callTargetReturnTypeRefSize + returnSignatureLength;
-    COR_SIGNATURE signature[signatureBufferSize];
-    unsigned      offset = 0;
-
-    signature[offset++] = ELEMENT_TYPE_GENERICINST;
-    signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    memcpy(&signature[offset], &callTargetReturnTypeRefBuffer, callTargetReturnTypeRefSize);
-    offset += callTargetReturnTypeRefSize;
-    signature[offset++] = 0x01;
-    memcpy(&signature[offset], returnSignatureBuffer, returnSignatureLength);
-    offset += returnSignatureLength;
-
-    hr = module_metadata->metadata_emit->GetTokenFromTypeSpec(signature, signatureLength, &returnValueTypeSpec);
-    if (FAILED(hr))
-    {
-        Logger::Warn("Error creating return value type spec");
-        return mdTypeSpecNil;
-    }
-
-    return returnValueTypeSpec;
-}
 
 mdMemberRef CallTargetTokens::GetCallTargetStateDefaultMemberRef()
 {
@@ -462,7 +280,7 @@ mdMemberRef CallTargetTokens::GetCallTargetReturnValueDefaultMemberRef(mdTypeSpe
     return callTargetReturnTypeGetDefault;
 }
 
-mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMethodArgument* methodArgument)
+mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(TypeSignature* methodArgument)
 {
     auto hr = EnsureBaseCalltargetTokens();
     if (FAILED(hr))
@@ -498,7 +316,7 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMetho
         }
     }
 
-    // *** Create de MethodSpec using the FunctionMethodArgument
+    // *** Create de MethodSpec using the TypeSignature
 
     // Gets the Return type signature
     PCCOR_SIGNATURE methodArgumentSignature = nullptr;
@@ -525,32 +343,8 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMetho
     return getDefaultMethodSpec;
 }
 
-mdToken CallTargetTokens::GetCurrentTypeRef(const TypeInfo* currentType, bool& isValueType)
-{
-    if (currentType->type_spec != mdTypeSpecNil)
-    {
-        return currentType->type_spec;
-    }
-    else
-    {
-        TypeInfo* cType = const_cast<TypeInfo*>(currentType);
-        while (!cType->isGeneric)
-        {
-            if (cType->parent_type == nullptr)
-            {
-                return cType->id;
-            }
-
-            cType = const_cast<TypeInfo*>(cType->parent_type.get());
-        }
-
-        isValueType = false;
-        return objectTypeRef;
-    }
-}
-
 HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter*             reWriter,
-                                         FunctionMethodArgument* methodReturnValue,
+                                         TypeSignature* methodReturnValue,
                                          ULONG*                  callTargetStateIndex,
                                          ULONG*                  exceptionIndex,
                                          ULONG*                  callTargetReturnIndex,
@@ -614,8 +408,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter*             reWriter,
     unsigned        callTargetReturnBuffer;
     ULONG           callTargetReturnSize;
     ULONG           callTargetReturnSizeForNewSignature = 0;
-    unsigned        retTypeElementType;
-    auto            retTypeFlags = methodReturnValue->GetTypeFlags(retTypeElementType);
+    const auto [retTypeElementType, retTypeFlags] = methodReturnValue->GetElementTypeAndFlags();
 
     if (retTypeFlags != TypeFlagVoid)
     {
@@ -739,109 +532,209 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter*             reWriter,
     return hr;
 }
 
-// slowpath BeginMethod
-HRESULT CallTargetTokens::WriteBeginMethodWithArgumentsArray(void*           rewriterWrapperPtr,
-                                                             mdTypeRef       integrationTypeRef,
-                                                             const TypeInfo* currentType,
-                                                             ILInstr**       instruction)
+/**
+ * PROTECTED
+ **/
+
+ModuleMetadata* CallTargetTokens::GetMetadata()
 {
-    auto hr = EnsureBaseCalltargetTokens();
+    return module_metadata_ptr;
+}
+
+
+HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
+{
+    auto hr = EnsureCorLibTokens();
     if (FAILED(hr))
     {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
-    ModuleMetadata*    module_metadata = GetMetadata();
 
-    if (beginArrayMemberRef == mdMemberRefNil)
+    ModuleMetadata* module_metadata = GetMetadata();
+
+    // *** Ensure profiler assembly ref
+    if (profilerAssemblyRef == mdAssemblyRefNil)
     {
-        unsigned callTargetStateBuffer;
-        auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+        const auto bytecode_instrumentation_name = trace::profiler->GetBytecodeInstrumentationAssembly();
+        Logger::Debug("CallTargetTokens::EnsureBaseCalltargetTokens() Bytecode Instrumentation Assembly: ",
+                      bytecode_instrumentation_name);
+        const AssemblyReference assemblyReference =
+            *trace::AssemblyReference::GetFromCache(bytecode_instrumentation_name);
+        ASSEMBLYMETADATA assembly_metadata{};
 
-        auto          signatureLength = 8 + callTargetStateSize;
-        COR_SIGNATURE signature[signatureBufferSize];
-        unsigned      offset = 0;
+        assembly_metadata.usMajorVersion   = assemblyReference.version.major;
+        assembly_metadata.usMinorVersion   = assemblyReference.version.minor;
+        assembly_metadata.usBuildNumber    = assemblyReference.version.build;
+        assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
+        if (assemblyReference.locale == WStr("neutral"))
+        {
+            assembly_metadata.szLocale = const_cast<WCHAR*>(WStr("\0"));
+            assembly_metadata.cbLocale = 0;
+        }
+        else
+        {
+            assembly_metadata.szLocale = const_cast<WCHAR*>(assemblyReference.locale.c_str());
+            assembly_metadata.cbLocale = (DWORD)(assemblyReference.locale.size());
+        }
 
-        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
-        signature[offset++] = 0x02;
-        signature[offset++] = 0x02;
+        DWORD public_key_size = 8;
+        if (assemblyReference.public_key == trace::PublicKey())
+        {
+            public_key_size = 0;
+        }
 
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-        memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
-        offset += callTargetStateSize;
+        hr = module_metadata->assembly_emit->DefineAssemblyRef(&assemblyReference.public_key.data, public_key_size,
+                                                               assemblyReference.name.data(), &assembly_metadata, NULL,
+                                                               0, 0, &profilerAssemblyRef);
 
-        signature[offset++] = ELEMENT_TYPE_MVAR;
-        signature[offset++] = 0x01;
-
-        signature[offset++] = ELEMENT_TYPE_SZARRAY;
-        signature[offset++] = ELEMENT_TYPE_OBJECT;
-
-        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
-                                                                  managed_profiler_calltarget_beginmethod_name.data(),
-                                                                  signature, signatureLength, &beginArrayMemberRef);
         if (FAILED(hr))
         {
-            Logger::Warn("Wrapper beginArrayMemberRef could not be defined.");
+            Logger::Warn("Wrapper profilerAssemblyRef could not be defined.");
             return hr;
         }
     }
 
-    mdMethodSpec beginArrayMethodSpec = mdMethodSpecNil;
-
-    unsigned integrationTypeBuffer;
-    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
-
-    bool    isValueType    = currentType->valueType;
-    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
-
-    unsigned currentTypeBuffer;
-    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
-
-    auto          signatureLength = 4 + integrationTypeSize + currentTypeSize;
-    COR_SIGNATURE signature[signatureBufferSize];
-    unsigned      offset = 0;
-    signature[offset++]  = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++]  = 0x02;
-
-    signature[offset++] = ELEMENT_TYPE_CLASS;
-    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
-    offset += integrationTypeSize;
-
-    if (isValueType)
+    // *** Ensure calltarget type ref
+    if (callTargetTypeRef == mdTypeRefNil)
     {
+        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef, GetCallTargetType().data(),
+                                                                 &callTargetTypeRef);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper callTargetTypeRef could not be defined.");
+            return hr;
+        }
+    }
+
+    // *** Ensure calltargetstate type ref
+    if (callTargetStateTypeRef == mdTypeRefNil)
+    {
+        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef, GetCallTargetStateType().data(),
+                                                                 &callTargetStateTypeRef);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper callTargetStateTypeRef could not be defined.");
+            return hr;
+        }
+    }
+
+    // *** Ensure CallTargetState.GetDefault() member ref
+    if (callTargetStateTypeGetDefault == mdMemberRefNil)
+    {
+        unsigned callTargetStateTypeBuffer;
+        auto     callTargetStateTypeSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateTypeBuffer);
+
+        const ULONG   signatureLength = 3 + callTargetStateTypeSize;
+        COR_SIGNATURE signature[signatureBufferSize];
+        unsigned      offset = 0;
+
+        signature[offset++] = IMAGE_CEE_CS_CALLCONV_DEFAULT;
+        signature[offset++] = 0x00;
+
         signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    }
-    else
-    {
-        signature[offset++] = ELEMENT_TYPE_CLASS;
-    }
-    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
-    offset += currentTypeSize;
+        memcpy(&signature[offset], &callTargetStateTypeBuffer, callTargetStateTypeSize);
+        offset += callTargetStateTypeSize;
 
-    hr = module_metadata->metadata_emit->DefineMethodSpec(beginArrayMemberRef, signature, signatureLength,
-                                                          &beginArrayMethodSpec);
-    if (FAILED(hr))
-    {
-        Logger::Warn("Error creating begin method spec.");
-        return hr;
+        auto hr =
+            module_metadata->metadata_emit
+                ->DefineMemberRef(callTargetStateTypeRef, managed_profiler_calltarget_statetype_getdefault_name.data(),
+                                  signature, signatureLength, &callTargetStateTypeGetDefault);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper callTargetStateTypeGetDefault could not be defined.");
+            return hr;
+        }
     }
 
-    *instruction = rewriterWrapper->CallMember(beginArrayMethodSpec, false);
     return S_OK;
 }
 
+mdTypeSpec CallTargetTokens::GetTargetReturnValueTypeRef(TypeSignature* returnArgument)
+{
+    auto hr = EnsureBaseCalltargetTokens();
+    if (FAILED(hr))
+    {
+        return mdTypeSpecNil;
+    }
+
+    ModuleMetadata* module_metadata     = GetMetadata();
+    mdTypeSpec      returnValueTypeSpec = mdTypeSpecNil;
+
+    // *** Ensure calltargetreturn type ref
+    if (callTargetReturnTypeRef == mdTypeRefNil)
+    {
+        hr = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef,
+                                                                 GetCallTargetReturnGenericType().data(),
+                                                                 &callTargetReturnTypeRef);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper callTargetReturnTypeRef could not be defined.");
+            return mdTypeSpecNil;
+        }
+    }
+
+    PCCOR_SIGNATURE returnSignatureBuffer;
+    auto            returnSignatureLength = returnArgument->GetSignature(returnSignatureBuffer);
+
+    // Get The base calltargetReturnTypeRef Buffer and Size
+    unsigned callTargetReturnTypeRefBuffer;
+    auto     callTargetReturnTypeRefSize = CorSigCompressToken(callTargetReturnTypeRef, &callTargetReturnTypeRefBuffer);
+
+    auto          signatureLength = 3 + callTargetReturnTypeRefSize + returnSignatureLength;
+    COR_SIGNATURE signature[signatureBufferSize];
+    unsigned      offset = 0;
+
+    signature[offset++] = ELEMENT_TYPE_GENERICINST;
+    signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    memcpy(&signature[offset], &callTargetReturnTypeRefBuffer, callTargetReturnTypeRefSize);
+    offset += callTargetReturnTypeRefSize;
+    signature[offset++] = 0x01;
+    memcpy(&signature[offset], returnSignatureBuffer, returnSignatureLength);
+    offset += returnSignatureLength;
+
+    hr = module_metadata->metadata_emit->GetTokenFromTypeSpec(signature, signatureLength, &returnValueTypeSpec);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error creating return value type spec");
+        return mdTypeSpecNil;
+    }
+
+    return returnValueTypeSpec;
+}
+
+mdToken CallTargetTokens::GetCurrentTypeRef(const TypeInfo* currentType, bool& isValueType)
+{
+    if (currentType->type_spec != mdTypeSpecNil)
+    {
+        return currentType->type_spec;
+    }
+    else
+    {
+
+        TypeInfo* cType = const_cast<TypeInfo*>(currentType);
+        while (!cType->isGeneric)
+        {
+
+            if (cType->parent_type == nullptr)
+            {
+                return cType->id;
+            }
+
+            cType = const_cast<TypeInfo*>(cType->parent_type.get());
+        }
+
+        isValueType = false;
+        return objectTypeRef;
+    }
+}
+
+CallTargetTokens::CallTargetTokens(ModuleMetadata* moduleMetadataPtr)
+    : module_metadata_ptr(moduleMetadataPtr)
+{
+}
 /**
  * PUBLIC
  **/
-
-CallTargetTokens::CallTargetTokens(ModuleMetadata* module_metadata_ptr)
-{
-    this->module_metadata_ptr = module_metadata_ptr;
-    for (int i = 0; i < FASTPATH_COUNT; i++)
-    {
-        beginMethodFastPathRefs[i] = mdMemberRefNil;
-    }
-}
 
 mdTypeRef CallTargetTokens::GetObjectTypeRef()
 {
@@ -870,7 +763,7 @@ HRESULT CallTargetTokens::ModifyLocalSigAndInitialize(void*         rewriterWrap
     ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
 
     // Modify the Local Var Signature of the method
-    auto returnFunctionMethod = functionInfo->method_signature.GetRet();
+    auto returnFunctionMethod = functionInfo->method_signature.GetReturnValue();
 
     auto hr = ModifyLocalSig(rewriterWrapper->GetILRewriter(), &returnFunctionMethod, callTargetStateIndex,
                              exceptionIndex, callTargetReturnIndex, returnValueIndex, callTargetStateToken,
@@ -904,490 +797,6 @@ HRESULT CallTargetTokens::ModifyLocalSigAndInitialize(void*         rewriterWrap
     // So we can save 2 instructions.
     /*rewriterWrapper->CallMember(GetCallTargetStateDefaultMemberRef(), false);
     rewriterWrapper->StLocal(*callTargetStateIndex);*/
-    return S_OK;
-}
-
-HRESULT CallTargetTokens::WriteBeginMethod(void*                                      rewriterWrapperPtr,
-                                           mdTypeRef                                  integrationTypeRef,
-                                           const TypeInfo*                            currentType,
-                                           const std::vector<FunctionMethodArgument>& methodArguments,
-                                           ILInstr**                                  instruction)
-{
-    auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
-    ModuleMetadata*    module_metadata = GetMetadata();
-
-    auto numArguments = (int)methodArguments.size();
-    if (numArguments >= FASTPATH_COUNT)
-    {
-        return WriteBeginMethodWithArgumentsArray(rewriterWrapperPtr, integrationTypeRef, currentType, instruction);
-    }
-
-    //
-    // FastPath
-    //
-
-    if (beginMethodFastPathRefs[numArguments] == mdMemberRefNil)
-    {
-        unsigned callTargetStateBuffer;
-        auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
-
-        unsigned long signatureLength;
-        if (enable_by_ref_instrumentation)
-        {
-            signatureLength = 6 + (numArguments * 3) + callTargetStateSize;
-        }
-        else
-        {
-            signatureLength = 6 + (numArguments * 2) + callTargetStateSize;
-        }
-        COR_SIGNATURE signature[signatureBufferSize];
-        unsigned      offset = 0;
-
-        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
-        signature[offset++] = 0x02 + numArguments;
-        signature[offset++] = 0x01 + numArguments;
-
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-        memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
-        offset += callTargetStateSize;
-
-        signature[offset++] = ELEMENT_TYPE_MVAR;
-        signature[offset++] = 0x01;
-
-        for (auto i = 0; i < numArguments; i++)
-        {
-            if (enable_by_ref_instrumentation)
-            {
-                signature[offset++] = ELEMENT_TYPE_BYREF;
-            }
-            signature[offset++] = ELEMENT_TYPE_MVAR;
-            signature[offset++] = 0x01 + (i + 1);
-        }
-
-        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
-                                                                  managed_profiler_calltarget_beginmethod_name.data(),
-                                                                  signature, signatureLength,
-                                                                  &beginMethodFastPathRefs[numArguments]);
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper beginMethod for ", numArguments, " arguments could not be defined.");
-            return hr;
-        }
-    }
-
-    mdMethodSpec beginMethodSpec = mdMethodSpecNil;
-
-    unsigned integrationTypeBuffer;
-    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
-
-    bool    isValueType    = currentType->valueType;
-    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
-
-    unsigned currentTypeBuffer;
-    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
-
-    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
-
-    PCCOR_SIGNATURE argumentsSignatureBuffer[FASTPATH_COUNT];
-    ULONG           argumentsSignatureSize[FASTPATH_COUNT];
-    unsigned        elementType;
-    for (auto i = 0; i < numArguments; i++)
-    {
-        const auto& argTypeFlags = methodArguments[i].GetTypeFlags(elementType);
-        if (enable_by_ref_instrumentation && (argTypeFlags & TypeFlagByRef))
-        {
-            PCCOR_SIGNATURE argSigBuff;
-            auto            signatureSize = methodArguments[i].GetSignature(argSigBuff);
-            if (argSigBuff[0] == ELEMENT_TYPE_BYREF)
-            {
-                argumentsSignatureBuffer[i] = argSigBuff + 1;
-                argumentsSignatureSize[i]   = signatureSize - 1;
-                signatureLength += signatureSize - 1;
-            }
-            else
-            {
-                argumentsSignatureBuffer[i] = argSigBuff;
-                argumentsSignatureSize[i]   = signatureSize;
-                signatureLength += signatureSize;
-            }
-        }
-        else
-        {
-            auto signatureSize        = methodArguments[i].GetSignature(argumentsSignatureBuffer[i]);
-            argumentsSignatureSize[i] = signatureSize;
-            signatureLength += signatureSize;
-        }
-    }
-
-    COR_SIGNATURE signature[signatureBufferSize];
-    unsigned      offset = 0;
-
-    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++] = 0x02 + numArguments;
-
-    signature[offset++] = ELEMENT_TYPE_CLASS;
-    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
-    offset += integrationTypeSize;
-
-    if (isValueType)
-    {
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    }
-    else
-    {
-        signature[offset++] = ELEMENT_TYPE_CLASS;
-    }
-    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
-    offset += currentTypeSize;
-
-    for (auto i = 0; i < numArguments; i++)
-    {
-        memcpy(&signature[offset], argumentsSignatureBuffer[i], argumentsSignatureSize[i]);
-        offset += argumentsSignatureSize[i];
-    }
-
-    hr = module_metadata->metadata_emit->DefineMethodSpec(beginMethodFastPathRefs[numArguments], signature,
-                                                          signatureLength, &beginMethodSpec);
-    if (FAILED(hr))
-    {
-        Logger::Warn("Error creating begin method spec.");
-        return hr;
-    }
-
-    *instruction = rewriterWrapper->CallMember(beginMethodSpec, false);
-    return S_OK;
-}
-
-// endmethod with void return
-HRESULT CallTargetTokens::WriteEndVoidReturnMemberRef(void*           rewriterWrapperPtr,
-                                                      mdTypeRef       integrationTypeRef,
-                                                      const TypeInfo* currentType,
-                                                      ILInstr**       instruction)
-{
-    auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
-    ModuleMetadata*    module_metadata = GetMetadata();
-
-    if (endVoidMemberRef == mdMemberRefNil)
-    {
-        unsigned callTargetReturnVoidBuffer;
-        auto callTargetReturnVoidSize = CorSigCompressToken(callTargetReturnVoidTypeRef, &callTargetReturnVoidBuffer);
-
-        unsigned exTypeRefBuffer;
-        auto     exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
-
-        unsigned callTargetStateBuffer;
-        auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
-
-        auto signatureLength = 8 + callTargetReturnVoidSize + exTypeRefSize + callTargetStateSize;
-        if (enable_calltarget_state_by_ref)
-        {
-            signatureLength++;
-        }
-
-        COR_SIGNATURE signature[signatureBufferSize];
-        unsigned      offset = 0;
-
-        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
-        signature[offset++] = 0x02;
-        signature[offset++] = 0x03;
-
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-        memcpy(&signature[offset], &callTargetReturnVoidBuffer, callTargetReturnVoidSize);
-        offset += callTargetReturnVoidSize;
-
-        signature[offset++] = ELEMENT_TYPE_MVAR;
-        signature[offset++] = 0x01;
-
-        signature[offset++] = ELEMENT_TYPE_CLASS;
-        memcpy(&signature[offset], &exTypeRefBuffer, exTypeRefSize);
-        offset += exTypeRefSize;
-
-        if (enable_calltarget_state_by_ref)
-        {
-            signature[offset++] = ELEMENT_TYPE_BYREF;
-        }
-
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-        memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
-        offset += callTargetStateSize;
-
-        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
-                                                                  managed_profiler_calltarget_endmethod_name.data(),
-                                                                  signature, signatureLength, &endVoidMemberRef);
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper endVoidMemberRef could not be defined.");
-            return hr;
-        }
-    }
-
-    mdMethodSpec endVoidMethodSpec = mdMethodSpecNil;
-
-    unsigned integrationTypeBuffer;
-    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
-
-    bool    isValueType    = currentType->valueType;
-    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
-
-    unsigned currentTypeBuffer;
-    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
-
-    auto          signatureLength = 4 + integrationTypeSize + currentTypeSize;
-    COR_SIGNATURE signature[signatureBufferSize];
-    unsigned      offset = 0;
-    signature[offset++]  = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++]  = 0x02;
-
-    signature[offset++] = ELEMENT_TYPE_CLASS;
-    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
-    offset += integrationTypeSize;
-
-    if (isValueType)
-    {
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    }
-    else
-    {
-        signature[offset++] = ELEMENT_TYPE_CLASS;
-    }
-    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
-    offset += currentTypeSize;
-
-    hr = module_metadata->metadata_emit->DefineMethodSpec(endVoidMemberRef, signature, signatureLength,
-                                                          &endVoidMethodSpec);
-    if (FAILED(hr))
-    {
-        Logger::Warn("Error creating end void method method spec.");
-        return hr;
-    }
-
-    *instruction = rewriterWrapper->CallMember(endVoidMethodSpec, false);
-    return S_OK;
-}
-
-// endmethod with return type
-HRESULT CallTargetTokens::WriteEndReturnMemberRef(void*                   rewriterWrapperPtr,
-                                                  mdTypeRef               integrationTypeRef,
-                                                  const TypeInfo*         currentType,
-                                                  FunctionMethodArgument* returnArgument,
-                                                  ILInstr**               instruction)
-{
-    auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
-    ModuleMetadata*    module_metadata = GetMetadata();
-    GetTargetReturnValueTypeRef(returnArgument);
-
-    // *** Define base MethodMemberRef for the type
-
-    mdMemberRef endMethodMemberRef = mdMemberRefNil;
-
-    unsigned callTargetReturnTypeRefBuffer;
-    auto     callTargetReturnTypeRefSize = CorSigCompressToken(callTargetReturnTypeRef, &callTargetReturnTypeRefBuffer);
-
-    unsigned exTypeRefBuffer;
-    auto     exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
-
-    unsigned callTargetStateBuffer;
-    auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
-
-    auto signatureLength = 14 + callTargetReturnTypeRefSize + exTypeRefSize + callTargetStateSize;
-    if (enable_calltarget_state_by_ref)
-    {
-        signatureLength++;
-    }
-
-    COR_SIGNATURE signature[signatureBufferSize];
-    unsigned      offset = 0;
-
-    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
-    signature[offset++] = 0x03;
-    signature[offset++] = 0x04;
-
-    signature[offset++] = ELEMENT_TYPE_GENERICINST;
-    signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    memcpy(&signature[offset], &callTargetReturnTypeRefBuffer, callTargetReturnTypeRefSize);
-    offset += callTargetReturnTypeRefSize;
-    signature[offset++] = 0x01;
-    signature[offset++] = ELEMENT_TYPE_MVAR;
-    signature[offset++] = 0x02;
-
-    signature[offset++] = ELEMENT_TYPE_MVAR;
-    signature[offset++] = 0x01;
-
-    signature[offset++] = ELEMENT_TYPE_MVAR;
-    signature[offset++] = 0x02;
-
-    signature[offset++] = ELEMENT_TYPE_CLASS;
-    memcpy(&signature[offset], &exTypeRefBuffer, exTypeRefSize);
-    offset += exTypeRefSize;
-
-    if (enable_calltarget_state_by_ref)
-    {
-        signature[offset++] = ELEMENT_TYPE_BYREF;
-    }
-    signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
-    offset += callTargetStateSize;
-
-    hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
-                                                         managed_profiler_calltarget_endmethod_name.data(), signature,
-                                                         signatureLength, &endMethodMemberRef);
-    if (FAILED(hr))
-    {
-        Logger::Warn("Wrapper endMethodMemberRef could not be defined.");
-        return hr;
-    }
-
-    // *** Define Method Spec
-
-    mdMethodSpec endMethodSpec = mdMethodSpecNil;
-
-    unsigned integrationTypeBuffer;
-    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
-
-    bool    isValueType    = currentType->valueType;
-    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
-
-    unsigned currentTypeBuffer;
-    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
-
-    PCCOR_SIGNATURE returnSignatureBuffer;
-    auto            returnSignatureLength = returnArgument->GetSignature(returnSignatureBuffer);
-
-    signatureLength = 4 + integrationTypeSize + currentTypeSize + returnSignatureLength;
-    offset          = 0;
-
-    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++] = 0x03;
-
-    signature[offset++] = ELEMENT_TYPE_CLASS;
-    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
-    offset += integrationTypeSize;
-
-    if (isValueType)
-    {
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    }
-    else
-    {
-        signature[offset++] = ELEMENT_TYPE_CLASS;
-    }
-    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
-    offset += currentTypeSize;
-
-    memcpy(&signature[offset], returnSignatureBuffer, returnSignatureLength);
-    offset += returnSignatureLength;
-
-    hr = module_metadata->metadata_emit->DefineMethodSpec(endMethodMemberRef, signature, signatureLength,
-                                                          &endMethodSpec);
-    if (FAILED(hr))
-    {
-        Logger::Warn("Error creating end method member spec.");
-        return hr;
-    }
-
-    *instruction = rewriterWrapper->CallMember(endMethodSpec, false);
-    return S_OK;
-}
-
-// write log exception
-HRESULT CallTargetTokens::WriteLogException(void*           rewriterWrapperPtr,
-                                            mdTypeRef       integrationTypeRef,
-                                            const TypeInfo* currentType,
-                                            ILInstr**       instruction)
-{
-    auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
-    ModuleMetadata*    module_metadata = GetMetadata();
-
-    if (logExceptionRef == mdMemberRefNil)
-    {
-        unsigned exTypeRefBuffer;
-        auto     exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
-
-        auto          signatureLength = 5 + exTypeRefSize;
-        COR_SIGNATURE signature[signatureBufferSize];
-        unsigned      offset = 0;
-
-        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
-        signature[offset++] = 0x02;
-        signature[offset++] = 0x01;
-
-        signature[offset++] = ELEMENT_TYPE_VOID;
-        signature[offset++] = ELEMENT_TYPE_CLASS;
-        memcpy(&signature[offset], &exTypeRefBuffer, exTypeRefSize);
-        offset += exTypeRefSize;
-
-        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
-                                                                  managed_profiler_calltarget_logexception_name.data(),
-                                                                  signature, signatureLength, &logExceptionRef);
-        if (FAILED(hr))
-        {
-            Logger::Warn("Wrapper logExceptionRef could not be defined.");
-            return hr;
-        }
-    }
-
-    mdMethodSpec logExceptionMethodSpec = mdMethodSpecNil;
-
-    unsigned integrationTypeBuffer;
-    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
-
-    bool    isValueType    = currentType->valueType;
-    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
-
-    unsigned currentTypeBuffer;
-    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
-
-    auto          signatureLength = 4 + integrationTypeSize + currentTypeSize;
-    COR_SIGNATURE signature[signatureBufferSize];
-    unsigned      offset = 0;
-    signature[offset++]  = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++]  = 0x02;
-
-    signature[offset++] = ELEMENT_TYPE_CLASS;
-    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
-    offset += integrationTypeSize;
-
-    if (isValueType)
-    {
-        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    }
-    else
-    {
-        signature[offset++] = ELEMENT_TYPE_CLASS;
-    }
-    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
-    offset += currentTypeSize;
-
-    hr = module_metadata->metadata_emit->DefineMethodSpec(logExceptionRef, signature, signatureLength,
-                                                          &logExceptionMethodSpec);
-    if (FAILED(hr))
-    {
-        Logger::Warn("Error creating log exception method spec.");
-        return hr;
-    }
-
-    *instruction = rewriterWrapper->CallMember(logExceptionMethodSpec, false);
     return S_OK;
 }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.cpp
@@ -340,23 +340,24 @@ HRESULT GetCorLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
     }
 }
 
-// FunctionMethodArgument
-int FunctionMethodArgument::GetTypeFlags(unsigned& elementType) const
+// TypeSignature
+std::tuple<unsigned, int> TypeSignature::GetElementTypeAndFlags() const
 {
-    int             flag  = 0;
+    int             typeFlags = 0;
+    unsigned        elementType;
+
     PCCOR_SIGNATURE pbCur = &pbBase[offset];
 
     if (*pbCur == ELEMENT_TYPE_VOID)
     {
         elementType = ELEMENT_TYPE_VOID;
-        flag |= TypeFlagVoid;
-        return flag;
+        typeFlags |= TypeFlagVoid;
     }
 
     if (*pbCur == ELEMENT_TYPE_BYREF)
     {
         pbCur++;
-        flag |= TypeFlagByRef;
+        typeFlags |= TypeFlagByRef;
     }
 
     elementType = *pbCur;
@@ -380,22 +381,22 @@ int FunctionMethodArgument::GetTypeFlags(unsigned& elementType) const
         case ELEMENT_TYPE_VALUETYPE:
         case ELEMENT_TYPE_MVAR:
         case ELEMENT_TYPE_VAR:
-            flag |= TypeFlagBoxedType;
+            typeFlags |= TypeFlagBoxedType;
             break;
         case ELEMENT_TYPE_GENERICINST:
             pbCur++;
             if (*pbCur == ELEMENT_TYPE_VALUETYPE)
             {
-                flag |= TypeFlagBoxedType;
+                typeFlags |= TypeFlagBoxedType;
             }
             break;
         default:
             break;
     }
-    return flag;
+    return {elementType, typeFlags};
 }
 
-mdToken FunctionMethodArgument::GetTypeTok(ComPtr<IMetaDataEmit2>& pEmit, mdAssemblyRef corLibRef) const
+mdToken TypeSignature::GetTypeTok(ComPtr<IMetaDataEmit2>& pEmit, mdAssemblyRef corLibRef) const
 {
     mdToken               token  = mdTokenNil;
     PCCOR_SIGNATURE       pbCur  = &pbBase[offset];
@@ -612,13 +613,13 @@ WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>
     return tokenName;
 }
 
-WSTRING FunctionMethodArgument::GetTypeTokName(ComPtr<IMetaDataImport2>& pImport) const
+WSTRING TypeSignature::GetTypeTokName(ComPtr<IMetaDataImport2>& pImport) const
 {
     PCCOR_SIGNATURE pbCur = &pbBase[offset];
     return GetSigTypeTokName(pbCur, pImport);
 }
 
-ULONG FunctionMethodArgument::GetSignature(PCCOR_SIGNATURE& data) const
+ULONG TypeSignature::GetSignature(PCCOR_SIGNATURE& data) const
 {
     data = &pbBase[offset];
     return length;
@@ -839,7 +840,7 @@ bool ParseType(PCCOR_SIGNATURE& pbCur, PCCOR_SIGNATURE pbEnd)
 
 // Param ::= CustomMod* ( TYPEDBYREF | [BYREF] Type )
 // CustomMod* TYPEDBYREF we don't support
-bool ParseParam(PCCOR_SIGNATURE& pbCur, PCCOR_SIGNATURE pbEnd)
+bool ParseParamOrLocal(PCCOR_SIGNATURE& pbCur, PCCOR_SIGNATURE pbEnd)
 {
     if (*pbCur == ELEMENT_TYPE_CMOD_OPT || *pbCur == ELEMENT_TYPE_CMOD_REQD)
     {
@@ -905,9 +906,9 @@ HRESULT FunctionMethodSignature::TryParse()
     const PCCOR_SIGNATURE pbRet = pbCur;
 
     IfFalseRetFAIL(ParseRetType(pbCur, pbEnd));
-    ret.pbBase = pbBase;
-    ret.length = (ULONG)(pbCur - pbRet);
-    ret.offset = (ULONG)(pbCur - pbBase - ret.length);
+    returnValue.pbBase = pbBase;
+    returnValue.length = (ULONG)(pbCur - pbRet);
+    returnValue.offset = (ULONG)(pbCur - pbBase - returnValue.length);
 
     auto fEncounteredSentinal = false;
     for (unsigned i = 0; i < param_count; i++)
@@ -926,9 +927,9 @@ HRESULT FunctionMethodSignature::TryParse()
 
         const PCCOR_SIGNATURE pbParam = pbCur;
 
-        IfFalseRetFAIL(ParseParam(pbCur, pbEnd));
+        IfFalseRetFAIL(ParseParamOrLocal(pbCur, pbEnd));
 
-        FunctionMethodArgument argument{};
+        TypeSignature argument{};
         argument.pbBase = pbBase;
         argument.length = (ULONG)(pbCur - pbParam);
         argument.offset = (ULONG)(pbCur - pbBase - argument.length);
@@ -984,4 +985,45 @@ bool FindTypeDefByName(const trace::WSTRING            instrumentationTargetMeth
 
     return true;
 }
+
+// FunctionLocalSignature
+HRESULT FunctionLocalSignature::TryParse(PCCOR_SIGNATURE pbBase, unsigned len, std::vector<TypeSignature>& locals)
+{
+    PCCOR_SIGNATURE pbCur = pbBase;
+    PCCOR_SIGNATURE pbEnd = pbBase + len;
+
+    BYTE     temp;
+    unsigned get_locals_count;
+
+    const int LocalVarSig = 0x07;
+
+    IfFalseRetFAIL(ParseByte(pbCur, pbEnd, &temp));
+    if (temp != LocalVarSig)
+    {
+        // Not a LocalVarSig
+        return E_FAIL;
+    }
+
+    // Number of locals - 1 to 0xFFFE (65534)
+    IfFalseRetFAIL(ParseNumber(pbCur, pbEnd, &get_locals_count));
+
+    for (unsigned i = 0; i < get_locals_count; i++)
+    {
+        if (pbCur >= pbEnd)
+            return E_FAIL;
+
+        const PCCOR_SIGNATURE pbLocal = pbCur;
+
+        IfFalseRetFAIL(ParseParamOrLocal(pbCur, pbEnd));
+
+        TypeSignature local{};
+        local.pbBase = pbBase;
+        local.length = (ULONG)(pbCur - pbLocal);
+        local.offset = (ULONG)(pbCur - pbBase - local.length);
+
+        locals.push_back(local);
+    }
+    return S_OK;
+}
+
 } // namespace trace

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.cpp
@@ -343,8 +343,8 @@ HRESULT GetCorLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
 // TypeSignature
 std::tuple<unsigned, int> TypeSignature::GetElementTypeAndFlags() const
 {
-    int             typeFlags = 0;
-    unsigned        elementType;
+    int      typeFlags = 0;
+    unsigned elementType;
 
     PCCOR_SIGNATURE pbCur = &pbBase[offset];
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_helpers.h
@@ -407,14 +407,16 @@ enum MethodArgumentTypeFlag
     TypeFlagBoxedType = 0x04
 };
 
-struct FunctionMethodArgument
+// Represents a segment inside a larger signature (Method Signature / Local Var Signature) of
+// an Argument, Local or Return Value.
+struct TypeSignature
 {
     ULONG offset;
     ULONG length;
     PCCOR_SIGNATURE pbBase;
     mdToken GetTypeTok(ComPtr<IMetaDataEmit2>& pEmit, mdAssemblyRef corLibRef) const;
     WSTRING GetTypeTokName(ComPtr<IMetaDataImport2>& pImport) const;
-    int GetTypeFlags(unsigned& elementType) const;
+    std::tuple<unsigned, int> GetElementTypeAndFlags() const;
     ULONG GetSignature(PCCOR_SIGNATURE& data) const;
 };
 
@@ -425,8 +427,8 @@ private:
     unsigned len;
     ULONG numberOfTypeArguments = 0;
     ULONG numberOfArguments = 0;
-    FunctionMethodArgument ret{};
-    std::vector<FunctionMethodArgument> params;
+    TypeSignature returnValue{};
+    std::vector<TypeSignature> params;
 
 public:
     FunctionMethodSignature() : pbBase(nullptr), len(0)
@@ -449,11 +451,11 @@ public:
     {
         return HexStr(pbBase, len);
     }
-    FunctionMethodArgument GetRet() const
+    TypeSignature GetReturnValue() const
     {
-        return ret;
+        return returnValue;
     }
-    std::vector<FunctionMethodArgument> GetMethodArguments() const
+    const std::vector<TypeSignature>& GetMethodArguments() const
     {
         return params;
     }
@@ -465,6 +467,46 @@ public:
     CorCallingConvention CallingConvention() const
     {
         return CorCallingConvention(len == 0 ? 0 : pbBase[0]);
+    }
+    bool IsEmpty() const
+    {
+        return len == 0;
+    }
+};
+
+struct FunctionLocalSignature
+{
+private:
+    PCCOR_SIGNATURE            pbBase;
+    unsigned                   len;
+    ULONG                      numberOfLocals = 0;
+    std::vector<TypeSignature> locals;
+
+public:
+    FunctionLocalSignature() : pbBase(nullptr), len(0) {}
+    FunctionLocalSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer, std::vector<TypeSignature>&& localsSigs)
+        : pbBase(pb)
+        , len(cbBuffer)
+        , numberOfLocals(static_cast<ULONG>(localsSigs.size()))
+        , locals(std::move(localsSigs))
+    {
+    }
+    ULONG NumberOfLocals() const
+    {
+        return numberOfLocals;
+    }
+    WSTRING str() const
+    {
+        return HexStr(pbBase, len);
+    }
+    const std::vector<TypeSignature>& GetMethodLocals() const
+    {
+        return locals;
+    }
+    static HRESULT TryParse(PCCOR_SIGNATURE pbBase, unsigned len, std::vector<TypeSignature>& locals);
+    bool           operator==(const FunctionLocalSignature& other) const
+    {
+        return memcmp(pbBase, other.pbBase, len);
     }
     bool IsEmpty() const
     {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -2585,7 +2585,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
                      functionId);
         return S_OK;
     }
-    
+
     // Call RequestRejit for register inliners and current NGEN module.
     if (rejit_handler != nullptr)
     {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -615,7 +615,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
     {
         // We check if the Module contains NGEN images and added to the
         // rejit handler list to verify the inlines.
-        rejit_handler->AddNGenModule(module_id);
+        rejit_handler->AddNGenInlinerModule(module_id);
     }
 
     AppDomainID app_domain_id = module_info.assembly.app_domain_id;
@@ -2584,6 +2584,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
         Logger::Warn("JITCachedFunctionSearchStarted: Call to ICorProfilerInfo4.GetFunctionInfo() failed for ",
                      functionId);
         return S_OK;
+    }
+    
+    // Call RequestRejit for register inliners and current NGEN module.
+    if (rejit_handler != nullptr)
+    {
+        // Process the current module to detect inliners.
+        rejit_handler->AddNGenInlinerModule(module_id);
     }
 
     // Verify that we have the metadata for this module

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -95,7 +95,7 @@ private:
     //
     // Loader methods. These are only used on the .NET Framework.
     //
-    HRESULT RunAutoInstrumentationLoader(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token);
+    HRESULT RunAutoInstrumentationLoader(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token, const FunctionInfo& caller, const ModuleMetadata& module_metadata);
     HRESULT GenerateLoaderMethod(const ModuleID module_id, mdMethodDef* ret_method_token);
     HRESULT AddIISPreStartInitFlags(const ModuleID module_id, const mdToken function_token);
 #endif
@@ -108,7 +108,7 @@ private:
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
     bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
     std::string GetILCodes(const std::string& title, ILRewriter* rewriter, const FunctionInfo& caller,
-                           const ModuleMetadata& module_metadata);
+                           const ComPtr<IMetaDataImport2>& metadata_import);
 
     //
     // Initialization methods

--- a/src/OpenTelemetry.AutoInstrumentation.Native/method_rewriter.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/method_rewriter.cpp
@@ -152,7 +152,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     if (IsDumpILRewriteEnabled())
     {
         original_code = corProfiler->GetILCodes("*** CallTarget_RewriterCallback(): Original Code: ", &rewriter,
-                                                *caller, module_metadata);
+                                                *caller, module_metadata.metadata_import);
     }
 
     // *** Create the rewriter wrapper helper
@@ -549,7 +549,8 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     if (IsDumpILRewriteEnabled())
     {
         Logger::Info(original_code);
-        Logger::Info(corProfiler->GetILCodes("*** Rewriter(): Modified Code: ", &rewriter, *caller, module_metadata));
+        Logger::Info(corProfiler->GetILCodes("*** Rewriter(): Modified Code: ", &rewriter, *caller,
+                                             module_metadata.metadata_import));
     }
 
     hr = rewriter.Export();

--- a/src/OpenTelemetry.AutoInstrumentation.Native/method_rewriter.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/method_rewriter.cpp
@@ -100,13 +100,13 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     mdToken                function_token         = caller->id;
     TypeSignature          retFuncArg             = caller->method_signature.GetReturnValue();
     IntegrationDefinition* integration_definition = tracerMethodHandler->GetIntegrationDefinition();
-    const auto [retFuncElementType, retTypeFlags] = retFuncArg.GetElementTypeAndFlags();
-    bool                   isVoid       = (retTypeFlags & TypeFlagVoid) > 0;
-    bool                   isStatic = !(caller->method_signature.CallingConvention() & IMAGE_CEE_CS_CALLCONV_HASTHIS);
-    const auto&            methodArguments              = caller->method_signature.GetMethodArguments();
-    int                                 numArgs         = caller->method_signature.NumberOfArguments();
-    auto                                metaEmit        = module_metadata.metadata_emit;
-    auto                                metaImport      = module_metadata.metadata_import;
+    const auto[retFuncElementType, retTypeFlags] = retFuncArg.GetElementTypeAndFlags();
+    bool        isVoid          = (retTypeFlags & TypeFlagVoid) > 0;
+    bool        isStatic        = !(caller->method_signature.CallingConvention() & IMAGE_CEE_CS_CALLCONV_HASTHIS);
+    const auto& methodArguments = caller->method_signature.GetMethodArguments();
+    int         numArgs         = caller->method_signature.NumberOfArguments();
+    auto        metaEmit        = module_metadata.metadata_emit;
+    auto        metaImport      = module_metadata.metadata_import;
 
     // *** Get reference to the integration type
     mdTypeRef integration_type_ref = mdTypeRefNil;
@@ -168,8 +168,8 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     mdToken  callTargetReturnToken = mdTokenNil;
     ILInstr* firstInstruction;
     tracerTokens->ModifyLocalSigAndInitialize(&reWriterWrapper, caller, &callTargetStateIndex, &exceptionIndex,
-                                                  &callTargetReturnIndex, &returnValueIndex, &callTargetStateToken,
-                                                  &exceptionToken, &callTargetReturnToken, &firstInstruction);
+                                              &callTargetReturnIndex, &returnValueIndex, &callTargetStateToken,
+                                              &exceptionToken, &callTargetReturnToken, &firstInstruction);
 
     // ***
     // BEGIN METHOD PART
@@ -226,7 +226,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
         // Load the arguments directly (FastPath)
         for (int i = 0; i < numArgs; i++)
         {
-            const auto [elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
+            const auto[elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
             if (corProfiler->enable_by_ref_instrumentation)
             {
                 if (argTypeFlags & TypeFlagByRef)
@@ -258,7 +258,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
         {
             reWriterWrapper.BeginLoadValueIntoArray(i);
             reWriterWrapper.LoadArgument(i + (isStatic ? 0 : 1));
-            const auto [elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
+            const auto[elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
             if (argTypeFlags & TypeFlagByRef)
             {
                 Logger::Warn("*** CallTarget_RewriterCallback(): Methods with ref parameters "
@@ -315,7 +315,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     ILInstr* beginCallInstruction;
     hr = tracerTokens->WriteBeginMethod(&reWriterWrapper, integration_type_ref, &caller->type, methodArguments,
-                                            &beginCallInstruction);
+                                        &beginCallInstruction);
     if (FAILED(hr))
     {
         // Error message is written to the log in WriteBeginMethod.
@@ -326,8 +326,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     // *** BeginMethod call catch
     ILInstr* beginMethodCatchFirstInstr = nullptr;
-    tracerTokens->WriteLogException(&reWriterWrapper, integration_type_ref, &caller->type,
-                                        &beginMethodCatchFirstInstr);
+    tracerTokens->WriteLogException(&reWriterWrapper, integration_type_ref, &caller->type, &beginMethodCatchFirstInstr);
     ILInstr* beginMethodCatchLeaveInstr = reWriterWrapper.CreateInstr(CEE_LEAVE_S);
 
     // *** BeginMethod exception handling clause
@@ -435,12 +434,12 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     if (isVoid)
     {
         tracerTokens->WriteEndVoidReturnMemberRef(&reWriterWrapper, integration_type_ref, &caller->type,
-                                                      &endMethodCallInstr);
+                                                  &endMethodCallInstr);
     }
     else
     {
         tracerTokens->WriteEndReturnMemberRef(&reWriterWrapper, integration_type_ref, &caller->type, &retFuncArg,
-                                                  &endMethodCallInstr);
+                                              &endMethodCallInstr);
     }
     reWriterWrapper.StLocal(callTargetReturnIndex);
 
@@ -449,7 +448,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
         ILInstr* callTargetReturnGetReturnInstr;
         reWriterWrapper.LoadLocalAddress(callTargetReturnIndex);
         tracerTokens->WriteCallTargetReturnGetReturnValue(&reWriterWrapper, callTargetReturnToken,
-                                                              &callTargetReturnGetReturnInstr);
+                                                          &callTargetReturnGetReturnInstr);
         reWriterWrapper.StLocal(returnValueIndex);
     }
 
@@ -457,8 +456,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     // *** EndMethod call catch
     ILInstr* endMethodCatchFirstInstr = nullptr;
-    tracerTokens->WriteLogException(&reWriterWrapper, integration_type_ref, &caller->type,
-                                        &endMethodCatchFirstInstr);
+    tracerTokens->WriteLogException(&reWriterWrapper, integration_type_ref, &caller->type, &endMethodCatchFirstInstr);
     ILInstr* endMethodCatchLeaveInstr = reWriterWrapper.CreateInstr(CEE_LEAVE_S);
 
     // *** EndMethod exception handling clause

--- a/src/OpenTelemetry.AutoInstrumentation.Native/module_metadata.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/module_metadata.h
@@ -16,6 +16,7 @@
 #include "com_ptr.h"
 #include "integration.h"
 #include "string.h"
+#include "tracer_tokens.h"
 
 namespace trace
 {
@@ -25,7 +26,7 @@ class ModuleMetadata
 private:
     std::mutex wrapper_mutex;
     std::unique_ptr<std::unordered_map<WSTRING, mdTypeRef>> integration_types = nullptr;
-    std::unique_ptr<CallTargetTokens> calltargetTokens = nullptr;
+    std::unique_ptr<TracerTokens> tracerTokens = nullptr;
     std::unique_ptr<std::vector<IntegrationDefinition>> integrations = nullptr;
 
 public:
@@ -99,13 +100,14 @@ public:
         (*integration_types)[keyIn] = valueIn;
     }
 
-    CallTargetTokens* GetCallTargetTokens()
+    TracerTokens* GetTracerTokens()
     {
-        if (calltargetTokens == nullptr)
+        if (tracerTokens == nullptr)
         {
-            calltargetTokens = std::make_unique<CallTargetTokens>(this);
+            tracerTokens =
+                std::make_unique<TracerTokens>(this);
         }
-        return calltargetTokens.get();
+        return tracerTokens.get();
     }
 };
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
@@ -301,9 +301,6 @@ void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector, std::vecto
         {
             Logger::Warn("Error requesting ReJIT for ", modulesVector.size(), " methods");
         }
-
-        // Request for NGen Inliners
-        RequestRejitForNGenInliners();
     }
 }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
@@ -3,7 +3,6 @@
 
 #include "rejit_handler.h"
 
-#include "otel_profiler_constants.h"
 #include "logger.h"
 #include "stats.h"
 
@@ -241,8 +240,7 @@ void RejitHandlerModule::RequestRejitForInlinersInModule(ModuleID moduleId)
 
 void RejitHandler::RequestRejitForInlinersInModule(ModuleID moduleId)
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return;
     }
@@ -259,8 +257,7 @@ void RejitHandler::RequestRejitForInlinersInModule(ModuleID moduleId)
 
 void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef)
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return;
     }
@@ -326,8 +323,7 @@ RejitHandler::RejitHandler(ICorProfilerInfo12* pInfo, std::shared_ptr<RejitWorkO
 
 RejitHandlerModule* RejitHandler::GetOrAddModule(ModuleID moduleId)
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return nullptr;
     }
@@ -346,8 +342,7 @@ RejitHandlerModule* RejitHandler::GetOrAddModule(ModuleID moduleId)
 
 bool RejitHandler::HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef)
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return false;
     }
@@ -365,8 +360,7 @@ bool RejitHandler::HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef)
 
 void RejitHandler::RemoveModule(ModuleID moduleId)
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return;
     }
@@ -377,8 +371,7 @@ void RejitHandler::RemoveModule(ModuleID moduleId)
 
 void RejitHandler::AddNGenModule(ModuleID moduleId)
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return;
     }
@@ -437,8 +430,7 @@ HRESULT RejitHandler::NotifyReJITParameters(ModuleID                     moduleI
                                             mdMethodDef                  methodId,
                                             ICorProfilerFunctionControl* pFunctionControl)
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return S_FALSE;
     }
@@ -533,8 +525,7 @@ AssemblyProperty* RejitHandler::GetCorAssemblyProperty()
 
 void RejitHandler::RequestRejitForNGenInliners()
 {
-    ReadLock r_lock(m_shutdown_lock);
-    if (m_shutdown)
+    if (IsShutdownRequested())
     {
         return;
     }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
@@ -56,13 +56,14 @@ void RejitHandlerModuleMethod::SetFunctionInfo(const FunctionInfo& functionInfo)
 bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId)
 {
     // Enumerate all inliners and request rejit
-    ModuleID           currentModuleId  = m_module->GetModuleId();
-    mdMethodDef        currentMethodDef = m_methodDef;
+    ModuleID    currentModuleId  = m_module->GetModuleId();
+    mdMethodDef currentMethodDef = m_methodDef;
 
-    Logger::Debug("RejitHandlerModuleMethod::RequestRejitForInlinersInModule for ", "[ModuleInliner=", moduleId, ", ModuleId=", currentModuleId, ", MethodDef=", currentMethodDef, "]");
+    Logger::Debug("RejitHandlerModuleMethod::RequestRejitForInlinersInModule for ", "[ModuleInliner=", moduleId,
+                  ", ModuleId=", currentModuleId, ", MethodDef=", currentMethodDef, "]");
 
-    RejitHandler*      handler          = m_module->GetHandler();
-    ICorProfilerInfo7* pInfo            = handler->GetCorProfilerInfo();
+    RejitHandler*      handler = m_module->GetHandler();
+    ICorProfilerInfo7* pInfo   = handler->GetCorProfilerInfo();
     if (pInfo != nullptr)
     {
         // Now we enumerate all methods that inline the current methodDef
@@ -232,7 +233,7 @@ void RejitHandlerModule::RequestRejitForInlinersInModule(ModuleID moduleId)
     }
 
     std::lock_guard<std::mutex> methodsGuard(m_methods_lock);
-    bool success = true;
+    bool                        success = true;
     for (const auto& method : m_methods)
     {
         success = success && method.second.get()->RequestRejitForInlinersInModule(moduleId);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_handler.cpp
@@ -53,24 +53,16 @@ void RejitHandlerModuleMethod::SetFunctionInfo(const FunctionInfo& functionInfo)
     m_functionInfo = std::make_unique<FunctionInfo>(functionInfo);
 }
 
-void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId)
+bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId)
 {
-    Logger::Debug("RejitHandlerModuleMethod::RequestRejitForInlinersInModule: ", moduleId);
-    std::lock_guard<std::mutex> guard(m_ngenModulesLock);
-
-    // We check first if we already processed this module to skip it.
-    auto find_res = m_ngenModules.find(moduleId);
-    if (find_res != m_ngenModules.end())
-    {
-        return;
-    }
-
     // Enumerate all inliners and request rejit
     ModuleID           currentModuleId  = m_module->GetModuleId();
     mdMethodDef        currentMethodDef = m_methodDef;
+
+    Logger::Debug("RejitHandlerModuleMethod::RequestRejitForInlinersInModule for ", "[ModuleInliner=", moduleId, ", ModuleId=", currentModuleId, ", MethodDef=", currentMethodDef, "]");
+
     RejitHandler*      handler          = m_module->GetHandler();
     ICorProfilerInfo7* pInfo            = handler->GetCorProfilerInfo();
-
     if (pInfo != nullptr)
     {
         // Now we enumerate all methods that inline the current methodDef
@@ -104,13 +96,10 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
                              currentMethodDef, "]");
             }
 
-            if (!incompleteData)
-            {
-                m_ngenModules[moduleId] = true;
-            }
-            else
+            if (incompleteData)
             {
                 Logger::Warn("NGen inliner data for module '", moduleId, "' is incomplete.");
+                return false;
             }
         }
         else if (hr == E_INVALIDARG)
@@ -122,6 +111,8 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
         {
             Logger::Info("NGEN:: Error Incomplete data in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef,
                          ", HR=", hexValue.str(), "]");
+
+            return false;
         }
         else if (hr == CORPROF_E_UNSUPPORTED_CALL_SEQUENCE)
         {
@@ -133,7 +124,11 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
             Logger::Info("NGEN:: Error in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef, ", HR=",
                          hexValue.str(), "]");
         }
+
+        return true;
     }
+
+    return false;
 }
 
 //
@@ -227,33 +222,37 @@ bool RejitHandlerModule::ContainsMethod(mdMethodDef methodDef)
 
 void RejitHandlerModule::RequestRejitForInlinersInModule(ModuleID moduleId)
 {
-    std::lock_guard<std::mutex> guard(m_methods_lock);
+    std::lock_guard<std::mutex> moduleGuard(m_ngenProcessedInlinerModulesLock);
+
+    // We check first if we already processed this module to skip it.
+    auto find_res = m_ngenProcessedInlinerModules.find(moduleId);
+    if (find_res != m_ngenProcessedInlinerModules.end())
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> methodsGuard(m_methods_lock);
+    bool success = true;
     for (const auto& method : m_methods)
     {
-        method.second.get()->RequestRejitForInlinersInModule(moduleId);
+        success = success && method.second.get()->RequestRejitForInlinersInModule(moduleId);
+        // If we fail to process a method, we stop the processing and try again in another call.
+        if (!success)
+        {
+            break;
+        }
+    }
+
+    if (success)
+    {
+        // We mark module as processed.
+        m_ngenProcessedInlinerModules[moduleId] = true;
     }
 }
 
 //
 // RejitHandler
 //
-
-void RejitHandler::RequestRejitForInlinersInModule(ModuleID moduleId)
-{
-    if (IsShutdownRequested())
-    {
-        return;
-    }
-
-    std::lock_guard<std::mutex> guard(m_modules_lock);
-    if (m_profilerInfo != nullptr)
-    {
-        for (const auto& mod : m_modules)
-        {
-            mod.second->RequestRejitForInlinersInModule(moduleId);
-        }
-    }
-}
 
 void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef)
 {
@@ -366,16 +365,49 @@ void RejitHandler::RemoveModule(ModuleID moduleId)
     m_modules.erase(moduleId);
 }
 
-void RejitHandler::AddNGenModule(ModuleID moduleId)
+void RejitHandler::AddNGenInlinerModule(ModuleID moduleId)
 {
     if (IsShutdownRequested())
     {
         return;
     }
 
-    std::lock_guard<std::mutex> guard(m_ngenModules_lock);
-    m_ngenModules.push_back(moduleId);
-    RequestRejitForInlinersInModule(moduleId);
+    // Process the inliner module list ( to catch any incomplete data module )
+    // and also check if the module is already in the inliners list
+    std::lock_guard<std::mutex> guard(m_ngenInlinersModules_lock);
+    bool                        alreadyAdded = false;
+    if (m_profilerInfo != nullptr)
+    {
+        for (const auto& moduleInliner : m_ngenInlinersModules)
+        {
+            if (moduleInliner == moduleId)
+            {
+                alreadyAdded = true;
+            }
+            else
+            {
+                std::lock_guard<std::mutex> guard(m_modules_lock);
+                for (const auto& mod : m_modules)
+                {
+                    mod.second->RequestRejitForInlinersInModule(moduleInliner);
+                }
+            }
+        }
+    }
+
+    if (!alreadyAdded)
+    {
+        // Add the new module inliner
+        m_ngenInlinersModules.push_back(moduleId);
+        if (m_profilerInfo != nullptr)
+        {
+            std::lock_guard<std::mutex> guard(m_modules_lock);
+            for (const auto& mod : m_modules)
+            {
+                mod.second->RequestRejitForInlinersInModule(moduleId);
+            }
+        }
+    }
 }
 
 void RejitHandler::EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef)
@@ -407,7 +439,7 @@ void RejitHandler::Shutdown()
     m_work_offloader->WaitForTermination();
 
     std::lock_guard<std::mutex> moduleGuard(m_modules_lock);
-    std::lock_guard<std::mutex> ngenModuleGuard(m_ngenModules_lock);
+    std::lock_guard<std::mutex> ngenModuleGuard(m_ngenInlinersModules_lock);
 
     WriteLock w_lock(m_shutdown_lock);
     m_shutdown.store(true);
@@ -518,23 +550,6 @@ void RejitHandler::SetCorAssemblyProfiler(AssemblyProperty* pCorAssemblyProfiler
 AssemblyProperty* RejitHandler::GetCorAssemblyProperty()
 {
     return m_pCorAssemblyProperty;
-}
-
-void RejitHandler::RequestRejitForNGenInliners()
-{
-    if (IsShutdownRequested())
-    {
-        return;
-    }
-
-    std::lock_guard<std::mutex> guard(m_ngenModules_lock);
-    if (m_profilerInfo != nullptr)
-    {
-        for (const auto& mod : m_ngenModules)
-        {
-            RequestRejitForInlinersInModule(mod);
-        }
-    }
 }
 
 } // namespace trace

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
@@ -80,7 +80,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
         }
 
         // Compare each mdMethodDef argument type to the instrumentation target
-        bool       argumentsMismatch = false;
+        bool        argumentsMismatch = false;
         const auto& methodArguments   = functionInfo.method_signature.GetMethodArguments();
 
         Logger::Debug("    * Comparing signature for method: ", caller.type.name, ".", caller.name);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
@@ -81,7 +81,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
 
         // Compare each mdMethodDef argument type to the instrumentation target
         bool       argumentsMismatch = false;
-        const auto methodArguments   = functionInfo.method_signature.GetMethodArguments();
+        const auto& methodArguments   = functionInfo.method_signature.GetMethodArguments();
 
         Logger::Debug("    * Comparing signature for method: ", caller.type.name, ".", caller.name);
         for (unsigned int i = 0; i < numOfArgs; i++)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
@@ -385,7 +385,6 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::RequestRejitForLoadedModules(
         else
         {
             m_rejit_handler->EnqueueForRejit(vtModules, vtMethodDefs);
-            m_rejit_handler->RequestRejitForNGenInliners();
         }
     }
 
@@ -435,7 +434,6 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejitForLoadedModu
 
     // Enqueue
     m_work_offloader->Enqueue(std::make_unique<RejitWorkItem>(std::move(action)));
-    m_rejit_handler->RequestRejitForNGenInliners();
 }
 
 // TraceIntegrationRejitPreprocessor

--- a/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/rejit_preprocessor.cpp
@@ -385,6 +385,7 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::RequestRejitForLoadedModules(
         else
         {
             m_rejit_handler->EnqueueForRejit(vtModules, vtMethodDefs);
+            m_rejit_handler->RequestRejitForNGenInliners();
         }
     }
 
@@ -434,6 +435,7 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejitForLoadedModu
 
     // Enqueue
     m_work_offloader->Enqueue(std::make_unique<RejitWorkItem>(std::move(action)));
+    m_rejit_handler->RequestRejitForNGenInliners();
 }
 
 // TraceIntegrationRejitPreprocessor

--- a/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
@@ -1,0 +1,631 @@
+#include "tracer_tokens.h"
+
+#include "otel_profiler_constants.h"
+#include "il_rewriter_wrapper.h"
+#include "logger.h"
+#include "module_metadata.h"
+
+namespace trace
+{
+
+const int signatureBufferSize = 500;
+
+/**
+ * TRACER CONSTANTS
+ **/
+
+static const WSTRING managed_profiler_calltarget_type = WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker");
+static const WSTRING managed_profiler_calltarget_statetype =WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState");
+static const WSTRING managed_profiler_calltarget_returntype = WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn");
+static const WSTRING managed_profiler_calltarget_returntype_generics = WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn`1");
+static const WSTRING managed_profiler_calltarget_beginmethod_name = WStr("BeginMethod");
+static const WSTRING managed_profiler_calltarget_endmethod_name = WStr("EndMethod");
+static const WSTRING managed_profiler_calltarget_logexception_name = WStr("LogException");
+
+/**
+ * PRIVATE
+ **/
+
+// slowpath BeginMethod
+HRESULT TracerTokens::WriteBeginMethodWithArgumentsArray(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
+                                                             const TypeInfo* currentType, ILInstr** instruction)
+{
+    auto hr = EnsureBaseCalltargetTokens();
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
+    ModuleMetadata* module_metadata = GetMetadata();
+
+    if (beginArrayMemberRef == mdMemberRefNil)
+    {
+        unsigned callTargetStateBuffer;
+        auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+
+        auto signatureLength = 8 + callTargetStateSize;
+        COR_SIGNATURE signature[signatureBufferSize];
+        unsigned offset = 0;
+
+        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
+        signature[offset++] = 0x02;
+        signature[offset++] = 0x02;
+
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+        memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
+        offset += callTargetStateSize;
+
+        signature[offset++] = ELEMENT_TYPE_MVAR;
+        signature[offset++] = 0x01;
+
+        signature[offset++] = ELEMENT_TYPE_SZARRAY;
+        signature[offset++] = ELEMENT_TYPE_OBJECT;
+
+        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
+                                                                  managed_profiler_calltarget_beginmethod_name.data(),
+                                                                  signature, signatureLength, &beginArrayMemberRef);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper beginArrayMemberRef could not be defined.");
+            return hr;
+        }
+    }
+
+    mdMethodSpec beginArrayMethodSpec = mdMethodSpecNil;
+
+    unsigned integrationTypeBuffer;
+    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+
+    bool isValueType = currentType->valueType;
+    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
+
+    unsigned currentTypeBuffer;
+    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+
+    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
+    COR_SIGNATURE signature[signatureBufferSize];
+    unsigned offset = 0;
+    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++] = 0x02;
+
+    signature[offset++] = ELEMENT_TYPE_CLASS;
+    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
+    offset += integrationTypeSize;
+
+    if (isValueType)
+    {
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    }
+    else
+    {
+        signature[offset++] = ELEMENT_TYPE_CLASS;
+    }
+    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
+    offset += currentTypeSize;
+
+    hr = module_metadata->metadata_emit->DefineMethodSpec(beginArrayMemberRef, signature, signatureLength,
+                                                          &beginArrayMethodSpec);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error creating begin method spec.");
+        return hr;
+    }
+
+    *instruction = rewriterWrapper->CallMember(beginArrayMethodSpec, false);
+    return S_OK;
+}
+
+/**
+ * PROTECTED
+ **/
+
+const WSTRING& TracerTokens::GetCallTargetType()
+{
+    return managed_profiler_calltarget_type;
+}
+
+const WSTRING& TracerTokens::GetCallTargetStateType()
+{
+    return managed_profiler_calltarget_statetype;
+}
+
+const WSTRING& TracerTokens::GetCallTargetReturnType()
+{
+    return managed_profiler_calltarget_returntype;
+}
+
+const WSTRING& TracerTokens::GetCallTargetReturnGenericType()
+{
+    return managed_profiler_calltarget_returntype_generics;
+}
+
+
+/**
+ * PUBLIC
+ **/
+
+TracerTokens::TracerTokens(ModuleMetadata* module_metadata_ptr) :
+    CallTargetTokens(module_metadata_ptr)
+{
+    for (int i = 0; i < FASTPATH_COUNT; i++)
+    {
+        beginMethodFastPathRefs[i] = mdMemberRefNil;
+    }
+}
+
+HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
+                                           const TypeInfo* currentType,
+                                           const std::vector<TypeSignature>& methodArguments, ILInstr** instruction)
+{
+    auto hr = EnsureBaseCalltargetTokens();
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
+    ModuleMetadata* module_metadata = GetMetadata();
+
+    auto numArguments = (int) methodArguments.size();
+    if (numArguments >= FASTPATH_COUNT)
+    {
+        return WriteBeginMethodWithArgumentsArray(rewriterWrapperPtr, integrationTypeRef, currentType, instruction);
+    }
+
+    //
+    // FastPath
+    //
+
+    if (beginMethodFastPathRefs[numArguments] == mdMemberRefNil)
+    {
+        unsigned callTargetStateBuffer;
+        auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+
+        unsigned long signatureLength;
+        if (enable_by_ref_instrumentation)
+        {
+            signatureLength = 6 + (numArguments * 3) + callTargetStateSize;
+        }
+        else
+        {
+            signatureLength = 6 + (numArguments * 2) + callTargetStateSize;
+        }
+        COR_SIGNATURE signature[signatureBufferSize];
+        unsigned offset = 0;
+
+        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
+        signature[offset++] = 0x02 + numArguments;
+        signature[offset++] = 0x01 + numArguments;
+
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+        memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
+        offset += callTargetStateSize;
+
+        signature[offset++] = ELEMENT_TYPE_MVAR;
+        signature[offset++] = 0x01;
+
+        for (auto i = 0; i < numArguments; i++)
+        {
+            if (enable_by_ref_instrumentation)
+            {
+                signature[offset++] = ELEMENT_TYPE_BYREF;
+            }
+            signature[offset++] = ELEMENT_TYPE_MVAR;
+            signature[offset++] = 0x01 + (i + 1);
+        }
+
+        auto hr = module_metadata->metadata_emit->DefineMemberRef(
+            callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(), signature, signatureLength,
+            &beginMethodFastPathRefs[numArguments]);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper beginMethod for ", numArguments, " arguments could not be defined.");
+            return hr;
+        }
+    }
+
+    mdMethodSpec beginMethodSpec = mdMethodSpecNil;
+
+    unsigned integrationTypeBuffer;
+    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+
+    bool isValueType = currentType->valueType;
+    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
+
+    unsigned currentTypeBuffer;
+    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+
+    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
+
+    PCCOR_SIGNATURE argumentsSignatureBuffer[FASTPATH_COUNT];
+    ULONG argumentsSignatureSize[FASTPATH_COUNT];
+    for (auto i = 0; i < numArguments; i++)
+    {
+        const auto [elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
+
+        if (enable_by_ref_instrumentation && (argTypeFlags & TypeFlagByRef))
+        {
+            PCCOR_SIGNATURE argSigBuff;
+            auto signatureSize = methodArguments[i].GetSignature(argSigBuff);
+            if (argSigBuff[0] == ELEMENT_TYPE_BYREF)
+            {
+                argumentsSignatureBuffer[i] = argSigBuff + 1;
+                argumentsSignatureSize[i] = signatureSize - 1;
+                signatureLength += signatureSize - 1;
+            }
+            else
+            {
+                argumentsSignatureBuffer[i] = argSigBuff;
+                argumentsSignatureSize[i] = signatureSize;
+                signatureLength += signatureSize;
+            }
+        }
+        else
+        {
+            auto signatureSize = methodArguments[i].GetSignature(argumentsSignatureBuffer[i]);
+            argumentsSignatureSize[i] = signatureSize;
+            signatureLength += signatureSize;
+        }
+    }
+
+    COR_SIGNATURE signature[signatureBufferSize];
+    unsigned offset = 0;
+
+    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++] = 0x02 + numArguments;
+
+    signature[offset++] = ELEMENT_TYPE_CLASS;
+    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
+    offset += integrationTypeSize;
+
+    if (isValueType)
+    {
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    }
+    else
+    {
+        signature[offset++] = ELEMENT_TYPE_CLASS;
+    }
+    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
+    offset += currentTypeSize;
+
+    for (auto i = 0; i < numArguments; i++)
+    {
+        memcpy(&signature[offset], argumentsSignatureBuffer[i], argumentsSignatureSize[i]);
+        offset += argumentsSignatureSize[i];
+    }
+
+    hr = module_metadata->metadata_emit->DefineMethodSpec(beginMethodFastPathRefs[numArguments], signature,
+                                                          signatureLength, &beginMethodSpec);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error creating begin method spec.");
+        return hr;
+    }
+
+    *instruction = rewriterWrapper->CallMember(beginMethodSpec, false);
+    return S_OK;
+}
+
+// endmethod with void return
+HRESULT TracerTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
+                                                      const TypeInfo* currentType, ILInstr** instruction)
+{
+    auto hr = EnsureBaseCalltargetTokens();
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
+    ModuleMetadata* module_metadata = GetMetadata();
+
+    if (endVoidMemberRef == mdMemberRefNil)
+    {
+        unsigned callTargetReturnVoidBuffer;
+        auto callTargetReturnVoidSize = CorSigCompressToken(callTargetReturnVoidTypeRef, &callTargetReturnVoidBuffer);
+
+        unsigned exTypeRefBuffer;
+        auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
+
+        unsigned callTargetStateBuffer;
+        auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+
+        auto signatureLength = 8 + callTargetReturnVoidSize + exTypeRefSize + callTargetStateSize;
+        if (enable_calltarget_state_by_ref)
+        {
+            signatureLength++;
+        }
+
+        COR_SIGNATURE signature[signatureBufferSize];
+        unsigned offset = 0;
+
+        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
+        signature[offset++] = 0x02;
+        signature[offset++] = 0x03;
+
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+        memcpy(&signature[offset], &callTargetReturnVoidBuffer, callTargetReturnVoidSize);
+        offset += callTargetReturnVoidSize;
+
+        signature[offset++] = ELEMENT_TYPE_MVAR;
+        signature[offset++] = 0x01;
+
+        signature[offset++] = ELEMENT_TYPE_CLASS;
+        memcpy(&signature[offset], &exTypeRefBuffer, exTypeRefSize);
+        offset += exTypeRefSize;
+
+        if (enable_calltarget_state_by_ref)
+        {
+            signature[offset++] = ELEMENT_TYPE_BYREF;
+        }
+
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+        memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
+        offset += callTargetStateSize;
+
+        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
+                                                                  managed_profiler_calltarget_endmethod_name.data(),
+                                                                  signature, signatureLength, &endVoidMemberRef);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper endVoidMemberRef could not be defined.");
+            return hr;
+        }
+    }
+
+    mdMethodSpec endVoidMethodSpec = mdMethodSpecNil;
+
+    unsigned integrationTypeBuffer;
+    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+
+    bool isValueType = currentType->valueType;
+    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
+
+    unsigned currentTypeBuffer;
+    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+
+    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
+    COR_SIGNATURE signature[signatureBufferSize];
+    unsigned offset = 0;
+    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++] = 0x02;
+
+    signature[offset++] = ELEMENT_TYPE_CLASS;
+    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
+    offset += integrationTypeSize;
+
+    if (isValueType)
+    {
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    }
+    else
+    {
+        signature[offset++] = ELEMENT_TYPE_CLASS;
+    }
+    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
+    offset += currentTypeSize;
+
+    hr = module_metadata->metadata_emit->DefineMethodSpec(endVoidMemberRef, signature, signatureLength,
+                                                          &endVoidMethodSpec);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error creating end void method method spec.");
+        return hr;
+    }
+
+    *instruction = rewriterWrapper->CallMember(endVoidMethodSpec, false);
+    return S_OK;
+}
+
+// endmethod with return type
+HRESULT TracerTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
+                                                  const TypeInfo* currentType, TypeSignature* returnArgument,
+                                                  ILInstr** instruction)
+{
+    auto hr = EnsureBaseCalltargetTokens();
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
+    ModuleMetadata* module_metadata = GetMetadata();
+    GetTargetReturnValueTypeRef(returnArgument);
+
+    // *** Define base MethodMemberRef for the type
+
+    mdMemberRef endMethodMemberRef = mdMemberRefNil;
+
+    unsigned callTargetReturnTypeRefBuffer;
+    auto callTargetReturnTypeRefSize = CorSigCompressToken(callTargetReturnTypeRef, &callTargetReturnTypeRefBuffer);
+
+    unsigned exTypeRefBuffer;
+    auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
+
+    unsigned callTargetStateBuffer;
+    auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+
+    auto signatureLength = 14 + callTargetReturnTypeRefSize + exTypeRefSize + callTargetStateSize;
+    if (enable_calltarget_state_by_ref)
+    {
+        signatureLength++;
+    }
+
+    COR_SIGNATURE signature[signatureBufferSize];
+    unsigned offset = 0;
+
+    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
+    signature[offset++] = 0x03;
+    signature[offset++] = 0x04;
+
+    signature[offset++] = ELEMENT_TYPE_GENERICINST;
+    signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    memcpy(&signature[offset], &callTargetReturnTypeRefBuffer, callTargetReturnTypeRefSize);
+    offset += callTargetReturnTypeRefSize;
+    signature[offset++] = 0x01;
+    signature[offset++] = ELEMENT_TYPE_MVAR;
+    signature[offset++] = 0x02;
+
+    signature[offset++] = ELEMENT_TYPE_MVAR;
+    signature[offset++] = 0x01;
+
+    signature[offset++] = ELEMENT_TYPE_MVAR;
+    signature[offset++] = 0x02;
+
+    signature[offset++] = ELEMENT_TYPE_CLASS;
+    memcpy(&signature[offset], &exTypeRefBuffer, exTypeRefSize);
+    offset += exTypeRefSize;
+
+    if (enable_calltarget_state_by_ref)
+    {
+        signature[offset++] = ELEMENT_TYPE_BYREF;
+    }
+    signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    memcpy(&signature[offset], &callTargetStateBuffer, callTargetStateSize);
+    offset += callTargetStateSize;
+
+    hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
+                                                         managed_profiler_calltarget_endmethod_name.data(), signature,
+                                                         signatureLength, &endMethodMemberRef);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Wrapper endMethodMemberRef could not be defined.");
+        return hr;
+    }
+
+    // *** Define Method Spec
+
+    mdMethodSpec endMethodSpec = mdMethodSpecNil;
+
+    unsigned integrationTypeBuffer;
+    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+
+    bool isValueType = currentType->valueType;
+    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
+
+    unsigned currentTypeBuffer;
+    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+
+    PCCOR_SIGNATURE returnSignatureBuffer;
+    auto returnSignatureLength = returnArgument->GetSignature(returnSignatureBuffer);
+
+    signatureLength = 4 + integrationTypeSize + currentTypeSize + returnSignatureLength;
+    offset = 0;
+
+    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++] = 0x03;
+
+    signature[offset++] = ELEMENT_TYPE_CLASS;
+    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
+    offset += integrationTypeSize;
+
+    if (isValueType)
+    {
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    }
+    else
+    {
+        signature[offset++] = ELEMENT_TYPE_CLASS;
+    }
+    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
+    offset += currentTypeSize;
+
+    memcpy(&signature[offset], returnSignatureBuffer, returnSignatureLength);
+    offset += returnSignatureLength;
+
+    hr = module_metadata->metadata_emit->DefineMethodSpec(endMethodMemberRef, signature, signatureLength,
+                                                          &endMethodSpec);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error creating end method member spec.");
+        return hr;
+    }
+
+    *instruction = rewriterWrapper->CallMember(endMethodSpec, false);
+    return S_OK;
+}
+
+// write log exception
+HRESULT TracerTokens::WriteLogException(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
+                                            const TypeInfo* currentType, ILInstr** instruction)
+{
+    auto hr = EnsureBaseCalltargetTokens();
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
+    ModuleMetadata* module_metadata = GetMetadata();
+
+    if (logExceptionRef == mdMemberRefNil)
+    {
+        unsigned exTypeRefBuffer;
+        auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
+
+        auto signatureLength = 5 + exTypeRefSize;
+        COR_SIGNATURE signature[signatureBufferSize];
+        unsigned offset = 0;
+
+        signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
+        signature[offset++] = 0x02;
+        signature[offset++] = 0x01;
+
+        signature[offset++] = ELEMENT_TYPE_VOID;
+        signature[offset++] = ELEMENT_TYPE_CLASS;
+        memcpy(&signature[offset], &exTypeRefBuffer, exTypeRefSize);
+        offset += exTypeRefSize;
+
+        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
+                                                                  managed_profiler_calltarget_logexception_name.data(),
+                                                                  signature, signatureLength, &logExceptionRef);
+        if (FAILED(hr))
+        {
+            Logger::Warn("Wrapper logExceptionRef could not be defined.");
+            return hr;
+        }
+    }
+
+    mdMethodSpec logExceptionMethodSpec = mdMethodSpecNil;
+
+    unsigned integrationTypeBuffer;
+    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+
+    bool isValueType = currentType->valueType;
+    mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
+
+    unsigned currentTypeBuffer;
+    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+
+    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
+    COR_SIGNATURE signature[signatureBufferSize];
+    unsigned offset = 0;
+    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++] = 0x02;
+
+    signature[offset++] = ELEMENT_TYPE_CLASS;
+    memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
+    offset += integrationTypeSize;
+
+    if (isValueType)
+    {
+        signature[offset++] = ELEMENT_TYPE_VALUETYPE;
+    }
+    else
+    {
+        signature[offset++] = ELEMENT_TYPE_CLASS;
+    }
+    memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
+    offset += currentTypeSize;
+
+    hr = module_metadata->metadata_emit->DefineMethodSpec(logExceptionRef, signature, signatureLength,
+                                                          &logExceptionMethodSpec);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error creating log exception method spec.");
+        return hr;
+    }
+
+    *instruction = rewriterWrapper->CallMember(logExceptionMethodSpec, false);
+    return S_OK;
+}
+
+} // namespace trace

--- a/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "tracer_tokens.h"
 
 #include "otel_profiler_constants.h"

--- a/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.cpp
@@ -14,12 +14,16 @@ const int signatureBufferSize = 500;
  * TRACER CONSTANTS
  **/
 
-static const WSTRING managed_profiler_calltarget_type = WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker");
-static const WSTRING managed_profiler_calltarget_statetype =WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState");
-static const WSTRING managed_profiler_calltarget_returntype = WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn");
-static const WSTRING managed_profiler_calltarget_returntype_generics = WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn`1");
-static const WSTRING managed_profiler_calltarget_beginmethod_name = WStr("BeginMethod");
-static const WSTRING managed_profiler_calltarget_endmethod_name = WStr("EndMethod");
+static const WSTRING managed_profiler_calltarget_type =
+    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetInvoker");
+static const WSTRING managed_profiler_calltarget_statetype =
+    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetState");
+static const WSTRING managed_profiler_calltarget_returntype =
+    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn");
+static const WSTRING managed_profiler_calltarget_returntype_generics =
+    WStr("OpenTelemetry.AutoInstrumentation.CallTarget.CallTargetReturn`1");
+static const WSTRING managed_profiler_calltarget_beginmethod_name  = WStr("BeginMethod");
+static const WSTRING managed_profiler_calltarget_endmethod_name    = WStr("EndMethod");
 static const WSTRING managed_profiler_calltarget_logexception_name = WStr("LogException");
 
 /**
@@ -27,25 +31,27 @@ static const WSTRING managed_profiler_calltarget_logexception_name = WStr("LogEx
  **/
 
 // slowpath BeginMethod
-HRESULT TracerTokens::WriteBeginMethodWithArgumentsArray(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
-                                                             const TypeInfo* currentType, ILInstr** instruction)
+HRESULT TracerTokens::WriteBeginMethodWithArgumentsArray(void*           rewriterWrapperPtr,
+                                                         mdTypeRef       integrationTypeRef,
+                                                         const TypeInfo* currentType,
+                                                         ILInstr**       instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
     if (FAILED(hr))
     {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
-    ModuleMetadata* module_metadata = GetMetadata();
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ModuleMetadata*    module_metadata = GetMetadata();
 
     if (beginArrayMemberRef == mdMemberRefNil)
     {
         unsigned callTargetStateBuffer;
-        auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+        auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
 
-        auto signatureLength = 8 + callTargetStateSize;
+        auto          signatureLength = 8 + callTargetStateSize;
         COR_SIGNATURE signature[signatureBufferSize];
-        unsigned offset = 0;
+        unsigned      offset = 0;
 
         signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
         signature[offset++] = 0x02;
@@ -74,19 +80,19 @@ HRESULT TracerTokens::WriteBeginMethodWithArgumentsArray(void* rewriterWrapperPt
     mdMethodSpec beginArrayMethodSpec = mdMethodSpecNil;
 
     unsigned integrationTypeBuffer;
-    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
 
-    bool isValueType = currentType->valueType;
+    bool    isValueType    = currentType->valueType;
     mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
 
     unsigned currentTypeBuffer;
-    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
 
-    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
+    auto          signatureLength = 4 + integrationTypeSize + currentTypeSize;
     COR_SIGNATURE signature[signatureBufferSize];
-    unsigned offset = 0;
-    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++] = 0x02;
+    unsigned      offset = 0;
+    signature[offset++]  = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++]  = 0x02;
 
     signature[offset++] = ELEMENT_TYPE_CLASS;
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
@@ -139,13 +145,11 @@ const WSTRING& TracerTokens::GetCallTargetReturnGenericType()
     return managed_profiler_calltarget_returntype_generics;
 }
 
-
 /**
  * PUBLIC
  **/
 
-TracerTokens::TracerTokens(ModuleMetadata* module_metadata_ptr) :
-    CallTargetTokens(module_metadata_ptr)
+TracerTokens::TracerTokens(ModuleMetadata* module_metadata_ptr) : CallTargetTokens(module_metadata_ptr)
 {
     for (int i = 0; i < FASTPATH_COUNT; i++)
     {
@@ -153,9 +157,11 @@ TracerTokens::TracerTokens(ModuleMetadata* module_metadata_ptr) :
     }
 }
 
-HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
-                                           const TypeInfo* currentType,
-                                           const std::vector<TypeSignature>& methodArguments, ILInstr** instruction)
+HRESULT TracerTokens::WriteBeginMethod(void*                             rewriterWrapperPtr,
+                                       mdTypeRef                         integrationTypeRef,
+                                       const TypeInfo*                   currentType,
+                                       const std::vector<TypeSignature>& methodArguments,
+                                       ILInstr**                         instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
     if (FAILED(hr))
@@ -163,10 +169,10 @@ HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integ
         return hr;
     }
 
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
-    ModuleMetadata* module_metadata = GetMetadata();
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ModuleMetadata*    module_metadata = GetMetadata();
 
-    auto numArguments = (int) methodArguments.size();
+    auto numArguments = (int)methodArguments.size();
     if (numArguments >= FASTPATH_COUNT)
     {
         return WriteBeginMethodWithArgumentsArray(rewriterWrapperPtr, integrationTypeRef, currentType, instruction);
@@ -179,7 +185,7 @@ HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integ
     if (beginMethodFastPathRefs[numArguments] == mdMemberRefNil)
     {
         unsigned callTargetStateBuffer;
-        auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+        auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
 
         unsigned long signatureLength;
         if (enable_by_ref_instrumentation)
@@ -191,7 +197,7 @@ HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integ
             signatureLength = 6 + (numArguments * 2) + callTargetStateSize;
         }
         COR_SIGNATURE signature[signatureBufferSize];
-        unsigned offset = 0;
+        unsigned      offset = 0;
 
         signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
         signature[offset++] = 0x02 + numArguments;
@@ -214,9 +220,10 @@ HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integ
             signature[offset++] = 0x01 + (i + 1);
         }
 
-        auto hr = module_metadata->metadata_emit->DefineMemberRef(
-            callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(), signature, signatureLength,
-            &beginMethodFastPathRefs[numArguments]);
+        auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
+                                                                  managed_profiler_calltarget_beginmethod_name.data(),
+                                                                  signature, signatureLength,
+                                                                  &beginMethodFastPathRefs[numArguments]);
         if (FAILED(hr))
         {
             Logger::Warn("Wrapper beginMethod for ", numArguments, " arguments could not be defined.");
@@ -227,49 +234,49 @@ HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integ
     mdMethodSpec beginMethodSpec = mdMethodSpecNil;
 
     unsigned integrationTypeBuffer;
-    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
 
-    bool isValueType = currentType->valueType;
+    bool    isValueType    = currentType->valueType;
     mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
 
     unsigned currentTypeBuffer;
-    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
 
     auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
 
     PCCOR_SIGNATURE argumentsSignatureBuffer[FASTPATH_COUNT];
-    ULONG argumentsSignatureSize[FASTPATH_COUNT];
+    ULONG           argumentsSignatureSize[FASTPATH_COUNT];
     for (auto i = 0; i < numArguments; i++)
     {
-        const auto [elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
+        const auto[elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
 
         if (enable_by_ref_instrumentation && (argTypeFlags & TypeFlagByRef))
         {
             PCCOR_SIGNATURE argSigBuff;
-            auto signatureSize = methodArguments[i].GetSignature(argSigBuff);
+            auto            signatureSize = methodArguments[i].GetSignature(argSigBuff);
             if (argSigBuff[0] == ELEMENT_TYPE_BYREF)
             {
                 argumentsSignatureBuffer[i] = argSigBuff + 1;
-                argumentsSignatureSize[i] = signatureSize - 1;
+                argumentsSignatureSize[i]   = signatureSize - 1;
                 signatureLength += signatureSize - 1;
             }
             else
             {
                 argumentsSignatureBuffer[i] = argSigBuff;
-                argumentsSignatureSize[i] = signatureSize;
+                argumentsSignatureSize[i]   = signatureSize;
                 signatureLength += signatureSize;
             }
         }
         else
         {
-            auto signatureSize = methodArguments[i].GetSignature(argumentsSignatureBuffer[i]);
+            auto signatureSize        = methodArguments[i].GetSignature(argumentsSignatureBuffer[i]);
             argumentsSignatureSize[i] = signatureSize;
             signatureLength += signatureSize;
         }
     }
 
     COR_SIGNATURE signature[signatureBufferSize];
-    unsigned offset = 0;
+    unsigned      offset = 0;
 
     signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
     signature[offset++] = 0x02 + numArguments;
@@ -308,16 +315,18 @@ HRESULT TracerTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integ
 }
 
 // endmethod with void return
-HRESULT TracerTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
-                                                      const TypeInfo* currentType, ILInstr** instruction)
+HRESULT TracerTokens::WriteEndVoidReturnMemberRef(void*           rewriterWrapperPtr,
+                                                  mdTypeRef       integrationTypeRef,
+                                                  const TypeInfo* currentType,
+                                                  ILInstr**       instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
     if (FAILED(hr))
     {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
-    ModuleMetadata* module_metadata = GetMetadata();
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ModuleMetadata*    module_metadata = GetMetadata();
 
     if (endVoidMemberRef == mdMemberRefNil)
     {
@@ -325,10 +334,10 @@ HRESULT TracerTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTy
         auto callTargetReturnVoidSize = CorSigCompressToken(callTargetReturnVoidTypeRef, &callTargetReturnVoidBuffer);
 
         unsigned exTypeRefBuffer;
-        auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
+        auto     exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
 
         unsigned callTargetStateBuffer;
-        auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+        auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
 
         auto signatureLength = 8 + callTargetReturnVoidSize + exTypeRefSize + callTargetStateSize;
         if (enable_calltarget_state_by_ref)
@@ -337,7 +346,7 @@ HRESULT TracerTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTy
         }
 
         COR_SIGNATURE signature[signatureBufferSize];
-        unsigned offset = 0;
+        unsigned      offset = 0;
 
         signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
         signature[offset++] = 0x02;
@@ -376,19 +385,19 @@ HRESULT TracerTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTy
     mdMethodSpec endVoidMethodSpec = mdMethodSpecNil;
 
     unsigned integrationTypeBuffer;
-    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
 
-    bool isValueType = currentType->valueType;
+    bool    isValueType    = currentType->valueType;
     mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
 
     unsigned currentTypeBuffer;
-    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
 
-    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
+    auto          signatureLength = 4 + integrationTypeSize + currentTypeSize;
     COR_SIGNATURE signature[signatureBufferSize];
-    unsigned offset = 0;
-    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++] = 0x02;
+    unsigned      offset = 0;
+    signature[offset++]  = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++]  = 0x02;
 
     signature[offset++] = ELEMENT_TYPE_CLASS;
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
@@ -418,17 +427,19 @@ HRESULT TracerTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTy
 }
 
 // endmethod with return type
-HRESULT TracerTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
-                                                  const TypeInfo* currentType, TypeSignature* returnArgument,
-                                                  ILInstr** instruction)
+HRESULT TracerTokens::WriteEndReturnMemberRef(void*           rewriterWrapperPtr,
+                                              mdTypeRef       integrationTypeRef,
+                                              const TypeInfo* currentType,
+                                              TypeSignature*  returnArgument,
+                                              ILInstr**       instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
     if (FAILED(hr))
     {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
-    ModuleMetadata* module_metadata = GetMetadata();
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ModuleMetadata*    module_metadata = GetMetadata();
     GetTargetReturnValueTypeRef(returnArgument);
 
     // *** Define base MethodMemberRef for the type
@@ -436,13 +447,13 @@ HRESULT TracerTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTypeRe
     mdMemberRef endMethodMemberRef = mdMemberRefNil;
 
     unsigned callTargetReturnTypeRefBuffer;
-    auto callTargetReturnTypeRefSize = CorSigCompressToken(callTargetReturnTypeRef, &callTargetReturnTypeRefBuffer);
+    auto     callTargetReturnTypeRefSize = CorSigCompressToken(callTargetReturnTypeRef, &callTargetReturnTypeRefBuffer);
 
     unsigned exTypeRefBuffer;
-    auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
+    auto     exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
 
     unsigned callTargetStateBuffer;
-    auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
+    auto     callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
 
     auto signatureLength = 14 + callTargetReturnTypeRefSize + exTypeRefSize + callTargetStateSize;
     if (enable_calltarget_state_by_ref)
@@ -451,7 +462,7 @@ HRESULT TracerTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTypeRe
     }
 
     COR_SIGNATURE signature[signatureBufferSize];
-    unsigned offset = 0;
+    unsigned      offset = 0;
 
     signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
     signature[offset++] = 0x03;
@@ -497,19 +508,19 @@ HRESULT TracerTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTypeRe
     mdMethodSpec endMethodSpec = mdMethodSpecNil;
 
     unsigned integrationTypeBuffer;
-    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
 
-    bool isValueType = currentType->valueType;
+    bool    isValueType    = currentType->valueType;
     mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
 
     unsigned currentTypeBuffer;
-    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
 
     PCCOR_SIGNATURE returnSignatureBuffer;
-    auto returnSignatureLength = returnArgument->GetSignature(returnSignatureBuffer);
+    auto            returnSignatureLength = returnArgument->GetSignature(returnSignatureBuffer);
 
     signatureLength = 4 + integrationTypeSize + currentTypeSize + returnSignatureLength;
-    offset = 0;
+    offset          = 0;
 
     signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
     signature[offset++] = 0x03;
@@ -545,25 +556,27 @@ HRESULT TracerTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTypeRe
 }
 
 // write log exception
-HRESULT TracerTokens::WriteLogException(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
-                                            const TypeInfo* currentType, ILInstr** instruction)
+HRESULT TracerTokens::WriteLogException(void*           rewriterWrapperPtr,
+                                        mdTypeRef       integrationTypeRef,
+                                        const TypeInfo* currentType,
+                                        ILInstr**       instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
     if (FAILED(hr))
     {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
-    ModuleMetadata* module_metadata = GetMetadata();
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ModuleMetadata*    module_metadata = GetMetadata();
 
     if (logExceptionRef == mdMemberRefNil)
     {
         unsigned exTypeRefBuffer;
-        auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
+        auto     exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
 
-        auto signatureLength = 5 + exTypeRefSize;
+        auto          signatureLength = 5 + exTypeRefSize;
         COR_SIGNATURE signature[signatureBufferSize];
-        unsigned offset = 0;
+        unsigned      offset = 0;
 
         signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERIC;
         signature[offset++] = 0x02;
@@ -587,19 +600,19 @@ HRESULT TracerTokens::WriteLogException(void* rewriterWrapperPtr, mdTypeRef inte
     mdMethodSpec logExceptionMethodSpec = mdMethodSpecNil;
 
     unsigned integrationTypeBuffer;
-    ULONG integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
+    ULONG    integrationTypeSize = CorSigCompressToken(integrationTypeRef, &integrationTypeBuffer);
 
-    bool isValueType = currentType->valueType;
+    bool    isValueType    = currentType->valueType;
     mdToken currentTypeRef = GetCurrentTypeRef(currentType, isValueType);
 
     unsigned currentTypeBuffer;
-    ULONG currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
+    ULONG    currentTypeSize = CorSigCompressToken(currentTypeRef, &currentTypeBuffer);
 
-    auto signatureLength = 4 + integrationTypeSize + currentTypeSize;
+    auto          signatureLength = 4 + integrationTypeSize + currentTypeSize;
     COR_SIGNATURE signature[signatureBufferSize];
-    unsigned offset = 0;
-    signature[offset++] = IMAGE_CEE_CS_CALLCONV_GENERICINST;
-    signature[offset++] = 0x02;
+    unsigned      offset = 0;
+    signature[offset++]  = IMAGE_CEE_CS_CALLCONV_GENERICINST;
+    signature[offset++]  = 0x02;
 
     signature[offset++] = ELEMENT_TYPE_CLASS;
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.h
@@ -1,0 +1,46 @@
+#ifndef OTEL_CLR_PROFILER_TRACER_TOKENS_H_
+#define OTEL_CLR_PROFILER_TRACER_TOKENS_H_
+
+#include "calltarget_tokens.h"
+
+#define FASTPATH_COUNT 9
+
+namespace trace
+{
+
+class TracerTokens : public CallTargetTokens
+{
+private:
+    mdMemberRef beginArrayMemberRef = mdMemberRefNil;
+    mdMemberRef beginMethodFastPathRefs[FASTPATH_COUNT];
+    mdMemberRef endVoidMemberRef = mdMemberRefNil;
+    mdMemberRef logExceptionRef = mdMemberRefNil;
+
+    HRESULT WriteBeginMethodWithArgumentsArray(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
+                                               const TypeInfo* currentType, ILInstr** instruction);
+
+protected:
+    const WSTRING& GetCallTargetType() override;
+    const WSTRING& GetCallTargetStateType() override;
+    const WSTRING& GetCallTargetReturnType() override;
+    const WSTRING& GetCallTargetReturnGenericType() override;
+
+public:
+    TracerTokens(ModuleMetadata* module_metadata_ptr);
+
+    HRESULT WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef, const TypeInfo* currentType,
+                             const std::vector<TypeSignature>& methodArguments, ILInstr** instruction);
+
+    HRESULT WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
+                                        const TypeInfo* currentType, ILInstr** instruction);
+
+    HRESULT WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef, const TypeInfo* currentType,
+                                    TypeSignature* returnArgument, ILInstr** instruction);
+
+    HRESULT WriteLogException(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef, const TypeInfo* currentType,
+                              ILInstr** instruction);
+};
+
+} // namespace trace
+
+#endif // OTEL_CLR_PROFILER_TRACER_TOKENS_H_

--- a/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/tracer_tokens.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef OTEL_CLR_PROFILER_TRACER_TOKENS_H_
 #define OTEL_CLR_PROFILER_TRACER_TOKENS_H_
 


### PR DESCRIPTION
## Why

Towards #3074
Follow up #2280

## What

Update native code part based on https://github.com/DataDog/dd-trace-dotnet/compare/v2.3.0...v2.4.0
Continuous profile implementation in SignalFx/Splunk repository relays on changes from this upgrade. It is better to make upgrade first than downgrade donated code.

List of changes: 
* Use IsShutdownRequested to avoid recursive lock acquisition - https://github.com/DataDog/dd-trace-dotnet/commit/40d6d6a6883bf17e92d1d89f1c1041070275c27e
* Move EnumNgenModuleMethodsInliningThisMethod call from the background thread - https://github.com/DataDog/dd-trace-dotnet/commit/3ff5c498a74a6f3b7cc7e7b89d2763fca6cca912
* Add regression tests for running in partial trust environments - https://github.com/DataDog/dd-trace-dotnet/commit/9855be86bcb2f6ac47d634bc9f2222884480ed66 - adjusted to changes from https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/commit/909fe3e834723c9e2a605148e34ea5258a7df145
* Refactorings to avoid merge conflicts with the Live Debugger - https://github.com/DataDog/dd-trace-dotnet/commit/2d16f745b6a2be22e68e421bce8e4d29e009b1f3 - adsjusted by https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/commit/4d5167f5da8f93200ae7d3919e3bfda3b8a653fd#diff-8bf37bfc95dfd31f530857af76bf993aa717e988084918f54a228d2242ef39d6R171-R173 and dropped enableByRefInstrumentation and enableCallTargetStateByRef (always true)
* Refactor all EnumNgenModuleMethodsInliningThisMethod call sites - https://github.com/DataDog/dd-trace-dotnet/commit/579d5163a57a1d0af4505b420ecc056b0e2f34a8


Skipped https://github.com/DataDog/dd-trace-dotnet/commit/08d734ed98bafc449bd0719dd7a1b04e16e4b3f1 and https://github.com/DataDog/dd-trace-dotnet/commit/4fdd8a8bd107cd36bbaad62d803030f5e93a492d as together brings no changes. It will be part for further upgrade to v2.5.0 tag.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~

## Notes

@zacharycmontoya, please review and check if DataDog is fine with donating these changes.

While reviewing please consider to make commit by commit review, it should be easier.