### PR TITLE
Bump GraphQL to 7.7.2

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -53,7 +53,7 @@ public static class LibraryVersion
             new List<PackageBuildInfo>
             {
                 new("7.5.0", new() {{"GraphQLMicrosoftDI","7.5.0"},{"GraphQLServerTransportsAspNetCore","7.5.0"},{"GraphQLServerUIPlayground","7.5.0"}}),
-                new("7.6.1", new() {{"GraphQLMicrosoftDI","7.6.1"},{"GraphQLServerTransportsAspNetCore","7.6.0"},{"GraphQLServerUIPlayground","7.6.0"}}),
+                new("7.7.2", new() {{"GraphQLMicrosoftDI","7.7.2"},{"GraphQLServerTransportsAspNetCore","7.6.0"},{"GraphQLServerUIPlayground","7.6.0"}}),
             }
         },
         {

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -6,8 +6,8 @@
     <PackageVersion Include="Confluent.Kafka" Version="2.3.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.25.1" />
-    <PackageVersion Include="GraphQL" Version="7.6.1" />
-    <PackageVersion Include="GraphQL.MicrosoftDI" Version="7.6.1" />
+    <PackageVersion Include="GraphQL" Version="7.7.2" />
+    <PackageVersion Include="GraphQL.MicrosoftDI" Version="7.7.2" />
     <PackageVersion Include="GraphQL.Server.Transports.AspNetCore" Version="7.6.0" />
     <PackageVersion Include="GraphQL.Server.Ui.Playground" Version="7.6.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.59.0" />

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -56,7 +56,7 @@ public static class LibraryVersion
         new object[] { string.Empty }
 #else
         new object[] { "7.5.0" },
-        new object[] { "7.6.1" },
+        new object[] { "7.7.2" },
 #endif
     };
     public static readonly IReadOnlyCollection<object[]> GrpcNetClient = new List<object[]>

--- a/test/test-applications/integrations/TestApplication.GraphQL/StarWars/Types/DroidType.cs
+++ b/test/test-applications/integrations/TestApplication.GraphQL/StarWars/Types/DroidType.cs
@@ -21,8 +21,12 @@ public class DroidType : ObjectGraphType<Droid>
         Field<ListGraphType<CharacterInterface>>("friends")
             .Resolve(context => data.GetFriends(context.Source));
 
+#if GRAPHQL_7_7_OR_GREATER
+        Connection<CharacterInterface>("friendsConnection")
+#else
         Connection<CharacterInterface>()
             .Name("friendsConnection")
+#endif
             .Description("A list of a character's friends.")
             .Bidirectional()
             .Resolve(context => context.GetPagedResults<Droid, StarWarsCharacter>(data, context.Source.Friends));

--- a/test/test-applications/integrations/TestApplication.GraphQL/StarWars/Types/HumanType.cs
+++ b/test/test-applications/integrations/TestApplication.GraphQL/StarWars/Types/HumanType.cs
@@ -20,8 +20,12 @@ public class HumanType : ObjectGraphType<Human>
         Field<ListGraphType<CharacterInterface>>("friends")
             .Resolve(context => data.GetFriends(context.Source));
 
+#if GRAPHQL_7_7_OR_GREATER
+        Connection<CharacterInterface>("friendsConnection")
+#else
         Connection<CharacterInterface>()
             .Name("friendsConnection")
+#endif
             .Description("A list of a character's friends.")
             .Bidirectional()
             .Resolve(context => context.GetPagedResults<Human, StarWarsCharacter>(data, context.Source.Friends));

--- a/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
+++ b/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsCentos)' == '' ">net8.0;$(TargetFrameworks)</TargetFrameworks>
+    <DefineConstants Condition="'$(LibraryVersion)' == '' or '$(LibraryVersion)'>='7.7.0'">$(DefineConstants);GRAPHQL_7_7_OR_GREATER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why &  What

Bump GraphQL to 7.7.2.

It includes changes required by 7.7.0.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
