### PR TITLE
OracleMDA for .NETFx test application targets only .NET Framework 4.7.2

### DIFF
--- a/test/test-applications/integrations/TestApplication.OracleMda.NetFramework/TestApplication.OracleMda.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.OracleMda.NetFramework/TestApplication.OracleMda.NetFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

Fixes local build in VisualStudio.

## What

OracleMDA for .NETFx test application targets only .NET Framework 4.7.2
It allows to build solution without errors in Visual Studio

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
