### PR TITLE
assign-reviewers.yml - use first component owner gh action release

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
         
       - name: Assign reviewers
-        uses: dyladan/component-owners@cdaadffde64c918909ee081e3fe044b8910f56c2 # tag: main
+        uses: dyladan/component-owners@58bd86e9814d23f1525d0a970682cead459fa783 # tag: v0.1.0
         with:
           assign-owners: "false"
           request-owner-reviews: "true"


### PR DESCRIPTION
## Why

Follow up to #3505
Handles https://github.com/dyladan/component-owners/releases/tag/v0.1.0 - all next should be handled by dependabot

## What

assign-reviewers.yml - use first component owner gh action release

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
