### PR TITLE
Fix console export bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,6 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
-- Fix bug where the console was enabled by
- `OTEL_DOTNET_AUTO_{SIGNAL}_CONSOLE_EXPORTER_ENABLED` and wasn't working
-
 ## [1.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.7.0)
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
+- Fix bug where the console was enabled by
+ `OTEL_DOTNET_AUTO_{SIGNAL}_CONSOLE_EXPORTER_ENABLED` and wasn't working
+
 ## [1.7.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.7.0)
 
 - [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
@@ -47,15 +47,10 @@ internal class TracerSettings : Settings
     /// </summary>
     public InstrumentationOptions InstrumentationOptions { get; private set; } = new(new Configuration(failFast: false));
 
-    /// <summary>
-    /// Gets or sets a value indicating whether the console exporter is enabled.
-    /// </summary>
-    private bool ConsoleExporterEnabled { get; set; }
-
     protected override void OnLoad(Configuration configuration)
     {
-        ConsoleExporterEnabled = configuration.GetBool(ConfigurationKeys.Traces.ConsoleExporterEnabled) ?? false;
-        TracesExporters = ParseTracesExporter(configuration);
+        var consoleExporterEnabled = configuration.GetBool(ConfigurationKeys.Traces.ConsoleExporterEnabled) ?? false;
+        TracesExporters = ParseTracesExporter(configuration, consoleExporterEnabled);
 
         var instrumentationEnabledByDefault =
             configuration.GetBool(ConfigurationKeys.Traces.TracesInstrumentationEnabled) ??
@@ -89,16 +84,26 @@ internal class TracerSettings : Settings
         InstrumentationOptions = new InstrumentationOptions(configuration);
     }
 
-    private IReadOnlyList<TracesExporter> ParseTracesExporter(Configuration configuration)
+    private static IReadOnlyList<TracesExporter> ParseTracesExporter(Configuration configuration, bool consoleExporterEnabled)
     {
         var tracesExporterEnvVar = configuration.GetString(ConfigurationKeys.Traces.Exporter);
+        var exporters = new List<TracesExporter>();
+
+        if (consoleExporterEnabled)
+        {
+            Logger.Warning($"The '{ConfigurationKeys.Traces.ConsoleExporterEnabled}' environment variable is deprecated and " +
+                "will be removed in the next minor release. " +
+                "Please set the console exporter using OTEL_TRACES_EXPORTER environmental variable. " +
+                "Refer to the updated documentation for details.");
+
+            exporters.Add(TracesExporter.Console);
+        }
 
         if (string.IsNullOrEmpty(tracesExporterEnvVar))
         {
-            return new List<TracesExporter> { TracesExporter.Otlp };
+            exporters.Add(TracesExporter.Otlp);
+            return exporters;
         }
-
-        var exporters = new List<TracesExporter>();
 
         var exporterNames = tracesExporterEnvVar!.Split(Constants.ConfigurationValues.Separator);
 
@@ -128,16 +133,6 @@ internal class TracerSettings : Settings
                     Logger.Error($"Traces exporter '{exporterName}' is not supported.");
                     break;
             }
-        }
-
-        if (ConsoleExporterEnabled)
-        {
-            Logger.Warning($"The '{ConfigurationKeys.Traces.ConsoleExporterEnabled}' environment variable is deprecated and " +
-                "will be removed in the next minor release. " +
-                "Please set the console exporter using OTEL_TRACES_EXPORTER environmental variable. " +
-                "Refer to the updated documentation for details.");
-
-            exporters.Add(TracesExporter.Console);
         }
 
         return exporters;


### PR DESCRIPTION
## Why
This change is necessary to fix a bug where enabling the console via OTEL_DOTNET_AUTO_{SIGNAL}_CONSOLE_EXPORTER_ENABLED was not functioning as expected. 
<!-- Explain why the changes are needed.  -->

## Tests

Manual testing to verify that enabling the console exporter works as expected.
<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
