### PR TITLE
.NET - simplify code for taking .NET version

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetCore.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetCore.cs
@@ -29,9 +29,9 @@ internal partial class FrameworkDescription
             {
                 // RuntimeInformation.FrameworkDescription returns a string like ".NET Framework 4.7.2" or ".NET Core 2.1",
                 // we want to return everything before the last space
-                frameworkVersion = RuntimeInformation.FrameworkDescription;
-                var index = frameworkVersion.LastIndexOf(' ');
-                frameworkName = frameworkVersion.Substring(0, index).Trim();
+                var frameworkDescription = RuntimeInformation.FrameworkDescription;
+                var index = frameworkDescription.LastIndexOf(' ');
+                frameworkName = frameworkDescription.Substring(0, index).Trim();
             }
             catch (Exception e)
             {

--- a/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetCore.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetCore.cs
@@ -3,7 +3,6 @@
 
 #if NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 
 namespace OpenTelemetry.AutoInstrumentation;
 
@@ -31,7 +30,7 @@ internal partial class FrameworkDescription
                 // RuntimeInformation.FrameworkDescription returns a string like ".NET Framework 4.7.2" or ".NET Core 2.1",
                 // we want to return everything before the last space
                 frameworkVersion = RuntimeInformation.FrameworkDescription;
-                int index = frameworkVersion.LastIndexOf(' ');
+                var index = frameworkVersion.LastIndexOf(' ');
                 frameworkName = frameworkVersion.Substring(0, index).Trim();
             }
             catch (Exception e)
@@ -54,7 +53,7 @@ internal partial class FrameworkDescription
 
             osArchitecture = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
             processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-            frameworkVersion = GetNetCoreOrNetFrameworkVersion();
+            frameworkVersion = Environment.Version.ToString();
         }
         catch (Exception ex)
         {
@@ -67,54 +66,6 @@ internal partial class FrameworkDescription
             osPlatform: osPlatform,
             osArchitecture: osArchitecture,
             processArchitecture: processArchitecture);
-    }
-
-    private static string GetNetCoreOrNetFrameworkVersion()
-    {
-        string? productVersion = null;
-
-        if (Environment.Version.Major == 3 || Environment.Version.Major >= 5)
-        {
-            // Environment.Version returns "4.x" in .NET Core 2.x,
-            // but it is correct since .NET Core 3.0.0
-            productVersion = Environment.Version.ToString();
-        }
-
-        if (productVersion == null)
-        {
-            try
-            {
-                // try to get product version from assembly path
-                Match match = Regex.Match(
-                    RootAssembly.Location,
-                    @"/[^/]*microsoft\.netcore\.app/(\d+\.\d+\.\d+[^/]*)/",
-                    RegexOptions.IgnoreCase);
-
-                if (match.Success && match.Groups.Count > 0 && match.Groups[1].Success)
-                {
-                    productVersion = match.Groups[1].Value;
-                }
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Error getting .NET Core version from assembly path");
-            }
-        }
-
-        if (productVersion == null)
-        {
-            // if we fail to extract version from assembly path,
-            // fall back to the [AssemblyInformationalVersion] or [AssemblyFileVersion]
-            productVersion = GetVersionFromAssemblyAttributes();
-        }
-
-        if (productVersion == null)
-        {
-            // at this point, everything else has failed (this is probably the same as [AssemblyFileVersion] above)
-            productVersion = Environment.Version.ToString();
-        }
-
-        return productVersion;
     }
 }
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetFramework.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.NetFramework.cs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
+using System.Reflection;
 using Microsoft.Win32;
 
 namespace OpenTelemetry.AutoInstrumentation;
 
 internal partial class FrameworkDescription
 {
+    private static readonly Assembly RootAssembly = typeof(object).Assembly;
+
     private static readonly Tuple<int, string>[] DotNetFrameworkVersionMapping =
     {
         // known min value for each framework version
@@ -92,6 +95,40 @@ internal partial class FrameworkDescription
         {
             // at this point, everything else has failed (this is probably the same as [AssemblyFileVersion] above)
             productVersion = Environment.Version.ToString();
+        }
+
+        return productVersion;
+    }
+
+    private static string? GetVersionFromAssemblyAttributes()
+    {
+        string? productVersion = null;
+
+        try
+        {
+            // if we fail to extract version from assembly path, fall back to the [AssemblyInformationalVersion],
+            var informationalVersionAttribute = RootAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+            // split remove the commit hash from pre-release versions
+            productVersion = informationalVersionAttribute?.InformationalVersion?.Split('+')[0];
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Error getting framework version from [AssemblyInformationalVersion]");
+        }
+
+        if (productVersion == null)
+        {
+            try
+            {
+                // and if that fails, try [AssemblyFileVersion]
+                var fileVersionAttribute = RootAssembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+                productVersion = fileVersionAttribute?.Version;
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Error getting framework version from [AssemblyFileVersion]");
+            }
         }
 
         return productVersion;

--- a/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/FrameworkDescription.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Reflection;
 using OpenTelemetry.AutoInstrumentation.Logging;
 
 namespace OpenTelemetry.AutoInstrumentation;
@@ -9,8 +8,6 @@ namespace OpenTelemetry.AutoInstrumentation;
 internal partial class FrameworkDescription
 {
     private static readonly IOtelLogger Log = OtelLogging.GetLogger();
-
-    private static readonly Assembly RootAssembly = typeof(object).Assembly;
 
     private FrameworkDescription(
         string name,
@@ -42,39 +39,5 @@ internal partial class FrameworkDescription
         // .NET Framework 4.8 x86 on Windows x64
         // .NET Core 3.0.0 x64 on Linux x64
         return $"{Name} {ProductVersion} {ProcessArchitecture} on {OSPlatform} {OSArchitecture}";
-    }
-
-    private static string? GetVersionFromAssemblyAttributes()
-    {
-        string? productVersion = null;
-
-        try
-        {
-            // if we fail to extract version from assembly path, fall back to the [AssemblyInformationalVersion],
-            var informationalVersionAttribute = RootAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-
-            // split remove the commit hash from pre-release versions
-            productVersion = informationalVersionAttribute?.InformationalVersion?.Split('+')[0];
-        }
-        catch (Exception e)
-        {
-            Log.Error(e, "Error getting framework version from [AssemblyInformationalVersion]");
-        }
-
-        if (productVersion == null)
-        {
-            try
-            {
-                // and if that fails, try [AssemblyFileVersion]
-                var fileVersionAttribute = RootAssembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
-                productVersion = fileVersionAttribute?.Version;
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Error getting framework version from [AssemblyFileVersion]");
-            }
-        }
-
-        return productVersion;
     }
 }


### PR DESCRIPTION
## Why

Cleanup code.

## What

`OpenTelemetry.AutomaticInstrumentation` is targeted for .NET6 and .NET Fx 4.6.2.
This file, is conditionally compile for .NET6+. No chance to have values lower than 6 here.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
