### PR TITLE
Bump .NET SDK to 8.0.300/7.0.409/6.0.422

### DIFF
--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Check for NuGet packages cache
         uses: actions/cache@v4.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Check for NuGet packages cache
         uses: actions/cache@v4.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Check for NuGet packages cache
         uses: actions/cache@v4.0.2
@@ -131,9 +131,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Check for NuGet packages cache
         uses: actions/cache@v4.0.2
@@ -171,9 +171,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Check for NuGet packages cache
         uses: actions/cache@v4.0.2
@@ -276,9 +276,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Check for NuGet packages cache
         uses: actions/cache@v4.0.2

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET 8
       uses: actions/setup-dotnet@v4.0.0
       with:
-        dotnet-version: 8.0.204
+        dotnet-version: 8.0.300
 
     - name: dotnet format
       run: dotnet format .\OpenTelemetry.AutoInstrumentation.sln --no-restore --verify-no-changes

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
             
       - name: Test the PowerShell module instructions from README.md
         shell: powershell
@@ -68,9 +68,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Install MacOS CoreUtils
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: | 
-            6.0.421
-            7.0.408
-            8.0.204
+            6.0.422
+            7.0.409
+            8.0.300
 
       - name: Run BuildTracer and ManagedTests
         run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project "${{ github.event.inputs.testProject }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}

--- a/OpenTelemetry.AutoInstrumentation.sln
+++ b/OpenTelemetry.AutoInstrumentation.sln
@@ -174,6 +174,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetPackagesTests", "test\NuGetPackagesTests\NuGetPackagesTests.csproj", "{AFD7582B-E9CD-4DF4-93B4-D5BBD7F539D0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget-packages", "nuget-packages", "{2EF2F7CE-E56F-4B81-A5A5-277693529D43}"
+	ProjectSection(SolutionItems) = preProject
+		test\test-applications\nuget-packages\Directory.Build.props = test\test-applications\nuget-packages\Directory.Build.props
+		test\test-applications\nuget-packages\Directory.Build.targets = test\test-applications\nuget-packages\Directory.Build.targets
+		test\test-applications\nuget-packages\Directory.Packages.props = test\test-applications\nuget-packages\Directory.Packages.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.SelfContained", "test\test-applications\nuget-packages\TestApplication.SelfContained\TestApplication.SelfContained.csproj", "{25ED93D0-A70C-4A07-84D9-EF94115259C9}"
 EndProject
@@ -221,15 +226,15 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "TestApplication.ContinuousP
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.ContinuousProfiler.ContextTracking", "test\test-applications\integrations\TestApplication.ContinuousProfiler.ContextTracking\TestApplication.ContinuousProfiler.ContextTracking.csproj", "{B74CB036-10F5-449D-8CBA-44F77E68D042}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication.OracleMda.NetFramework", "test\test-applications\integrations\TestApplication.OracleMda.NetFramework\TestApplication.OracleMda.NetFramework.csproj", "{283DBDE1-F643-48CD-BBC8-ACC65D2014F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.OracleMda.NetFramework", "test\test-applications\integrations\TestApplication.OracleMda.NetFramework\TestApplication.OracleMda.NetFramework.csproj", "{283DBDE1-F643-48CD-BBC8-ACC65D2014F2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "next-gen", "next-gen", "{3F051815-8E0D-4356-BC36-55CA642DDF18}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-dotnet-monitor-metrics", "next-gen\docs\getting-started-dotnet-monitor-metrics\getting-started-dotnet-monitor-metrics.csproj", "{022A03CE-DD7A-4326-847E-3B750E660845}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication.OracleMda.Core", "test\test-applications\integrations\TestApplication.OracleMda.Core\TestApplication.OracleMda.Core.csproj", "{21A915DF-8B9E-4CE8-84DA-1057CDCE117E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApplication.OracleMda.Core", "test\test-applications\integrations\TestApplication.OracleMda.Core\TestApplication.OracleMda.Core.csproj", "{21A915DF-8B9E-4CE8-84DA-1057CDCE117E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getting-started-dotnet-monitor-logs", "next-gen\docs\getting-started-dotnet-monitor-logs\getting-started-dotnet-monitor-logs.csproj", "{959764E7-5A0C-4511-8004-48DE6B10F499}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-dotnet-monitor-logs", "next-gen\docs\getting-started-dotnet-monitor-logs\getting-started-dotnet-monitor-logs.csproj", "{959764E7-5A0C-4511-8004-48DE6B10F499}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -21,8 +21,8 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
     && echo "fcce8126a0fac2aa826f0bdf0f3c8e65f9c5f846ee1ab0774a03a7c56267556c  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 6.0.421 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh -v 7.0.408 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 6.0.422 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 7.0.409 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 WORKDIR /project

--- a/docker/centos.dockerfile
+++ b/docker/centos.dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/open-telemetry/opentelemetry-dotnet-instrumentation-centos7-build-image:main
 
 RUN rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
-RUN yum -y install dotnet-sdk-6.0-6.0.421-1 dotnet-sdk-7.0-7.0.408-1
+RUN yum -y install dotnet-sdk-6.0-6.0.422-1 dotnet-sdk-7.0-7.0.409-1
 
 ENV IsCentos=true
 WORKDIR /project

--- a/docker/debian-arm64.dockerfile
+++ b/docker/debian-arm64.dockerfile
@@ -11,8 +11,8 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
     && echo "fcce8126a0fac2aa826f0bdf0f3c8e65f9c5f846ee1ab0774a03a7c56267556c  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 6.0.421 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh -v 7.0.408 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 6.0.422 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 7.0.409 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 WORKDIR /project

--- a/test/test-applications/nuget-packages/Directory.Packages.props
+++ b/test/test-applications/nuget-packages/Directory.Packages.props
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <!-- The NuGet package test applications shouldn't use the common build settings -->
 
+  <ItemGroup>
+    <!-- This version is here to avoid compilation warnings. During the build is overriden by nuke tasks. -->
+    <PackageVersion Include="OpenTelemetry.AutoInstrumentation" Version="1.6.0" />
+  </ItemGroup>
 </Project>

--- a/test/test-applications/nuget-packages/TestApplication.SelfContained/TestApplication.SelfContained.csproj
+++ b/test/test-applications/nuget-packages/TestApplication.SelfContained/TestApplication.SelfContained.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="OpenTelemetry.AutoInstrumentation" VersionOverride="$(NuGetPackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

Fixes missing parts from #3410

## What

Bump .NET SDK to 8.0.300/7.0.409/6.0.422

## Tests

CI
## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
