### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v1.6.0..HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v1.7.0..HEAD)
+
+### Added
+
+### Changed
+
+#### Dependency updates
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [1.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.7.0)
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
   [`1.9.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.9.0)
@@ -85,10 +99,6 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Support for [macOS Big Sur 11 x64](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md).
   All further releases will be supporting [macOS Monterey 12 x64](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)
   and newer.
-
-### Removed
-
-### Fixed
 
 ## [1.6.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.6.0)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,9 +13,9 @@ to .NET applications without having to modify their source code.
 > [!WARNING]
 > The following documentation refers to the in-development version
 of OpenTelemetry .NET Automatic Instrumentation. Docs for the latest version
-([1.6.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
+([1.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
 can be found in [opentelemetry.io](https://opentelemetry.io/docs/zero-code/net/)
-or [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.6.0/docs/README.md).
+or [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.7.0/docs/README.md).
 
 ---
 
@@ -213,7 +213,7 @@ Example usage (run as administrator):
 
 ```powershell
 # Download the module
-$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.6.0/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.7.0/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,7 +62,7 @@ When adding the NuGet packages to your project you get an error message similar
 to:
 
 ```txt
-Could not install package 'OpenTelemetry.AutoInstrumentation.Runtime.Native 1.6.0'. You are trying to install this package into a project that targets '.NETFramework,Version=v4.7.2', but the package does not contain any assembly references or content files that are compatible with that framework. For more information, contact the package author.
+Could not install package 'OpenTelemetry.AutoInstrumentation.Runtime.Native 1.7.0'. You are trying to install this package into a project that targets '.NETFramework,Version=v4.7.2', but the package does not contain any assembly references or content files that are compatible with that framework. For more information, contact the package author.
 ```
 
 #### Solution

--- a/docs/using-the-nuget-packages.md
+++ b/docs/using-the-nuget-packages.md
@@ -40,7 +40,7 @@ you to either add the missing instrumentation package or to skip the
 instrumentation of the corresponding package:
 
 ```terminal
-~packages/opentelemetry.autoinstrumentation.buildtasks/1.6.0/build/OpenTelemetry.AutoInstrumentation.BuildTasks.targets(29,5): error : OpenTelemetry.AutoInstrumentation: add a reference to the instrumentation package 'MongoDB.Driver.Core.Extensions.DiagnosticSources' version 1.4.0 or add 'MongoDB.Driver.Core' to the property 'SkippedInstrumentations' to suppress this error.
+~packages/opentelemetry.autoinstrumentation.buildtasks/1.7.0/build/OpenTelemetry.AutoInstrumentation.BuildTasks.targets(29,5): error : OpenTelemetry.AutoInstrumentation: add a reference to the instrumentation package 'MongoDB.Driver.Core.Extensions.DiagnosticSources' version 1.4.0 or add 'MongoDB.Driver.Core' to the property 'SkippedInstrumentations' to suppress this error.
 ```
 
 To resolve the error either add the recommended instrumentation package or skip

--- a/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
+++ b/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
@@ -14,7 +14,7 @@
         Condition="!$(SkippedInstrumentations.Contains('StackExchange.Redis')) AND !$(TargetFramework.StartsWith('net4'))"
         TargetNuGetPackageVersionRange="[2.1.58, 3.0.0)"
         InstrumentationNuGetPackageId="OpenTelemetry.Instrumentation.StackExchangeRedis"
-        InstrumentationNuGetPackageVersion="1.0.0-rc9.13" />
+        InstrumentationNuGetPackageVersion="1.0.0-rc9.15" />
 
     </ItemGroup>
 


### PR DESCRIPTION
## [1.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.7.0)

- [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.9.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.9.0)
- `System.Diagnostics.DiagnosticSource`: [`8.0.0`](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/8.0.0)

### Added

- Support for capturing HTTP headers for following traces instrumentations:
  - ASP.NET, configurable by
    `OTEL_DOTNET_AUTO_TRACES_ASPNET_INSTRUMENTATION_CAPTURE_REQUEST_HEADERS`
    and `OTEL_DOTNET_AUTO_TRACES_ASPNET_INSTRUMENTATION_CAPTURE_RESPONSE_HEADERS`,
  - ASP.NET Core, configurable by
    `OTEL_DOTNET_AUTO_TRACES_ASPNETCORE_INSTRUMENTATION_CAPTURE_REQUEST_HEADERS`
    and `OTEL_DOTNET_AUTO_TRACES_ASPNETCORE_INSTRUMENTATION_CAPTURE_RESPONSE_HEADERS`,
  - HTTP Client, configurable by
    `OTEL_DOTNET_AUTO_TRACES_HTTP_INSTRUMENTATION_CAPTURE_REQUEST_HEADERS`
    and `OTEL_DOTNET_AUTO_TRACES_HTTP_INSTRUMENTATION_CAPTURE_RESPONSE_HEADERS`.
- Support for capturing gRPC metadata for Grpc.Net.Client traces instrumentation.
  It can by configured by
  `OTEL_DOTNET_AUTO_TRACES_GRPCNETCLIENT_INSTRUMENTATION_CAPTURE_REQUEST_METADATA`
  and `OTEL_DOTNET_AUTO_TRACES_GRPCNETCLIENT_INSTRUMENTATION_CAPTURE_RESPONSE_METADATA`.
- Support for [Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core)
  and [Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess)
  traces instrumentation from 23.4.0 together with support for
  `OTEL_DOTNET_AUTO_ORACLEMDA_SET_DBSTATEMENT_FOR_TEXT` environment variable.
  ARM64 platform is not supported.
- Add support for NServiceBus 9.x metrics and traces instrumentations.

### Changed

- Musl-based (Alpine) libraries are compiled on Alpine v3.19.
- Do not use message creation context as a parent for consumer spans for `Confluent.Kafka`
  client instrumentation. See the [issue](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/3434)
  for details.
- Do not create consumer spans related to `PartitionEOF` events
  for `Confluent.Kafka` client instrumentation.
- Following properties can be set before calling plugins:
  - `OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnrichWithHttpRequest`,
  - `OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions.EnrichWithHttpResponse`,
  - `OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.EnrichWithHttpRequest`,
  - `OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions.EnrichWithHttpResponse`,
  - `OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions.EnrichWithHttpRequestMessage`,
  - `OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions.EnrichWithHttpResponseMessage`,
  - `OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpRequestMessage`,
  - `OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebRequest`,
  - `OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpResponseMessage`,
  - `OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions.EnrichWithHttpWebResponse`.

#### Dependency updates

- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.9.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.9.0).
- Following packages updated
  - `OpenTelemetry.Exporter.Prometheus.HttpListener` from `1.8.0-rc.1` to `1.9.0-beta.1`,
  - `OpenTelemetry.Instrumentation.GrpcNetClient` from `1.8.0-beta.1` to `1.9.0-beta.1`,
  - `OpenTelemetry.Instrumentation.Http` from `1.8.1` to `1.9.0`,
  - `OpenTelemetry.Instrumentation.Process` from `0.5.0-beta.5` to `0.5.0-beta.6`,
  - `OpenTelemetry.Instrumentation.Quartz` from `1.0.0-beta.2` to `1.0.0-beta.3`,
  - `OpenTelemetry.Instrumentation.Runtime` from `1.8.0` to `1.9.0`,
  - `OpenTelemetry.Instrumentation.SqlClient` from `1.8.0-beta.1` to `1.9.0-beta.1`,
  - `OpenTelemetry.Instrumentation.StackExchangeRedis` from `1.0.0-rc9.14` to `1.0.0-rc9.15`,
  - `OpenTelemetry.Instrumentation.Wcf` from `1.0.0-rc.16` to `1.0.0-rc.17`,
  - `OpenTelemetry.Shims.OpenTracing` from `1.7.0-beta.1` to `1.9.0-beta.1`,
  - `OpenTelemetry.Resources.Azure` from `1.0.0-beta.7` to `1.0.0-beta.8`,
  - `OpenTelemetry.Resources.Host` from `0.1.0-beta.1` to `0.1.0-beta.2`.
  - `OpenTelemetry.Resources.Process` from `0.1.0-beta.1` to `0.1.0-beta.2`.
  - `OpenTelemetry.Resources.ProcessRuntime` from `0.1.0-beta.1` to `0.1.0-beta.2`.
- .NET only, following packages updated
  - `OpenTelemetry.Instrumentation.AspNetCore` from `1.8.1` to `1.9.0`,
  - `OpenTelemetry.Instrumentation.EntityFrameworkCore` from `1.0.0-beta.11` to `1.0.0-beta.12`,
  - `OpenTelemetry.Resources.Container` from `1.0.0-beta.7` to `1.0.0-beta.9`.
- .NET Framework only, following packages updated
  - `OpenTelemetry.Instrumentation.AspNet` from `1.8.0-beta.2` to `1.9.0-beta.1`.

### Deprecated

- Support for [macOS Big Sur 11 x64](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md).
  All further releases will be supporting [macOS Monterey 12 x64](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)
  and newer.
## Tests

- [x] CI
- [x] MacOS with Linux Containers
- [x] Windows with Linux Containers

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
