### PR TITLE
Recommend NuGet package deployment method

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,12 +22,18 @@ or [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation
 ## Quick start
 
 If you'd like to try the instrumentation on an existing application before
-learning more about the configuration options and the project, follow the
-instructions at [Using the OpenTelemetry.AutoInstrumentation NuGet packages](./using-the-nuget-packages.md#using-the-opentelemetryautoinstrumentation-nuget-packages)
+learning more about the configuration options and the project, use the
+recommended installation method described at
+[Using the OpenTelemetry.AutoInstrumentation NuGet packages](./using-the-nuget-packages.md#using-the-opentelemetryautoinstrumentation-nuget-packages)
 or use the appropriate install script:
 
 - On Linux and macOS, use the [shell scripts](#shell-scripts).
 - On Windows, use the [PowerShell module](#powershell-module-windows).
+
+> [!NOTE]
+> The NuGet packages are the recommended way to deploy automatic instrumentation,
+> but they can't be used in all cases. See [Limitations](./using-the-nuget-packages.md#limitations)
+> for details.
 
 To see the telemetry from your application directly on the standard output, set
 the following environment variables to `true` before launching your application:
@@ -121,13 +127,20 @@ automatically generated in .NET 7+ whenever the `dotnet publish` or `dotnet buil
 command is used with a Runtime Identifier (RID) parameter, for example when `-r`
 or `--runtime` is used when running the command.
 
-### Install
+### Install using NuGet packages
 
-Download and extract the appropriate binaries from
+The NuGet packages are the recommended way to deploy automatic instrumentation,
+but they can't be used in all cases. To install using the NuGet packages,
+see [Using the OpenTelemetry.AutoInstrumentation NuGet packages](./using-the-nuget-packages.md).
+See [Limitations](./using-the-nuget-packages.md#limitations) for incompatible scenarios.
+
+### Install manually
+
+To install the automatic instrumentation manually, download and extract the appropriate binaries from
 [the latest release](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest).
 
 > [!NOTE]
-> The path where you put the binaries is referenced as `$INSTALL_DIR`
+> The path where you put the binaries is referenced as `$INSTALL_DIR`.
 
 ### Instrument a .NET application
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,21 +139,17 @@ File name: 'Microsoft.Extensions.DependencyInjection.Abstractions, Version=7.0.0
 
 #### Solution
 
-OpenTelemetry .NET NuGet packages and its dependencies
-are deployed with the OpenTelemetry .NET Automatic Instrumentation.
+OpenTelemetry .NET NuGet packages and their dependencies
+are deployed with the OpenTelemetry .NET Automatic Instrumentation. To avoid
+dependency version conflicts, the recommended way to install the automatic
+instrumentation is using the NuGet packages. For instructions on how to add the
+packages to your application, and the limitations of this installation method,
+see [Using the OpenTelemetry.AutoInstrumentation NuGet packages](./using-the-nuget-packages.md#using-the-opentelemetryautoinstrumentation-nuget-packages). 
 
-To handle dependency versions conflicts,
-update the instrumented application's project references
+Alternatively, you can handle the dependency versions conflicts by
+updating the instrumented application's project references
 to use the same versions as OpenTelemetry .NET Automatic Instrumentation.
 
-A simple way to ensure that no such conflicts happen is to add the
-`OpenTelemetry.AutoInstrumentation` package to your application.
-For instructions about how to add it to your application, see
-[Using the OpenTelemetry.AutoInstrumentation NuGet packages](./using-the-nuget-packages.md#using-the-opentelemetryautoinstrumentation-nuget-packages). 
-This is the recommended way to deploy automatic instrumentation, but it can't
-be used in all scenarios.
-
-Alternatively add only the conflicting packages to your project.
 The following dependencies are used by OpenTelemetry .NET Automatic Instrumentation:
 
 - [OpenTelemetry.AutoInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -149,8 +149,9 @@ to use the same versions as OpenTelemetry .NET Automatic Instrumentation.
 A simple way to ensure that no such conflicts happen is to add the
 `OpenTelemetry.AutoInstrumentation` package to your application.
 For instructions about how to add it to your application, see
-[Using the OpenTelemetry.AutoInstrumentation NuGet packages](./using-the-nuget-packages.md#using-the-opentelemetryautoinstrumentation-nuget-packages)
-.
+[Using the OpenTelemetry.AutoInstrumentation NuGet packages](./using-the-nuget-packages.md#using-the-opentelemetryautoinstrumentation-nuget-packages). 
+This is the recommended way to deploy automatic instrumentation, but it can't
+be used in all scenarios.
 
 Alternatively add only the conflicting packages to your project.
 The following dependencies are used by OpenTelemetry .NET Automatic Instrumentation:

--- a/docs/using-the-nuget-packages.md
+++ b/docs/using-the-nuget-packages.md
@@ -2,7 +2,9 @@
 
 ## When to use the NuGet packages
 
-Use the NuGet packages in the following scenarios:
+The NuGet packages are the recommended way to deploy automatic instrumentation,
+but they can't be used in all cases. Use the NuGet packages in the following
+scenarios:
 
 1. Simplify deployment. For example, a container running a single application.
 1. Support instrumentation of [`self-contained`](https://learn.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained)
@@ -14,7 +16,7 @@ Use the NuGet packages in the following scenarios:
 
 ## Limitations
 
-While NuGet packages are a convenient way to deploy automatic
+While NuGet packages are the recommended way to deploy automatic
 instrumentation, they can't be used in all cases. The most common
 reasons for not using NuGet packages include the following:
 


### PR DESCRIPTION
Updates README and other relevant files to clarify that the NuGet packages are the recommended method of deploying automatic instrumentation.
