### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v1.4.0..HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v1.5.0..HEAD)
+
+### Added
+
+### Changed
+
+#### Dependency updates
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [1.5.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.5.0)
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
   [`1.8.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.8.0)
@@ -54,10 +68,6 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `Microsoft.Extensions.Logging.Abstractions` from `8.0.0` to `8.0.1`,
   - `OpenTelemetry.Instrumentation.AspNet` from `1.7.0-beta.2` to `1.8.0-beta.1`,
   - `System.Text.Json` from `8.0.1` to `8.0.3`.
-
-### Deprecated
-
-### Removed
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `OpenTelemetry.Instrumentation.Quartz` from `1.0.0-beta.1` to `1.0.0-beta.2`,
   - `OpenTelemetry.Instrumentation.Runtime` from `1.7.0` to `1.8.0`,
   - `OpenTelemetry.Instrumentation.SqlClient` from `1.7.0-beta.1` to `1.8.0-beta.1`,
-  - `OpenTelemetry.Instrumentation.StackExchangeRedis` from `1.0.0-rc9.14` to `1.0.0-rc9.14`,
+  - `OpenTelemetry.Instrumentation.StackExchangeRedis` from `1.0.0-rc9.13` to `1.0.0-rc9.14`,
   - `OpenTelemetry.Instrumentation.Wcf` from `1.0.0-rc.15` to `1.0.0-rc.16`,
   - `OpenTelemetry.ResourceDetectors.Azure` from `1.0.0-beta.5` to `1.0.0-beta.6`,
   - `OpenTelemetry.ResourceDetectors.Host` from `0.1.0-alpha.2` to `0.1.0-alpha.3`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,9 +13,9 @@ to .NET applications without having to modify their source code.
 > [!WARNING]
 > The following documentation refers to the in-development version
 of OpenTelemetry .NET Automatic Instrumentation. Docs for the latest version
-([1.4.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
+([1.5.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
 can be found in [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/languages/net/automatic)
-or [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.4.0/docs/README.md).
+or [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.5.0/docs/README.md).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,7 +169,7 @@ Example usage:
 
 ```sh
 # Download the bash script
-curl -sSfL https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.4.0/otel-dotnet-auto-install.sh -O
+curl -sSfL https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.5.0/otel-dotnet-auto-install.sh -O
 
 # Install core files
 sh ./otel-dotnet-auto-install.sh
@@ -193,7 +193,7 @@ uses environment variables as parameters:
 | `OS_TYPE`               | Possible values: `linux-glibc`, `linux-musl`, `macos`, `windows` | No       | *Calculated*              |
 | `ARCHITECTURE`          | Possible values for Linux: `x64`, `arm64`                        | No       | *Calculated*              |
 | `TMPDIR`                | Temporary directory used when downloading the files              | No       | `$(mktemp -d)`            |
-| `VERSION`               | Version to download                                              | No       | `1.4.0`                   |
+| `VERSION`               | Version to download                                              | No       | `1.5.0`                   |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -213,7 +213,7 @@ Example usage (run as administrator):
 
 ```powershell
 # Download the module
-$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.4.0/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.5.0/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,7 +62,7 @@ When adding the NuGet packages to your project you get an error message similar
 to:
 
 ```txt
-Could not install package 'OpenTelemetry.AutoInstrumentation.Runtime.Native 1.4.0'. You are trying to install this package into a project that targets '.NETFramework,Version=v4.7.2', but the package does not contain any assembly references or content files that are compatible with that framework. For more information, contact the package author.
+Could not install package 'OpenTelemetry.AutoInstrumentation.Runtime.Native 1.5.0'. You are trying to install this package into a project that targets '.NETFramework,Version=v4.7.2', but the package does not contain any assembly references or content files that are compatible with that framework. For more information, contact the package author.
 ```
 
 #### Solution

--- a/docs/using-the-nuget-packages.md
+++ b/docs/using-the-nuget-packages.md
@@ -40,7 +40,7 @@ you to either add the missing instrumentation package or to skip the
 instrumentation of the corresponding package:
 
 ```terminal
-~packages/opentelemetry.autoinstrumentation.buildtasks/1.4.0/build/OpenTelemetry.AutoInstrumentation.BuildTasks.targets(29,5): error : OpenTelemetry.AutoInstrumentation: add a reference to the instrumentation package 'MongoDB.Driver.Core.Extensions.DiagnosticSources' version 1.4.0 or add 'MongoDB.Driver.Core' to the property 'SkippedInstrumentations' to suppress this error.
+~packages/opentelemetry.autoinstrumentation.buildtasks/1.5.0/build/OpenTelemetry.AutoInstrumentation.BuildTasks.targets(29,5): error : OpenTelemetry.AutoInstrumentation: add a reference to the instrumentation package 'MongoDB.Driver.Core.Extensions.DiagnosticSources' version 1.4.0 or add 'MongoDB.Driver.Core' to the property 'SkippedInstrumentations' to suppress this error.
 ```
 
 To resolve the error either add the recommended instrumentation package or skip


### PR DESCRIPTION
## Why & What

Release 1.5.0

- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components): [`1.8.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.8.0)
- `System.Diagnostics.DiagnosticSource`: [`8.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/8.0.0)

### Added

- .NET only, warning in logs about End of Support date and upcoming End of Support date for .NET version.
- Experimental support for ARM64 on Ubuntu, Alpine and Debian based images.
- Experimental ARM64 support for the `OpenTelemetry.AutoInstrumentation` NuGet package.

### Changed

- Changed supported method parameters for plugins
  - from `OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions` to `OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions`.

#### Dependency updates

- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components): [`1.8.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.8.0).
- Following packages updated
  - `MongoDB.Driver.Core.Extensions.DiagnosticSources` from `1.3.0` to `1.4.0`.
  - `OpenTelemetry.Exporter.Prometheus.HttpListener` from `1.7.0-rc.1` to `1.8.0-rc.1`,
  - `OpenTelemetry.Instrumentation.Http` from `1.7.1` to `1.8.0`,
  - `OpenTelemetry.Instrumentation.Process` from `0.5.0-beta.4` to `0.5.0-beta.5`,
  - `OpenTelemetry.Instrumentation.Quartz` from `1.0.0-beta.1` to `1.0.0-beta.2`,
  - `OpenTelemetry.Instrumentation.Runtime` from `1.7.0` to `1.8.0`,
  - `OpenTelemetry.Instrumentation.SqlClient` from `1.7.0-beta.1` to `1.8.0-beta.1`,
  - `OpenTelemetry.Instrumentation.StackExchangeRedis` from `1.0.0-rc9.14` to `1.0.0-rc9.14`,
  - `OpenTelemetry.Instrumentation.Wcf` from `1.0.0-rc.15` to `1.0.0-rc.16`,
  - `OpenTelemetry.ResourceDetectors.Azure` from `1.0.0-beta.5` to `1.0.0-beta.6`,
  - `OpenTelemetry.ResourceDetectors.Host` from `0.1.0-alpha.2` to `0.1.0-alpha.3`.
  - `OpenTelemetry.ResourceDetectors.Process` from `0.1.0-alpha.2` to `0.1.0-alpha.3`.
  - `OpenTelemetry.ResourceDetectors.ProcessRuntime` from `0.1.0-alpha.2` to `0.1.0-alpha.3`.
- .NET only, following packages updated
  - `OpenTelemetry.Instrumentation.AspNetCore` from `1.7.1` to `1.8.0`,
  - `OpenTelemetry.Instrumentation.EntityFrameworkCore` from `1.0.0-beta.10` to `1.0.0-beta.11`,
  - `OpenTelemetry.ResourceDetectors.Container` from `1.0.0-beta.6` to `1.0.0-beta.7`.
- .NET Framework only, following packages updated
  - `Google.Protobuf` updated from `3.25.2` to `3.26.1`,
  - `Grpc.Core.Api` from `2.60.0` to `2.62.0`,
  - `Microsoft.Extensions.DependencyInjection.Abstractions` from `8.0.0` to `8.0.1`,
  - `Microsoft.Extensions.Options` from `8.0.1` to `8.0.2`,
  - `Microsoft.Extensions.Logging.Abstractions` from `8.0.0` to `8.0.1`,
  - `OpenTelemetry.Instrumentation.AspNet` from `1.7.0-beta.2` to `1.8.0-beta.1`,
  - `System.Text.Json` from `8.0.1` to `8.0.3`.

### Fixed

- Resolved a crash issue caused by `System.IO.FileLoadException` for `Microsoft.Extensions*.dll` libraries. This issue was due to a conflict with runtime store libraries, impacting applications with mismatched dependency versions. This fix enhances stability by addressing the underlying compatibility concerns. For details see: ([#3075](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3075), [#3075](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/3168))

## Tests

- [x] CI
- [x] MacOS with Linux Containers
- [x] Windows with Linux Containers

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.
