### PR TITLE
.NET - End of Support warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 
+- .NET only, warning in logs about End of Support date
+  and upcoming End of Support date for .NET version.
+
 ### Changed
 
 #### Dependency updates

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/EndOfSupportRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/EndOfSupportRule.cs
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
+
+internal class EndOfSupportRule : Rule
+{
+    private static readonly IOtelLogger Logger = OtelLogging.GetLogger("StartupHook");
+
+    public EndOfSupportRule()
+    {
+        Name = ".NET End of Support Validator";
+        Description = "Warns if application is executed on the framework expected to reach EoS withing 3 months.";
+    }
+
+    internal override bool Evaluate()
+    {
+        var netVersion = Environment.Version.Major;
+
+        // dates from https://dotnet.microsoft.com/en-us/download/dotnet
+        DateTime eosDate;
+        switch (netVersion)
+        {
+            case 6:
+                eosDate = new DateTime(2024, 11, 12);
+                break;
+            case 7:
+                eosDate = new DateTime(2024, 5, 14);
+                break;
+            case 8:
+                eosDate = new DateTime(2026, 11, 10);
+                break;
+            default:
+                return true; // just return, not abe to verify anything here
+        }
+
+        var now = DateTime.UtcNow;
+
+        if (now > eosDate)
+        {
+            Logger.Warning("Rule Engine: .NET{0} reached End Of Support on {1}. Automatic Instrumentation and .NET is no longer supported. Upgrade your .NET version.", netVersion, eosDate.ToShortDateString());
+        }
+        else if (now > eosDate.AddMonths(-3))
+        {
+            Logger.Warning("Rule Engine: .NET{0} will reach End Of Support on {1}. After that date Automatic Instrumentation and .NET will be no longer supported. Consider upgrading your .NET version.", netVersion, eosDate.ToShortDateString());
+        }
+
+        return true;
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuleEngine.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuleEngine.cs
@@ -12,7 +12,8 @@ internal class RuleEngine
     private readonly List<Rule> _mandatoryRules = new()
     {
         new ApplicationInExcludeListRule(),
-        new MinSupportedFrameworkRule()
+        new MinSupportedFrameworkRule(),
+        new EndOfSupportRule()
     };
 
     private readonly Lazy<List<Rule>> _optionalRules;


### PR DESCRIPTION
## Why

In this year, two version of .NET will reach [EoS](https://dotnet.microsoft.com/en-us/download/dotnet). It will be great to inform users about lack of support for Automatic Instrumentation.

Fixes #

## What

Warning logs for 2 cases:
 - EoS already reached.
 - EoS within 3 months.

Rule never fail. It is designed only to inform.

## Tests

Manual tests only, as we do not have good rule engine tests suite.

Output from `otel-dotnet-auto-TestApplication.Smoke-29596-StartupHook-20240222.log`

```log
[2024-02-22T06:46:51.9919966Z] [Debug] Rule Engine: dotnet.exe is not in the exclusion list. ApplicationInExcludeListRule evaluation success. 
[2024-02-22T06:46:52.0615671Z] [Information] Rule Engine: MinSupportedFrameworkRule evaluation success. 
[2024-02-22T06:46:52.0778687Z] [Warning] Rule Engine: .NET7 will reach End Of Support on 5/14/2024. After that date Automatic Instrumentation and .NET will be no longer supported. Consider upgrading your .NET version. 
[2024-02-22T06:46:52.1126651Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.configuration\8.0.0\lib\net8.0\Microsoft.Extensions.Configuration.dll is validated successfully. 
[2024-02-22T06:46:52.1190822Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.configuration.abstractions\8.0.0\lib\net8.0\Microsoft.Extensions.Configuration.Abstractions.dll is validated successfully. 
[2024-02-22T06:46:52.1244299Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.configuration.binder\8.0.0\lib\net8.0\Microsoft.Extensions.Configuration.Binder.dll is validated successfully. 
[2024-02-22T06:46:52.1320122Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.dependencyinjection\8.0.0\lib\net8.0\Microsoft.Extensions.DependencyInjection.dll is validated successfully. 
[2024-02-22T06:46:52.1395754Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.dependencyinjection.abstractions\8.0.0\lib\net8.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll is validated successfully. 
[2024-02-22T06:46:52.1464793Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.logging\8.0.0\lib\net8.0\Microsoft.Extensions.Logging.dll is validated successfully. 
[2024-02-22T06:46:52.1535163Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.logging.abstractions\8.0.0\lib\net8.0\Microsoft.Extensions.Logging.Abstractions.dll is validated successfully. 
[2024-02-22T06:46:52.1584344Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.logging.configuration\8.0.0\lib\net8.0\Microsoft.Extensions.Logging.Configuration.dll is validated successfully. 
[2024-02-22T06:46:52.1658594Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.options\8.0.0\lib\net8.0\Microsoft.Extensions.Options.dll is validated successfully. 
[2024-02-22T06:46:52.1715962Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.options.configurationextensions\8.0.0\lib\net8.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll is validated successfully. 
[2024-02-22T06:46:52.1788359Z] [Debug] Rule Engine: Runtime store assembly C:\GitHub\opentelemetry-dotnet-instrumentation\bin\tracer-home\store\x64\net7.0\microsoft.extensions.primitives\8.0.0\lib\net8.0\Microsoft.Extensions.Primitives.dll is validated successfully. 
[2024-02-22T06:46:52.1835107Z] [Information] Rule Engine: OpenTelemetrySdkMinimumVersionRule evaluation success. 
[2024-02-22T06:46:52.2558857Z] [Warning] CORECLR_ENABLE_PROFILING environment variable is not set to '1'. The CLR Profiler is disabled and no bytecode instrumentations are going to be injected. 
[2024-02-22T06:46:52.2600444Z] [Information] Initialization. 
[2024-02-22T06:46:52.8442346Z] [Information] StartupHook initialized successfully! 

```

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
