### PR TITLE
[Tests] Drop references to obsolete Microsoft.AspNetCore* packages

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="Grpc.Net.Client.Web" Version="2.63.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.63.0" />
     <PackageVersion Include="MassTransit" Version="8.2.3" />
-    <PackageVersion Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.6" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -15,8 +15,6 @@
     <PackageVersion Include="Grpc.Net.Client.Web" Version="2.63.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.63.0" />
     <PackageVersion Include="MassTransit" Version="8.2.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.6" />
     <PackageVersion Include="Microsoft.Build" Version="15.9.20" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -28,11 +28,6 @@
     <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" />
-  </ItemGroup>
-
   <ItemGroup>
     <Content Include="docker\azure.Dockerfile" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="docker\mongodb.Dockerfile" CopyToOutputDirectory="PreserveNewest" />

--- a/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
+++ b/test/test-applications/integrations/TestApplication.GraphQL/TestApplication.GraphQL.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="GraphQL.MicrosoftDI" VersionOverride="$(GraphQLMicrosoftDI)" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" VersionOverride="$(GraphQLServerTransportsAspNetCore)" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" VersionOverride="$(GraphQLServerUIPlayground)" />
-    <PackageReference Include="Microsoft.AspNetCore" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reactive" />
   </ItemGroup>


### PR DESCRIPTION
## Why &  What

Drop references to obsolete Microsoft.AspNetCore* packages

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
