### PR TITLE
[kafka] do not create spans for PartitionEOF events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Do not use message creation context as a parent for consumer spans for `Confluent.Kafka`
   client instrumentation. See the [issue](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/3434)
   for details.
+- Do not create consumer spans related to `PartitionEOF` events
+  for `Confluent.Kafka` client instrumentation.
 
 #### Dependency updates
 

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IConsumeResult.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IConsumeResult.cs
@@ -13,4 +13,7 @@ internal interface IConsumeResult
     public Offset Offset { get; set; }
 
     public Partition Partition { get; set; }
+
+    // ReSharper disable once InconsistentNaming
+    public bool IsPartitionEOF { get; set; }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerConsumeSyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerConsumeSyncIntegration.cs
@@ -46,7 +46,7 @@ public static class ConsumerConsumeSyncIntegration
             consumeResult = response == null ? null : response.DuckAs<IConsumeResult>();
         }
 
-        if (consumeResult is not null)
+        if (consumeResult is not null && !consumeResult.IsPartitionEOF)
         {
             var activity = KafkaInstrumentation.StartConsumerActivity(consumeResult, (DateTimeOffset)state.StartTime!, instance!);
             if (exception is not null)

--- a/test/test-applications/integrations/TestApplication.Kafka/Properties/launchSettings.json
+++ b/test/test-applications/integrations/TestApplication.Kafka/Properties/launchSettings.json
@@ -3,7 +3,7 @@
   "profiles": {
     "instrumented": {
       "commandName": "Project",
-      "commandLineArgs": "test-topic",
+      "commandLineArgs": "--topic-name test-topic",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{918728DD-259F-4A6A-AC2B-B85E1B658318}",


### PR DESCRIPTION
## Why

When [`EnablePartitionEof`](https://docs.confluent.io/platform/current/clients/confluent-kafka-dotnet/_site/api/Confluent.Kafka.ConsumerConfig.html#Confluent_Kafka_ConsumerConfig_EnablePartitionEof) is set on consumer config (it's off by default), `ConsumeResult` instance with `IsPartitionEOF` set is returned when consumer reaches the end of partition.
This results in span being created, which have no link and might be confusing as noted [here](https://github.com/open-telemetry/opentelemetry-demo/pull/1538#issuecomment-2085257548).

Fixes #

## What

Stop creating spans for `ConsumeResult` related to `PartitionEOF` events.

## Tests

Included in PR.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
