### PR TITLE
[kafka] limit when `messaging.kafka.message.key` attribute is set to basic types

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
@@ -116,6 +116,16 @@ internal static class KafkaInstrumentation
             deliveryResult.Offset.Value);
     }
 
+    internal static string? ExtractMessageKeyValue(object key)
+    {
+        return key switch
+        {
+            string s => s,
+            int or long or float or double => key.ToString(),
+            _ => null
+        };
+    }
+
     private static void SetCommonAttributes(
         Activity activity,
         string operationName,
@@ -138,7 +148,11 @@ internal static class KafkaInstrumentation
 
         if (key is not null)
         {
-            activity.SetTag(MessagingAttributes.Keys.Kafka.MessageKey, key);
+            var keyValue = ExtractMessageKeyValue(key);
+            if (keyValue is not null)
+            {
+                activity.SetTag(MessagingAttributes.Keys.Kafka.MessageKey, keyValue);
+            }
         }
 
         if (partition is not null)

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using OpenTelemetry.AutoInstrumentation.DuckTyping;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.DuckTypes;
@@ -121,7 +122,7 @@ internal static class KafkaInstrumentation
         return key switch
         {
             string s => s,
-            int or long or float or double => key.ToString(),
+            int or long or float or double => Convert.ToString(key, CultureInfo.InvariantCulture),
             _ => null
         };
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
@@ -122,7 +122,7 @@ internal static class KafkaInstrumentation
         return key switch
         {
             string s => s,
-            int or long or float or double => Convert.ToString(key, CultureInfo.InvariantCulture),
+            int or uint or long or ulong or float or double or decimal => Convert.ToString(key, CultureInfo.InvariantCulture),
             _ => null
         };
     }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
@@ -13,12 +13,21 @@ public class KafkaInstrumentationTests
     [Theory]
     [InlineData("abc")]
     [InlineData(int.MaxValue)]
+    [InlineData(uint.MaxValue)]
     [InlineData(long.MaxValue)]
+    [InlineData(ulong.MaxValue)]
     [InlineData(float.MaxValue)]
     [InlineData(double.MaxValue)]
     public void MessageKeyValueIsExtractedForBasicType(object value)
     {
         KafkaInstrumentation.ExtractMessageKeyValue(value).Should().Be(Convert.ToString(value, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void MessageKeyValueIsExtractedForDecimal()
+    {
+        decimal input = decimal.MaxValue;
+        KafkaInstrumentation.ExtractMessageKeyValue(input).Should().Be(Convert.ToString(input, CultureInfo.InvariantCulture));
     }
 
     [Fact]

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using FluentAssertions;
+using OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka;
+using Xunit;
+
+namespace OpenTelemetry.AutoInstrumentation.Tests;
+
+public class KafkaInstrumentationTests
+{
+    [Theory]
+    [InlineData("abc")]
+    [InlineData(int.MaxValue)]
+    [InlineData(long.MaxValue)]
+    [InlineData(float.MaxValue)]
+    [InlineData(double.MaxValue)]
+    public void MessageKeyValueIsExtractedForBasicType(object value)
+    {
+        KafkaInstrumentation.ExtractMessageKeyValue(value).Should().Be(value.ToString());
+    }
+
+    [Fact]
+    public void MessageKeyValueIsNotExtractedForUnrecognizedType()
+    {
+        var value = new byte[] { 1, 2, 3 };
+        KafkaInstrumentation.ExtractMessageKeyValue(value).Should().BeNull();
+    }
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Globalization;
 using FluentAssertions;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka;
 using Xunit;
@@ -17,7 +18,7 @@ public class KafkaInstrumentationTests
     [InlineData(double.MaxValue)]
     public void MessageKeyValueIsExtractedForBasicType(object value)
     {
-        KafkaInstrumentation.ExtractMessageKeyValue(value).Should().Be(value.ToString());
+        KafkaInstrumentation.ExtractMessageKeyValue(value).Should().Be(Convert.ToString(value, CultureInfo.InvariantCulture));
     }
 
     [Fact]


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #

## What

Adjust to better align with semantic conventions [recommendation](https://github.com/open-telemetry/semantic-conventions/blob/ac9f85f0581e1fd621f539392a7218c5cf4f3a25/docs/messaging/kafka.md?plain=1#L38)

## Tests

Added in PR.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
