### PR TITLE
Workaround dotnet CLI build-server shutdown issue

### DIFF
--- a/test/IntegrationTests/DotNetCliTests.cs
+++ b/test/IntegrationTests/DotNetCliTests.cs
@@ -44,7 +44,7 @@ public sealed class DotNetCliTests : TestHelper, IDisposable
 
         // Stop all build servers to ensure user like experience.
         // Currently there is an issue trying to launch VBCSCompiler background server.
-        RunDotNetCli("build-server shutdown");
+        RunDotNetCli("build-server shutdown", successMessage: "MSBuild server shut down successfully.");
 
         var tfm = $"net{Environment.Version.Major}.0";
         RunDotNetCli($"new console --framework {tfm}");
@@ -74,7 +74,7 @@ Console.WriteLine(response.StatusCode);
         File.WriteAllText("Program.cs", ProgramContent);
     }
 
-    private void RunDotNetCli(string arguments)
+    private void RunDotNetCli(string arguments, string successMessage = "")
     {
         Output.WriteLine($"Running: {DotNetCli} {arguments}");
 
@@ -94,7 +94,14 @@ Console.WriteLine(response.StatusCode);
         Output.WriteResult(helper);
 
         processTimeout.Should().BeFalse("Test application timed out");
-        process.ExitCode.Should().Be(0, "Test application exited with non-zero exit code");
+        if (!string.IsNullOrEmpty(successMessage))
+        {
+            helper.StandardOutput.Should().Contain(successMessage, "Test application did not output expected message");
+        }
+        else
+        {
+            process.ExitCode.Should().Be(0, "Test application exited with non-zero exit code");
+        }
     }
 
     private void RunAppWithDotNetCliAndAssertHttpSpans(string arguments)


### PR DESCRIPTION
## Why

The test failure with `dotnet build-server shutdown` is happening on main, see https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3499#issuecomment-2234147860

## What

This change checks for success on actually stopping the build-server which is what matters for the test, not the return code of dotnet CLI command.

## Tests

N/A

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
