### PR TITLE
Add Paul as documentation component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -4,6 +4,8 @@
 # Please add the entries in alphabetically sorted order
 components:
   CHANGELOG.md:
+    - pauljwil
     - theletterf
   docs/:
+    - pauljwil
     - theletterf


### PR DESCRIPTION
## Why &  What

@pauljwil is working as a technical writer in Splunk. He can help as with reviewing documentation PRs.
This additional entries allows GitHub to automatically ping Paul.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
