### PR TITLE
[Tests] Bring back Npgql  6.0* / better handles CVE-2024-32655

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -121,6 +121,7 @@ public static partial class LibraryVersion
             "TestApplication.Npgsql",
             new List<PackageBuildInfo>
             {
+                new("6.0.11"),
                 new("8.0.3"),
             }
         },

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -140,6 +140,7 @@ public static partial class LibraryVersion
 #if DEFAULT_TEST_PACKAGE_VERSIONS
         new object[] { string.Empty }
 #else
+        new object[] { "6.0.11" },
         new object[] { "8.0.3" },
 #endif
     };

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -158,8 +158,8 @@ internal static class PackageVersionDefinitions
             TestApplicationName = "TestApplication.Npgsql",
             Versions = new List<PackageVersion>
             {
-                // new("6.0.0"), - high vulnerability https://github.com/advisories/GHSA-x9vc-6hfv-hg8c, <= 8.0.2 test should be skipped
-                new("8.0.3"),
+                // new("6.0.0"), - high vulnerability https://github.com/advisories/GHSA-x9vc-6hfv-hg8c, <= 6.0.10, <= 7.0.6, and <= 8.0.2 test should be skipped
+                new("6.0.11"),
                 new("*")
             }
         },


### PR DESCRIPTION
## Why

Follow up to #3404
Npgsql team released also 6.x version with fixes. It should be our new minimal tested version.

## What

Bring back tests with 6.x version

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
