### PR TITLE
[Tests] Bump Npgql to 8.0.3 / handles CVE-2024-32655

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -121,8 +121,7 @@ public static partial class LibraryVersion
             "TestApplication.Npgsql",
             new List<PackageBuildInfo>
             {
-                new("6.0.0"),
-                new("8.0.2"),
+                new("8.0.3"),
             }
         },
         {

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="MySql.Data" Version="8.3.0" />
     <PackageVersion Include="NServiceBus" Version="8.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Npgsql" Version="8.0.2" />
+    <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="NuGet.Versioning" Version="6.5.0" />
     <PackageVersion Include="OpenTracing" Version="0.12.1" />
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.4.0" />

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -140,8 +140,7 @@ public static partial class LibraryVersion
 #if DEFAULT_TEST_PACKAGE_VERSIONS
         new object[] { string.Empty }
 #else
-        new object[] { "6.0.0" },
-        new object[] { "8.0.2" },
+        new object[] { "8.0.3" },
 #endif
     };
     public static readonly IReadOnlyCollection<object[]> NServiceBus = new List<object[]>

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -158,7 +158,8 @@ internal static class PackageVersionDefinitions
             TestApplicationName = "TestApplication.Npgsql",
             Versions = new List<PackageVersion>
             {
-                new("6.0.0"),
+                // new("6.0.0"), - high vulnerability https://github.com/advisories/GHSA-x9vc-6hfv-hg8c, <= 8.0.2 test should be skipped
+                new("8.0.3"),
                 new("*")
             }
         },


### PR DESCRIPTION


## Why

Handles [CVE-2024-32655](https://github.com/advisories/GHSA-x9vc-6hfv-hg8c)

Fixes #

## What

Bump Npgql to 8.0.3, drop testing with older packages.
All older packages have high vulnerability https://github.com/advisories/GHSA-x9vc-6hfv-hg8c

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests,
