### PR TITLE
Add a test-jobs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,5 +241,5 @@ jobs:
           test ${{ needs.test-build-native.result }} == "success"
           echo ${{ needs.test-build-container.result }}
           test ${{ needs.test-build-container.result }} == "success"
-          echo ${{ needs.test-build-nuget.result }}
-          test ${{ needs.test-build-nuget.result }} == "success"
+          echo ${{ needs.test-nuget-packages.result }}
+          test ${{ needs.test-nuget-packages.result }} == "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,3 +224,22 @@ jobs:
 
       - name: Test NuGet Packages
         run: ./build.cmd TestNuGetPackages
+
+  test-jobs:
+    runs-on: ubuntu-20.04
+    needs:
+      - test-build-managed
+      - test-build-native
+      - test-build-container
+      - test-nuget-packages
+    steps:
+      - name: Test if test jobs passed
+        run: |
+          echo ${{ needs.test-build-managed.result }}
+          test ${{ needs.test-build-managed.result }} == "success"
+          echo ${{ needs.test-build-native.result }}
+          test ${{ needs.test-build-native.result }} == "success"
+          echo ${{ needs.test-build-container.result }}
+          test ${{ needs.test-build-container.result }} == "success"
+          echo ${{ needs.test-build-nuget.result }}
+          test ${{ needs.test-build-nuget.result }} == "success"


### PR DESCRIPTION
## Why

To reduce the number of times we need to update the branch protection rules e.g. for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3277

## What

Add a `test-jobs` job that waits for all test jobs to succeed. 

Inspired by https://github.com/open-telemetry/opentelemetry-go/blob/fe9bab54b7a1852da0001b91ec37a417e96d8e7c/.github/workflows/ci.yml#L136-L143

