### PR TITLE
Fix logs paths and filenames

### DIFF
--- a/build/Build.InstallationScripts.Steps.cs
+++ b/build/Build.InstallationScripts.Steps.cs
@@ -15,7 +15,7 @@ partial class Build
             foreach (var templateFile in templateFiles)
             {
                 var scriptFile = InstallationScriptsDirectory / templateFile.Name.Replace(".template", "");
-                FileSystemTasks.CopyFile(templateFile, scriptFile);
+                FileSystemTasks.CopyFile(templateFile, scriptFile, FileExistsPolicy.Overwrite);
                 scriptFile.UpdateText(x =>
                     x.Replace("{{VERSION}}", VersionHelper.GetVersion()));
             }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/logger.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/logger.h
@@ -17,7 +17,7 @@ namespace trace
 
 struct TracerLoggerPolicy
 {
-    inline static const std::string file_name = "otel-dotnet-auto-native";
+    inline static const std::string file_name = "otel-dotnet-auto-";
 #ifdef _WIN32
     // this field will be removed once merged with the profiler in order to have
     // the same product folder name

--- a/src/OpenTelemetry.AutoInstrumentation.Native/logger_impl.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/logger_impl.h
@@ -137,7 +137,7 @@ LoggerImpl<TLoggerPolicy>::LoggerImpl()
         current_process_name.substr(0, current_process_name.find_last_of("."));
 
     static auto file_name_suffix =
-        "-" + current_process_without_extension + "-" + std::to_string(current_process_id);
+        std::to_string(current_process_id) + "-" + current_process_without_extension + "-Native";
 
     // by default, use the same size as on managed side: 10MiB
     static auto file_size        = GetConfiguredSize(environment::max_log_file_size, 10485760);

--- a/src/OpenTelemetry.AutoInstrumentation/Logging/OtelLogging.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Logging/OtelLogging.cs
@@ -27,7 +27,8 @@ internal static class OtelLogging
     /// <returns>Logger</returns>
     public static IOtelLogger GetLogger()
     {
-        return GetLogger(string.Empty);
+        // Default to managed logs
+        return GetLogger("Managed");
     }
 
     /// <summary>
@@ -126,11 +127,11 @@ internal static class OtelLogging
         try
         {
             using var process = Process.GetCurrentProcess();
-            var appDomainName = AppDomain.CurrentDomain.FriendlyName;
+            var appDomainName = GetEncodedAppDomainName();
 
             return string.IsNullOrEmpty(suffix)
-                ? $"otel-dotnet-auto-{appDomainName}-{process.Id}-.log"
-                : $"otel-dotnet-auto-{appDomainName}-{process.Id}-{suffix}-.log";
+                ? $"otel-dotnet-auto-{process.Id}-{appDomainName}-.log"
+                : $"otel-dotnet-auto-{process.Id}-{appDomainName}-{suffix}-.log";
         }
         catch
         {
@@ -139,6 +140,15 @@ internal static class OtelLogging
                 ? $"otel-dotnet-auto-{Guid.NewGuid()}-.log"
                 : $"otel-dotnet-auto-{Guid.NewGuid()}-{suffix}-.log";
         }
+    }
+
+    private static string GetEncodedAppDomainName()
+    {
+        var name = AppDomain.CurrentDomain.FriendlyName;
+        return name
+            .Replace(Path.DirectorySeparatorChar, '-')
+            .Replace(Path.AltDirectorySeparatorChar, '-')
+            .Trim('-');
     }
 
     private static string? GetLogDirectory()

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -432,7 +432,7 @@ public class SmokeTests : TestHelper
         {
             RunTestApplication();
 
-            var nativeLog = tempLogsDirectory.GetFiles("otel-dotnet-auto-native-*").Single();
+            var nativeLog = tempLogsDirectory.GetFiles("otel-dotnet-auto-*-Native.log").Single();
             var nativeLogContent = File.ReadAllText(nativeLog.FullName);
             nativeLogContent.Should().NotBeNullOrWhiteSpace();
 


### PR DESCRIPTION
## Why

Fixes #3312

## What

* Fixes .NET Fx IIS managed logs path
* Fixes logs grouping
* Adds `Managed` marker for managed logs (simplifies filtering)

minor sidefix:
* does not fail Nuke build task when script files already exist.

## Tests

Existing.

Result >
![image](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/assets/4929112/8fe70516-baf1-470f-b690-1f8126d116a6)

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
