### PR TITLE
[kafka] BUG - stop creating spans on empty reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
+- Stop creating `receive` consumer spans for consume attempts that returned no message.
+
 ## [1.5.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.5.0)
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerConsumeSyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerConsumeSyncIntegration.cs
@@ -46,13 +46,16 @@ public static class ConsumerConsumeSyncIntegration
             consumeResult = response == null ? null : response.DuckAs<IConsumeResult>();
         }
 
-        var activity = KafkaInstrumentation.StartConsumerActivity(consumeResult, (DateTimeOffset)state.StartTime!, instance!);
-        if (exception is not null)
+        if (consumeResult is not null)
         {
-            activity.SetException(exception);
-        }
+            var activity = KafkaInstrumentation.StartConsumerActivity(consumeResult, (DateTimeOffset)state.StartTime!, instance!);
+            if (exception is not null)
+            {
+                activity.SetException(exception);
+            }
 
-        activity?.Stop();
+            activity?.Stop();
+        }
 
         return new CallTargetReturn<TResponse>(response);
     }


### PR DESCRIPTION
## Why

When `Consume` is called without timeout specified (e.g either with `CancellationToken`, or with no params), spans will be generated, by default, every 100ms (default value of `CancellationDelayMaxMs` from `ConsumerConfig`).
This results in great number of spans generated.

## What

No longer create spans for empty reads.

## Tests

Existing tests.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
