### PR TITLE
[Continuous profiler] drop tracking managed thread id

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
@@ -256,7 +256,6 @@ void ThreadSamplesBuffer::StartSample(ThreadID                   id,
 {
     CHECK_SAMPLES_BUFFER_LENGTH()
     WriteByte(kThreadSamplesStartSample);
-    WriteInt(span_context.managed_thread_id_);
     WriteString(state->thread_name_);
     WriteUInt64(span_context.trace_id_high_);
     WriteUInt64(span_context.trace_id_low_);
@@ -277,7 +276,6 @@ void ThreadSamplesBuffer::AllocationSample(uint64_t                   allocSize,
     WriteCurrentTimeMillis();
     WriteUInt64(allocSize);
     WriteString(allocType, allocTypeCharLen);
-    WriteInt(span_context.managed_thread_id_);
     WriteString(state->thread_name_);
     WriteUInt64(span_context.trace_id_high_);
     WriteUInt64(span_context.trace_id_low_);
@@ -1055,10 +1053,7 @@ EXPORTTHIS int32_t ContinuousProfilerReadAllocationSamples(int32_t len, unsigned
 {
     return AllocationSamplingConsumeAndReplaceBuffer(len, buf);
 }
-EXPORTTHIS void ContinuousProfilerSetNativeContext(uint64_t traceIdHigh,
-                                                   uint64_t traceIdLow,
-                                                   uint64_t spanId,
-                                                   int32_t  managedThreadId)
+EXPORTTHIS void ContinuousProfilerSetNativeContext(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId)
 {
     ThreadID      threadId;
     const HRESULT hr = profiler_info->GetCurrentThreadID(&threadId);
@@ -1070,7 +1065,6 @@ EXPORTTHIS void ContinuousProfilerSetNativeContext(uint64_t traceIdHigh,
 
     std::lock_guard<std::mutex> guard(thread_span_context_lock);
 
-    thread_span_context_map[threadId] =
-        continuous_profiler::thread_span_context(traceIdHigh, traceIdLow, spanId, managedThreadId);
+    thread_span_context_map[threadId] = continuous_profiler::thread_span_context(traceIdHigh, traceIdLow, spanId);
 }
 }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
@@ -16,8 +16,6 @@
 #include <unordered_map>
 #include <random>
 
-constexpr auto unknown_managed_thread_id = -1;
-
 #ifdef _WIN32
 #define EXPORTTHIS __declspec(dllexport)
 #else
@@ -29,7 +27,7 @@ extern "C"
     EXPORTTHIS int32_t ContinuousProfilerReadThreadSamples(int32_t len, unsigned char* buf);
     EXPORTTHIS int32_t ContinuousProfilerReadAllocationSamples(int32_t len, unsigned char* buf);
     // ReSharper disable CppInconsistentNaming
-    EXPORTTHIS void ContinuousProfilerSetNativeContext(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId, int32_t managedThreadId);
+    EXPORTTHIS void ContinuousProfilerSetNativeContext(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId);
     // ReSharper restore CppInconsistentNaming
 }
 
@@ -59,17 +57,16 @@ public:
     uint64_t trace_id_high_;
     uint64_t trace_id_low_;
     uint64_t span_id_;
-    int32_t managed_thread_id_;
 
-    thread_span_context() : trace_id_high_(0), trace_id_low_(0), span_id_(0), managed_thread_id_(unknown_managed_thread_id)
+    thread_span_context() : trace_id_high_(0), trace_id_low_(0), span_id_(0)
     {
     }
-    thread_span_context(uint64_t _traceIdHigh, uint64_t _traceIdLow, uint64_t _spanId, int32_t managedThreadId) :
-        trace_id_high_(_traceIdHigh), trace_id_low_(_traceIdLow), span_id_(_spanId), managed_thread_id_(managedThreadId)
+    thread_span_context(uint64_t _traceIdHigh, uint64_t _traceIdLow, uint64_t _spanId) :
+        trace_id_high_(_traceIdHigh), trace_id_low_(_traceIdLow), span_id_(_spanId)
     {
     }
     thread_span_context(thread_span_context const& other) :
-        trace_id_high_(other.trace_id_high_), trace_id_low_(other.trace_id_low_), span_id_(other.span_id_), managed_thread_id_(other.managed_thread_id_)
+        trace_id_high_(other.trace_id_high_), trace_id_low_(other.trace_id_low_), span_id_(other.span_id_)
     {
     }
 };

--- a/src/OpenTelemetry.AutoInstrumentation/ContinuousProfiler/ContinuousProfilerProcessor.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/ContinuousProfiler/ContinuousProfilerProcessor.cs
@@ -69,7 +69,6 @@ internal static class ContinuousProfilerProcessor
     private static void ActivityChanged(AsyncLocalValueChangedArgs<Activity?> sender)
     {
         var currentActivity = sender.CurrentValue;
-        var managedThreadId = Environment.CurrentManagedThreadId;
 
         if (currentActivity != null)
         {
@@ -79,12 +78,12 @@ internal static class ContinuousProfilerProcessor
                 ulong.TryParse(hexTraceId.AsSpan(16), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var traceIdLow) &&
                 ulong.TryParse(currentActivity.SpanId.ToHexString(), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var spanId))
             {
-                NativeMethods.ContinuousProfilerSetNativeContext(traceIdHigh, traceIdLow, spanId, managedThreadId);
+                NativeMethods.ContinuousProfilerSetNativeContext(traceIdHigh, traceIdLow, spanId);
                 return;
             }
         }
 
-        NativeMethods.ContinuousProfilerSetNativeContext(0, 0, 0, managedThreadId);
+        NativeMethods.ContinuousProfilerSetNativeContext(0, 0, 0);
     }
 
     private static void SampleReadingThread(BufferProcessor sampleExporter, TimeSpan exportInterval)

--- a/src/OpenTelemetry.AutoInstrumentation/NativeMethods.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/NativeMethods.cs
@@ -66,15 +66,15 @@ internal static class NativeMethods
         return IsWindows ? Windows.ContinuousProfilerReadAllocationSamples(len, buf) : NonWindows.ContinuousProfilerReadAllocationSamples(len, buf);
     }
 
-    public static void ContinuousProfilerSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId, int managedThreadId)
+    public static void ContinuousProfilerSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId)
     {
         if (IsWindows)
         {
-            Windows.ContinuousProfilerSetNativeContext(traceIdHigh, traceIdLow, spanId, managedThreadId);
+            Windows.ContinuousProfilerSetNativeContext(traceIdHigh, traceIdLow, spanId);
         }
         else
         {
-            NonWindows.ContinuousProfilerSetNativeContext(traceIdHigh, traceIdLow, spanId, managedThreadId);
+            NonWindows.ContinuousProfilerSetNativeContext(traceIdHigh, traceIdLow, spanId);
         }
     }
 #endif
@@ -101,7 +101,7 @@ internal static class NativeMethods
         public static extern int ContinuousProfilerReadAllocationSamples(int len, byte[] buf);
 
         [DllImport("OpenTelemetry.AutoInstrumentation.Native.dll")]
-        public static extern void ContinuousProfilerSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId, int managedThreadId);
+        public static extern void ContinuousProfilerSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId);
 #endif
     }
 
@@ -125,7 +125,7 @@ internal static class NativeMethods
         public static extern int ContinuousProfilerReadAllocationSamples(int len, byte[] buf);
 
         [DllImport("OpenTelemetry.AutoInstrumentation.Native")]
-        public static extern void ContinuousProfilerSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId, int managedThreadId);
+        public static extern void ContinuousProfilerSetNativeContext(ulong traceIdHigh, ulong traceIdLow, ulong spanId);
 #endif
     }
 }

--- a/test/IntegrationTests/ContinuousProfilerContextTrackingTests.cs
+++ b/test/IntegrationTests/ContinuousProfilerContextTrackingTests.cs
@@ -30,7 +30,7 @@ public class ContinuousProfilerContextTrackingTests : TestHelper
         var batchSeparator = $"{Environment.NewLine}{Environment.NewLine}";
 
         var totalSamplesWithTraceContextCount = 0;
-        var managedThreadsWithTraceContext = new HashSet<int>();
+        var managedThreadsWithTraceContext = new HashSet<string>();
 
         var exportedSampleBatches = standardOutput.TrimEnd().Split(batchSeparator);
 
@@ -53,7 +53,7 @@ public class ContinuousProfilerContextTrackingTests : TestHelper
             totalSamplesWithTraceContextCount += samplesWithTraceContext.Count;
             if (samplesWithTraceContext.FirstOrDefault() is { } sampleWithTraceContext)
             {
-                managedThreadsWithTraceContext.Add(GetPropertyValue("ManagedId", sampleWithTraceContext).GetInt32());
+                managedThreadsWithTraceContext.Add(GetPropertyValue("ThreadName", sampleWithTraceContext).GetString()!);
             }
         }
 
@@ -64,12 +64,11 @@ public class ContinuousProfilerContextTrackingTests : TestHelper
     private static bool HasTraceContextAssociated(List<JsonProperty> sample)
     {
         const int defaultTraceContextValue = 0;
-        const int defaultManagedThreadIdValue = -1;
 
         return GetPropertyValue("SpanId", sample).GetInt64() != defaultTraceContextValue &&
                GetPropertyValue("TraceIdHigh", sample).GetInt64() != defaultTraceContextValue &&
                GetPropertyValue("TraceIdLow", sample).GetInt64() != defaultTraceContextValue &&
-               GetPropertyValue("ManagedId", sample).GetInt32() != defaultManagedThreadIdValue;
+               !string.IsNullOrWhiteSpace(GetPropertyValue("ThreadName", sample).GetString());
     }
 
     private static JsonElement GetPropertyValue(string propertyName, List<JsonProperty> jsonProperties)

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler.ContextTracking/Program.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler.ContextTracking/Program.cs
@@ -11,6 +11,7 @@ internal class Program
 
     public static async Task Main(string[] args)
     {
+        Thread.CurrentThread.Name = "TestName";
         // Start an activity that remains active until async operation completes,
         // and verify that trace context flows properly between threads that carry out parts of the async operation.
         using var activity = Source.StartActivity();

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/SampleNativeFormatParser.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/SampleNativeFormatParser.cs
@@ -60,7 +60,6 @@ internal static class SampleNativeFormatParser
                 }
                 else if (operationCode == OpCodes.StartSample)
                 {
-                    var managedId = ReadInt(buffer, ref position);
                     var threadName = ReadString(buffer, ref position);
                     var traceIdHigh = ReadInt64(buffer, ref position);
                     var traceIdLow = ReadInt64(buffer, ref position);
@@ -80,7 +79,6 @@ internal static class SampleNativeFormatParser
                         traceIdHigh,
                         traceIdLow,
                         spanId,
-                        managedId,
                         threadName,
                         threadIndex);
 
@@ -154,7 +152,6 @@ internal static class SampleNativeFormatParser
                     var timestampMillis = ReadInt64(buffer, ref position);
                     var allocatedSize = ReadInt64(buffer, ref position); // Technically uint64 but whatever
                     var typeName = ReadString(buffer, ref position);
-                    var managedId = ReadInt(buffer, ref position);
                     var threadName = ReadString(buffer, ref position);
                     var traceIdHigh = ReadInt64(buffer, ref position);
                     var traceIdLow = ReadInt64(buffer, ref position);
@@ -165,7 +162,6 @@ internal static class SampleNativeFormatParser
                         traceIdHigh,
                         traceIdLow,
                         spanId,
-                        managedId,
                         threadName);
 
                     var code = ReadShort(buffer, ref position);

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/ThreadSample.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/ThreadSample.cs
@@ -5,13 +5,12 @@ namespace TestApplication.ContinuousProfiler;
 
 internal class ThreadSample
 {
-    public ThreadSample(Time timestamp, long traceIdHigh, long traceIdLow, long spanId, int managedId, string? threadName, uint threadIndex = default)
+    public ThreadSample(Time timestamp, long traceIdHigh, long traceIdLow, long spanId, string? threadName, uint threadIndex = default)
     {
         Timestamp = timestamp;
         TraceIdHigh = traceIdHigh;
         TraceIdLow = traceIdLow;
         SpanId = spanId;
-        ManagedId = managedId;
         ThreadName = threadName;
         ThreadIndex = threadIndex;
     }
@@ -23,8 +22,6 @@ internal class ThreadSample
     public long TraceIdHigh { get; }
 
     public long TraceIdLow { get; }
-
-    public int ManagedId { get; }
 
     public string? ThreadName { get; }
 


### PR DESCRIPTION
## Why

This property is unreliable, especially as long as on new Activity was not set on the particular thread.
Not used in on any of known scenarios.

## What

Drop tracking managed thread id.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
