### PR TITLE
Fix Diagnostic Logger

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Logging/InternalLogger.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Logging/InternalLogger.cs
@@ -201,7 +201,8 @@ internal class InternalLogger : IOtelLogger
     {
         try
         {
-            var rawMessage = string.Format(messageTemplate, args);
+            // Use template if no arguments provided, otherwise format the template with provided arguments.
+            var rawMessage = args == NoPropertyValues ? messageTemplate : string.Format(messageTemplate, args);
             if (exception != null)
             {
                 rawMessage += $"{Environment.NewLine}Exception: {exception.Message}{Environment.NewLine}{exception}";


### PR DESCRIPTION
## What

Fixes diagnostic logger when no arguments provided:
* Minor performance bump
* Fails if the log template contains chars used for `string.format` but when no arguments provided it's not intuitive failure.
  eg debug logging envs containing this row fails: `COR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}`

## Tests

Local

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
