### PR TITLE
Bump OTLP proto to 1.3.1

### DIFF
--- a/test/IntegrationTests/ContinuousProfilerTests.cs
+++ b/test/IntegrationTests/ContinuousProfilerTests.cs
@@ -4,8 +4,7 @@
 #if NET6_0_OR_GREATER
 
 using IntegrationTests.Helpers;
-using OpenTelemetry.Proto.Profiles.V1;
-using OpenTelemetry.Proto.Profiles.V1.Alternatives.PprofExtended;
+using OpenTelemetry.Proto.Profiles.V1Experimental;
 using Xunit.Abstractions;
 
 namespace IntegrationTests;

--- a/test/IntegrationTests/opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
+++ b/test/IntegrationTests/opentelemetry/proto/collector/profiles/v1experimental/profiles_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2019, OpenTelemetry Authors
+// Copyright 2023, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,18 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.collector.profiles.v1;
+package opentelemetry.proto.collector.profiles.v1experimental;
 
-import "opentelemetry/proto/profiles/v1/profiles.proto";
+import "opentelemetry/proto/profiles/v1experimental/profiles.proto";
 
-option csharp_namespace = "OpenTelemetry.Proto.Collector.Profiles.V1";
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Profiles.V1Experimental";
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.collector.profiles.v1";
+option java_package = "io.opentelemetry.proto.collector.profiles.v1experimental";
 option java_outer_classname = "ProfilesServiceProto";
-option go_package = "go.opentelemetry.io/proto/otlp/collector/profiles/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/profiles/v1experimental";
 
-// Service that can be used to push profiles data between one Application instrumented with
-// OpenTelemetry and a collector, or between a collector and a central collector (in this
-// case profiles data are sent/received to/from multiple Applications).
+// Service that can be used to push profiles between one Application instrumented with
+// OpenTelemetry and a collector, or between a collector and a central collector.
 service ProfilesService {
   // For performance reasons, it is recommended to keep this RPC
   // alive for the entire life of the application.
@@ -34,12 +33,12 @@ service ProfilesService {
 }
 
 message ExportProfilesServiceRequest {
-  // An array of ProfilesData.
+  // An array of ResourceProfiles.
   // For data coming from a single resource this array will typically contain one
   // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
   // data from multiple origins typically batch the data before forwarding further and
   // in that case this array will contain multiple elements.
-  repeated opentelemetry.proto.profiles.v1.ProfilesData profiles_data = 1;
+  repeated opentelemetry.proto.profiles.v1experimental.ResourceProfiles resource_profiles = 1;
 }
 
 message ExportProfilesServiceResponse {
@@ -62,11 +61,11 @@ message ExportProfilesServiceResponse {
 }
 
 message ExportProfilesPartialSuccess {
-  // The number of rejected spans.
+  // The number of rejected profiles.
   //
   // A `rejected_<signal>` field holding a `0` value indicates that the
   // request was fully accepted.
-  int64 rejected_spans = 1;
+  int64 rejected_profiles = 1;
 
   // A developer-facing human-readable message in English. It should be used
   // either to explain why the server rejected parts of the data during a partial

--- a/test/IntegrationTests/opentelemetry/proto/collector/profiles/v1experimental/profiles_service_http.yaml
+++ b/test/IntegrationTests/opentelemetry/proto/collector/profiles/v1experimental/profiles_service_http.yaml
@@ -4,6 +4,6 @@ type: google.api.Service
 config_version: 3
 http:
  rules:
- - selector: opentelemetry.proto.collector.profiles.v1.ProfilesService.Export
-   post: /v1/profiles
+ - selector: opentelemetry.proto.collector.profiles.v1experimental.ProfilesService.Export
+   post: /v1experimental/profiles
    body: "*"

--- a/test/IntegrationTests/opentelemetry/proto/profiles/v1experimental/pprofextended.proto
+++ b/test/IntegrationTests/opentelemetry/proto/profiles/v1experimental/pprofextended.proto
@@ -1,3 +1,33 @@
+// Copyright 2023, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file includes work covered by the following copyright and permission notices:
+//
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Profile is a common stacktrace profile format.
 //
 // Measurements represented with this format should follow the
@@ -24,12 +54,12 @@
 
 syntax = "proto3";
 
-package opentelemetry.proto.profiles.v1.alternatives.pprofextended;
+package opentelemetry.proto.profiles.v1experimental;
 
 import "opentelemetry/proto/common/v1/common.proto";
 
-option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1.Alternatives.PprofExtended";
-option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1/alternatives/pprofextended";
+option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1Experimental";
+option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1experimental";
 
 // Represents a complete profile, including sample types, samples,
 // mappings to binaries, locations, functions, string table, and additional metadata.
@@ -227,9 +257,9 @@ message Sample {
   // Reference to link in Profile.link_table. [optional]
   uint64 link = 12;
 
-  // Timestamps associated with Sample represented in ms. These timestamps are expected
+  // Timestamps associated with Sample represented in nanoseconds. These timestamps are expected
   // to fall within the Profile's time range. [optional]
-  repeated uint64 timestamps = 13;
+  repeated uint64 timestamps_unix_nano = 13;
 }
 
 // Provides additional context for a sample,

--- a/test/IntegrationTests/opentelemetry/proto/profiles/v1experimental/profiles.proto
+++ b/test/IntegrationTests/opentelemetry/proto/profiles/v1experimental/profiles.proto
@@ -1,17 +1,30 @@
+// Copyright 2023, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 syntax = "proto3";
 
-package opentelemetry.proto.profiles.v1;
+package opentelemetry.proto.profiles.v1experimental;
 
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
+import "opentelemetry/proto/profiles/v1experimental/pprofextended.proto";
 
-import "opentelemetry/proto/profiles/v1/alternatives/pprofextended/pprofextended.proto";
-
-option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1";
+option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1Experimental";
 option java_multiple_files = true;
-option java_package = "io.opentelemetry.proto.profiles.v1";
+option java_package = "io.opentelemetry.proto.profiles.v1experimental";
 option java_outer_classname = "ProfilesProto";
-option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1";
+option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1experimental";
 
 //                Relationships Diagram
 //
@@ -87,6 +100,7 @@ message ProfilesData {
   repeated ResourceProfiles resource_profiles = 1;
 }
 
+
 // A collection of ScopeProfiles from a Resource.
 message ResourceProfiles {
   reserved 1000;
@@ -98,12 +112,15 @@ message ResourceProfiles {
   // A list of ScopeProfiles that originate from a resource.
   repeated ScopeProfiles scope_profiles = 2;
 
+  // The Schema URL, if known. This is the identifier of the Schema that the resource data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_profiles" field which have their own schema_url field.
   string schema_url = 3;
 }
 
-// A collection of Profiles produced by an InstrumentationScope.
+// A collection of ProfileContainers produced by an InstrumentationScope.
 message ScopeProfiles {
   // The instrumentation scope information for the profiles in this message.
   // Semantically when InstrumentationScope isn't set, it is equivalent with
@@ -113,7 +130,10 @@ message ScopeProfiles {
   // A list of ProfileContainers that originate from an instrumentation scope.
   repeated ProfileContainer profiles = 2;
 
-  // This schema_url applies to all profiles and profile events in the "profiles" field.
+  // The Schema URL, if known. This is the identifier of the Schema that the metric data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  // This schema_url applies to all profiles in the "profiles" field.
   string schema_url = 3;
 }
 
@@ -167,5 +187,5 @@ message ProfileContainer {
   bytes original_payload = 7;
 
   // This is a reference to a pprof profile. Required, even when original_payload is present.
-  opentelemetry.proto.profiles.v1.alternatives.pprofextended.Profile profile = 8;
+  opentelemetry.proto.profiles.v1experimental.Profile profile = 8;
 }

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/ExtendedPprofBuilder.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/ExtendedPprofBuilder.cs
@@ -3,7 +3,7 @@
 
 using Google.Protobuf;
 using OpenTelemetry.Proto.Common.V1;
-using OpenTelemetry.Proto.Profiles.V1.Alternatives.PprofExtended;
+using OpenTelemetry.Proto.Profiles.V1Experimental;
 
 namespace TestApplication.ContinuousProfiler;
 

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/OtlpOverHttpExporter.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/OtlpOverHttpExporter.cs
@@ -7,10 +7,9 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using Google.Protobuf;
-using OpenTelemetry.Proto.Collector.Profiles.V1;
+using OpenTelemetry.Proto.Collector.Profiles.V1Experimental;
 using OpenTelemetry.Proto.Common.V1;
-using OpenTelemetry.Proto.Profiles.V1;
-using OpenTelemetry.Proto.Profiles.V1.Alternatives.PprofExtended;
+using OpenTelemetry.Proto.Profiles.V1Experimental;
 using OpenTelemetry.Proto.Resource.V1;
 
 namespace TestApplication.ContinuousProfiler;
@@ -149,7 +148,7 @@ public class OtlpOverHttpExporter
     {
         var request = new ExportProfilesServiceRequest();
 
-        request.ProfilesData.Add(profilesData);
+        request.ResourceProfiles.Add(profilesData.ResourceProfiles);
 
         return request;
     }

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/SampleBuilder.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/SampleBuilder.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpenTelemetry.Proto.Profiles.V1.Alternatives.PprofExtended;
+using OpenTelemetry.Proto.Profiles.V1Experimental;
 
 namespace TestApplication.ContinuousProfiler;
 

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/TestApplication.ContinuousProfiler.csproj
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/TestApplication.ContinuousProfiler.csproj
@@ -36,8 +36,8 @@
   <ItemGroup>
     <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\common\v1\common.proto" Link="opentelemetry\proto\common\v1\common.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
     <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\resource\v1\resource.proto" Link="opentelemetry\proto\resource\v1\resource.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
-    <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\profiles\v1\alternatives\pprofextended\pprofextended.proto" Link="opentelemetry\proto\profiles\v1\alternatives\pprofextended\pprofextended.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
-    <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\profiles\v1\profiles.proto" Link="opentelemetry\proto\profiles\v1\profiles.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
-    <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\collector\profiles\v1\profiles_service.proto" Link="opentelemetry\proto\collector\profiles\v1\profiles_service.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
+    <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\profiles\v1experimental\pprofextended.proto" Link="opentelemetry\proto\profiles\v1experimental\pprofextended.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
+    <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\profiles\v1experimental\profiles.proto" Link="opentelemetry\proto\profiles\v1experimental\profiles.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
+    <Protobuf Include="..\..\..\IntegrationTests\opentelemetry\proto\collector\profiles\v1experimental\profiles_service.proto" Link="opentelemetry\proto\collector\profiles\v1\profiles_service.proto" ProtoRoot="..\..\..\IntegrationTests" Access="internal" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

Handles https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.3.1
and https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.3.0

## What

First release of OTLP proto profiling signal (v1experimental).

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
