### PR TITLE
Update store diagnostic rule architecture check

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuntimeStoreDiagnosticRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/RuntimeStoreDiagnosticRule.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using OpenTelemetry.AutoInstrumentation.Logging;
 
 namespace OpenTelemetry.AutoInstrumentation.RulesEngine;
@@ -114,7 +115,13 @@ internal class RuntimeStoreDiagnosticRule : Rule
                 return null;
             }
 
-            var architecture = Environment.Is64BitProcess ? "x64" : "x86";
+            var architecture = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X86 => "x86",
+                Architecture.Arm64 => "arm64",
+                _ => "x64" // Default to x64 for architectures not explicitly handled
+            };
+
             var targetFramework = $"net{Environment.Version.Major}.{Environment.Version.Minor}";
             var finalPath = Path.Combine(storeDirectory, architecture, targetFramework);
 


### PR DESCRIPTION
## Why

Fixes #3347

## What

Follow up to #3343. Enables diagnostic check for arm64 store.

## Tests

Existing.

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
