### PR TITLE
Sync LangVersion to 11

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -10,6 +10,7 @@
     <NukeScriptDirectory>..\</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Integrations.props
+++ b/test/test-applications/integrations/Integrations.props
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
 
     <BaseIntermediateOutputPath Condition="'$(LibraryVersion)'!=''">..\obj\$(MSBuildProjectName)\$(LibraryVersion)\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="'$(LibraryVersion)'==''">..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>


### PR DESCRIPTION
## Why

Handles discussion about https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3273#discussion_r1490759933

Fixes #

## What

Sync LangVersion to 11

it is the highest supported version by all of our build targets

## Tests

CI + locally checked if array literals are not longer possible compile with .NET SDK 8

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
