### PR TITLE
Set service.name resource attribute before invoking the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
+- Set `service.name` resource attribute before invoking the plugin.
+
 ## [1.2.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.2.0)
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/ResourceConfigurator.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/ResourceConfigurator.cs
@@ -40,17 +40,17 @@ internal static class ResourceConfigurator
             };
         }
 
-        var pluginManager = Instrumentation.PluginManager;
-        if (pluginManager != null)
-        {
-            resourceBuilder.InvokePlugins(pluginManager);
-        }
-
         var resource = resourceBuilder.Build();
         if (!resource.Attributes.Any(kvp => kvp.Key == ServiceNameAttribute))
         {
             // service.name was not configured yet use the fallback.
             resourceBuilder.AddAttributes(new KeyValuePair<string, object>[] { new(ServiceNameAttribute, ServiceNameConfigurator.GetFallbackServiceName()) });
+        }
+
+        var pluginManager = Instrumentation.PluginManager;
+        if (pluginManager != null)
+        {
+            resourceBuilder.InvokePlugins(pluginManager);
         }
 
         return resourceBuilder;


### PR DESCRIPTION
## Why

From https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docs/plugins.md:

> You can use OTEL_DOTNET_AUTO_PLUGINS environment variable to extend the configuration and overwrite options of the OpenTelemetry .NET SDK Tracer, Meter or Logs.

The plugins should have access to all configuration done by OTel .NET Auto.

## What

Make sure to set the `service.name`  resource attribute before invoking the plugin.

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] ~~Documentation is updated.~~
- [ ] New features are covered by tests.
  - I am not sure if it is worth adding a test.
