### PR TITLE
Enhanced handling of comma separated lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Changed
 
+- More restrictive handling of invalid values in comma-separated lists.
+  When invalid value is recognized (unsupported option, supported option
+  with leading or trailing whitespaces, empty value, duplicate)
+  warning is logged, and if `FailFast` is enabled, exception is thrown.
 - Referencing `OpenTelemetry.AutoInstrumentation` manually no longer visibly injects
   instrumentation scripts into projects in an editor's solution window.
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/LogSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/LogSettings.cs
@@ -88,13 +88,13 @@ internal class LogSettings : Settings
             if (seenExporters.Contains(exporterName))
             {
                 var message = $"Duplicate log exporter '{exporterName}' found.";
-                Logger.Error(message);
-
                 if (configuration.FailFast)
                 {
+                    Logger.Error(message);
                     throw new NotSupportedException(message);
                 }
 
+                Logger.Warning(message);
                 continue;
             }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/MetricSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/MetricSettings.cs
@@ -96,13 +96,13 @@ internal class MetricSettings : Settings
             if (seenExporters.Contains(exporterName))
             {
                 var message = $"Duplicate metric exporter '{exporterName}' found.";
-                Logger.Error(message);
-
                 if (configuration.FailFast)
                 {
+                    Logger.Error(message);
                     throw new NotSupportedException(message);
                 }
 
+                Logger.Warning(message);
                 continue;
             }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/MetricSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/MetricSettings.cs
@@ -71,6 +71,7 @@ internal class MetricSettings : Settings
     {
         var metricsExporterEnvVar = configuration.GetString(ConfigurationKeys.Metrics.Exporter);
         var exporters = new List<MetricsExporter>();
+        var seenExporters = new HashSet<string>();
 
         if (consoleExporterEnabled)
         {
@@ -92,6 +93,21 @@ internal class MetricSettings : Settings
 
         foreach (var exporterName in exporterNames)
         {
+            if (seenExporters.Contains(exporterName))
+            {
+                var message = $"Duplicate metric exporter '{exporterName}' found.";
+                Logger.Error(message);
+
+                if (configuration.FailFast)
+                {
+                    throw new NotSupportedException(message);
+                }
+
+                continue;
+            }
+
+            seenExporters.Add(exporterName);
+
             switch (exporterName)
             {
                 case Constants.ConfigurationValues.Exporters.Otlp:
@@ -106,14 +122,14 @@ internal class MetricSettings : Settings
                 case Constants.ConfigurationValues.None:
                     break;
                 default:
+                    var unsupportedMessage = $"Metric exporter '{exporterName}' is not supported.";
+                    Logger.Error(unsupportedMessage);
+
                     if (configuration.FailFast)
                     {
-                        var message = $"Metric exporter '{exporterName}' is not supported.";
-                        Logger.Error(message);
-                        throw new NotSupportedException(message);
+                        throw new NotSupportedException(unsupportedMessage);
                     }
 
-                    Logger.Error($"Metric exporter '{exporterName}' is not supported.");
                     break;
             }
         }

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/SdkSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/SdkSettings.cs
@@ -41,13 +41,13 @@ internal class SdkSettings : Settings
             if (seenPropagators.Contains(propagatorName))
             {
                 var message = $"Duplicate propagator '{propagatorName}' found.";
-                Logger.Error(message);
-
                 if (configuration.FailFast)
                 {
+                    Logger.Error(message);
                     throw new NotSupportedException(message);
                 }
 
+                Logger.Warning(message);
                 continue;
             }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/SdkSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/SdkSettings.cs
@@ -16,50 +16,70 @@ internal class SdkSettings : Settings
     /// <summary>
     /// Gets the list of propagators to be used.
     /// </summary>
-    public IList<Propagator> Propagators { get; } = new List<Propagator>();
+    public IList<Propagator> Propagators { get; private set; } = new List<Propagator>();
 
     protected override void OnLoad(Configuration configuration)
     {
-        var propagators = configuration.GetString(ConfigurationKeys.Sdk.Propagators);
-
-        if (!string.IsNullOrEmpty(propagators))
-        {
-            foreach (var propagatorValue in propagators!.Split(Constants.ConfigurationValues.Separator))
-            {
-                if (TryParsePropagator(propagatorValue, out var propagator))
-                {
-                    Propagators.Add(propagator.Value);
-                }
-                else if (configuration.FailFast)
-                {
-                    throw new NotSupportedException($"Propagator '{propagatorValue}' is not supported.");
-                }
-            }
-        }
+        Propagators = ParsePropagator(configuration);
     }
 
-    private static bool TryParsePropagator(string propagatorValue, [NotNullWhen(true)] out Propagator? propagator)
+    private static IList<Propagator> ParsePropagator(Configuration configuration)
     {
-        switch (propagatorValue)
+        var propagatorEnvVar = configuration.GetString(ConfigurationKeys.Sdk.Propagators);
+        var propagators = new List<Propagator>();
+        var seenPropagators = new HashSet<string>();
+
+        if (string.IsNullOrEmpty(propagatorEnvVar))
         {
-            case Constants.ConfigurationValues.Propagators.W3CTraceContext:
-                propagator = Propagator.W3CTraceContext;
-                break;
-            case Constants.ConfigurationValues.Propagators.W3CBaggage:
-                propagator = Propagator.W3CBaggage;
-                break;
-            case Constants.ConfigurationValues.Propagators.B3Multi:
-                propagator = Propagator.B3Multi;
-                break;
-            case Constants.ConfigurationValues.Propagators.B3Single:
-                propagator = Propagator.B3Single;
-                break;
-            default:
-                propagator = null;
-                Logger.Error($"Propagator '{propagatorValue}' is not supported. Skipping.");
-                return false;
+            return propagators;
         }
 
-        return true;
+        var propagatorNames = propagatorEnvVar!.Split(Constants.ConfigurationValues.Separator);
+
+        foreach (var propagatorName in propagatorNames)
+        {
+            if (seenPropagators.Contains(propagatorName))
+            {
+                var message = $"Duplicate propagator '{propagatorName}' found.";
+                Logger.Error(message);
+
+                if (configuration.FailFast)
+                {
+                    throw new NotSupportedException(message);
+                }
+
+                continue;
+            }
+
+            seenPropagators.Add(propagatorName);
+
+            switch (propagatorName)
+            {
+                case Constants.ConfigurationValues.Propagators.W3CTraceContext:
+                    propagators.Add(Propagator.W3CTraceContext);
+                    break;
+                case Constants.ConfigurationValues.Propagators.W3CBaggage:
+                    propagators.Add(Propagator.W3CBaggage);
+                    break;
+                case Constants.ConfigurationValues.Propagators.B3Multi:
+                    propagators.Add(Propagator.B3Multi);
+                    break;
+                case Constants.ConfigurationValues.Propagators.B3Single:
+                    propagators.Add(Propagator.B3Single);
+                    break;
+                default:
+                    var unsupportedMessage = $"Propagator '{propagatorName}' is not supported.";
+                    Logger.Error(unsupportedMessage);
+
+                    if (configuration.FailFast)
+                    {
+                        throw new NotSupportedException(unsupportedMessage);
+                    }
+
+                    break;
+            }
+        }
+
+        return propagators;
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
@@ -98,6 +98,7 @@ internal class TracerSettings : Settings
     {
         var tracesExporterEnvVar = configuration.GetString(ConfigurationKeys.Traces.Exporter);
         var exporters = new List<TracesExporter>();
+        var seenExporters = new HashSet<string>();
 
         if (consoleExporterEnabled)
         {
@@ -119,6 +120,21 @@ internal class TracerSettings : Settings
 
         foreach (var exporterName in exporterNames)
         {
+            if (seenExporters.Contains(exporterName))
+            {
+                var message = $"Duplicate traces exporter '{exporterName}' found.";
+                Logger.Error(message);
+
+                if (configuration.FailFast)
+                {
+                    throw new NotSupportedException(message);
+                }
+
+                continue;
+            }
+
+            seenExporters.Add(exporterName);
+
             switch (exporterName)
             {
                 case Constants.ConfigurationValues.Exporters.Otlp:
@@ -133,14 +149,14 @@ internal class TracerSettings : Settings
                     exporters.Add(TracesExporter.Console);
                     break;
                 default:
+                    var unsupportedMessage = $"Traces exporter '{exporterName}' is not supported.";
+                    Logger.Error(unsupportedMessage);
+
                     if (configuration.FailFast)
                     {
-                        var message = $"Traces exporter '{exporterName}' is not supported.";
-                        Logger.Error(message);
-                        throw new NotSupportedException(message);
+                        throw new NotSupportedException(unsupportedMessage);
                     }
 
-                    Logger.Error($"Traces exporter '{exporterName}' is not supported.");
                     break;
             }
         }

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/TracerSettings.cs
@@ -123,13 +123,13 @@ internal class TracerSettings : Settings
             if (seenExporters.Contains(exporterName))
             {
                 var message = $"Duplicate traces exporter '{exporterName}' found.";
-                Logger.Error(message);
-
                 if (configuration.FailFast)
                 {
+                    Logger.Error(message);
                     throw new NotSupportedException(message);
                 }
 
+                Logger.Warning(message);
                 continue;
             }
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
@@ -152,12 +152,27 @@ public class SettingsTests : IDisposable
     }
 
     [Theory]
+    [InlineData("non-supported", new TracesExporter[0])]
+    [InlineData("otlp,otlp", new[] { TracesExporter.Otlp })]
+    [InlineData("otlp, ,console", new[] { TracesExporter.Otlp, TracesExporter.Console })]
+    [InlineData("otlp, , console", new[] { TracesExporter.Otlp })]
+    [InlineData("otlp,,,", new[] { TracesExporter.Otlp })]
+    internal void TracesExporter_FailFastOff(string tracesExporters, TracesExporter[] expectedTracesExporters)
+    {
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporters);
+
+        var settings = Settings.FromDefaultSources<TracerSettings>(false);
+
+        settings.TracesExporters.Should().Equal(expectedTracesExporters);
+    }
+
+    [Theory]
     [InlineData("non-supported")]
     [InlineData("otlp,otlp")]
     [InlineData("otlp, ,console")]
     [InlineData("otlp, console")]
     [InlineData("otlp,,,")]
-    internal void TracesExporter_FailFast(string tracesExporters)
+    internal void TracesExporter_FailFastOn(string tracesExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporters);
 
@@ -188,12 +203,27 @@ public class SettingsTests : IDisposable
     }
 
     [Theory]
+    [InlineData("non-supported", new MetricsExporter[0])]
+    [InlineData("otlp,otlp", new[] { MetricsExporter.Otlp })]
+    [InlineData("otlp, ,console", new[] { MetricsExporter.Otlp, MetricsExporter.Console })]
+    [InlineData("otlp, , console", new[] { MetricsExporter.Otlp })]
+    [InlineData("otlp,,,", new[] { MetricsExporter.Otlp })]
+    internal void MetricExporter_FailFastOff(string metricExporters, MetricsExporter[] expectedMetricsExporters)
+    {
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporters);
+
+        var settings = Settings.FromDefaultSources<MetricSettings>(false);
+
+        settings.MetricExporters.Should().Equal(expectedMetricsExporters);
+    }
+
+    [Theory]
     [InlineData("non-supported")]
     [InlineData("otlp,otlp")]
     [InlineData("otlp, ,console")]
     [InlineData("otlp, console")]
     [InlineData("otlp,,,")]
-    internal void MetricExporter_FailFast(string metricExporters)
+    internal void MetricExporter_FailFastOn(string metricExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporters);
 
@@ -223,12 +253,27 @@ public class SettingsTests : IDisposable
     }
 
     [Theory]
+    [InlineData("non-supported", new LogExporter[0])]
+    [InlineData("otlp,otlp", new[] { LogExporter.Otlp })]
+    [InlineData("otlp, ,console", new[] { LogExporter.Otlp, LogExporter.Console })]
+    [InlineData("otlp, console", new[] { LogExporter.Otlp })]
+    [InlineData("otlp,,,", new[] { LogExporter.Otlp })]
+    internal void LogExporter_FailFastOff(string logExporters, LogExporter[] expectedLogExporters)
+    {
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporters);
+
+        var settings = Settings.FromDefaultSources<LogSettings>(false);
+
+        settings.LogExporters.Should().Equal(expectedLogExporters);
+    }
+
+    [Theory]
     [InlineData("non-supported")]
     [InlineData("otlp,otlp")]
     [InlineData("otlp, ,console")]
     [InlineData("otlp, console")]
     [InlineData("otlp,,,")]
-    internal void LogExporter_FailFast(string logExporters)
+    internal void LogExporter_FailFastOn(string logExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporters);
 
@@ -239,6 +284,7 @@ public class SettingsTests : IDisposable
 
     [Theory]
     [InlineData(null, new Propagator[0])]
+    [InlineData("", new Propagator[0])]
     [InlineData("not-supported", new Propagator[0])]
     [InlineData("not-supported1,not-supported2", new Propagator[0])]
     [InlineData("tracecontext", new[] { Propagator.W3CTraceContext })]
@@ -257,12 +303,27 @@ public class SettingsTests : IDisposable
     }
 
     [Theory]
+    [InlineData("not-supported", new Propagator[0])]
+    [InlineData("tracecontext,tracecontext", new[] { Propagator.W3CTraceContext })]
+    [InlineData("tracecontext, ,b3multi", new[] { Propagator.W3CTraceContext, Propagator.B3Multi })]
+    [InlineData("tracecontext, b3multi", new[] { Propagator.W3CTraceContext })]
+    [InlineData("tracecontext,,,", new[] { Propagator.W3CTraceContext })]
+    internal void Propagators_FailFastOff(string? propagators, Propagator[] expectedPropagators)
+    {
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, propagators);
+
+        var settings = Settings.FromDefaultSources<SdkSettings>(false);
+
+        settings.Propagators.Should().BeEquivalentTo(expectedPropagators);
+    }
+
+    [Theory]
     [InlineData("not-supported")]
     [InlineData("tracecontext,tracecontext")]
     [InlineData("tracecontext, ,b3multi")]
     [InlineData("tracecontext, baggage")]
     [InlineData("tracecontext,,,")]
-    internal void Propagators_FailFast(string propagators)
+    internal void Propagators_FailFastOn(string propagators)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, propagators);
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
@@ -142,19 +142,24 @@ public class SettingsTests : IDisposable
     [InlineData("otlp,none", new[] { TracesExporter.Otlp })]
     [InlineData("non-supported,none", new TracesExporter[0])]
     [InlineData("zipkin,non-supported,none", new[] { TracesExporter.Zipkin })]
-    internal void TracesExporter_SupportedValues(string tracesExporter, TracesExporter[] expectedTracesExporter)
+    internal void TracesExporter_SupportedValues(string tracesExporters, TracesExporter[] expectedTracesExporters)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporter);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporters);
 
         var settings = Settings.FromDefaultSources<TracerSettings>(false);
 
-        settings.TracesExporters.Should().Equal(expectedTracesExporter);
+        settings.TracesExporters.Should().Equal(expectedTracesExporters);
     }
 
-    [Fact]
-    internal void TracesExporter_FailFast()
+    [Theory]
+    [InlineData("non-supported")]
+    [InlineData("otlp,otlp")]
+    [InlineData("otlp, ,console")]
+    [InlineData("otlp, console")]
+    [InlineData("otlp,,,")]
+    internal void TracesExporter_FailFast(string tracesExporters)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, "not-supported");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporters);
 
         var action = () => Settings.FromDefaultSources<TracerSettings>(true);
 
@@ -173,19 +178,24 @@ public class SettingsTests : IDisposable
     [InlineData("prometheus,non-supported,none", new[] { MetricsExporter.Prometheus })]
     [InlineData("non-supported,none", new MetricsExporter[0])]
     [InlineData("otlp,non-supported,none", new[] { MetricsExporter.Otlp })]
-    internal void MetricExporter_SupportedValues(string metricExporter, MetricsExporter[] expectedMetricsExporters)
+    internal void MetricExporter_SupportedValues(string metricExporters, MetricsExporter[] expectedMetricsExporters)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporter);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporters);
 
         var settings = Settings.FromDefaultSources<MetricSettings>(false);
 
         settings.MetricExporters.Should().Equal(expectedMetricsExporters);
     }
 
-    [Fact]
-    internal void MetricExporter_FailFast()
+    [Theory]
+    [InlineData("non-supported")]
+    [InlineData("otlp,otlp")]
+    [InlineData("otlp, ,console")]
+    [InlineData("otlp, console")]
+    [InlineData("otlp,,,")]
+    internal void MetricExporter_FailFast(string metricExporters)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, "not-supported");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporters);
 
         var action = () => Settings.FromDefaultSources<MetricSettings>(true);
 
@@ -203,19 +213,24 @@ public class SettingsTests : IDisposable
     [InlineData("none,otlp", new[] { LogExporter.Otlp })]
     [InlineData("non-supported,none", new LogExporter[0])]
     [InlineData("non-supported,none,otlp", new[] { LogExporter.Otlp })]
-    internal void LogExporter_SupportedValues(string logExporter, LogExporter[] expectedLogExporter)
+    internal void LogExporter_SupportedValues(string logExporters, LogExporter[] expectedLogExporters)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporter);
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporters);
 
         var settings = Settings.FromDefaultSources<LogSettings>(false);
 
-        settings.LogExporters.Should().Equal(expectedLogExporter);
+        settings.LogExporters.Should().Equal(expectedLogExporters);
     }
 
-    [Fact]
-    internal void LogExporter_FailFast()
+    [Theory]
+    [InlineData("non-supported")]
+    [InlineData("otlp,otlp")]
+    [InlineData("otlp, ,console")]
+    [InlineData("otlp, console")]
+    [InlineData("otlp,,,")]
+    internal void LogExporter_FailFast(string logExporters)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, "not-supported");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporters);
 
         var action = () => Settings.FromDefaultSources<LogSettings>(true);
 
@@ -223,14 +238,14 @@ public class SettingsTests : IDisposable
     }
 
     [Theory]
-    [InlineData(null, new Propagator[] { })]
-    [InlineData("not-supported", new Propagator[] { })]
-    [InlineData("not-supported1,not-supported2", new Propagator[] { })]
+    [InlineData(null, new Propagator[0])]
+    [InlineData("not-supported", new Propagator[0])]
+    [InlineData("not-supported1,not-supported2", new Propagator[0])]
     [InlineData("tracecontext", new[] { Propagator.W3CTraceContext })]
     [InlineData("baggage", new[] { Propagator.W3CBaggage })]
     [InlineData("b3multi", new[] { Propagator.B3Multi })]
     [InlineData("b3", new[] { Propagator.B3Single })]
-    [InlineData("not-supported,b3", new Propagator[] { Propagator.B3Single })]
+    [InlineData("not-supported,b3", new[] { Propagator.B3Single })]
     [InlineData("tracecontext,baggage,b3multi,b3", new[] { Propagator.W3CTraceContext, Propagator.W3CBaggage, Propagator.B3Multi, Propagator.B3Single })]
     internal void Propagators_SupportedValues(string? propagators, Propagator[] expectedPropagators)
     {
@@ -241,10 +256,15 @@ public class SettingsTests : IDisposable
         settings.Propagators.Should().BeEquivalentTo(expectedPropagators);
     }
 
-    [Fact]
-    internal void Propagators_FailFast()
+    [Theory]
+    [InlineData("not-supported")]
+    [InlineData("tracecontext,tracecontext")]
+    [InlineData("tracecontext, ,b3multi")]
+    [InlineData("tracecontext, baggage")]
+    [InlineData("tracecontext,,,")]
+    internal void Propagators_FailFast(string propagators)
     {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, "not-supported");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, propagators);
 
         var action = () => Settings.FromDefaultSources<SdkSettings>(true);
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
@@ -133,31 +133,20 @@ public class SettingsTests : IDisposable
     [Theory]
     [InlineData("", new[] { TracesExporter.Otlp })]
     [InlineData("none", new TracesExporter[0])]
-    [InlineData("non-supported", new TracesExporter[0])]
     [InlineData("otlp", new[] { TracesExporter.Otlp })]
     [InlineData("console", new[] { TracesExporter.Console })]
     [InlineData("zipkin", new[] { TracesExporter.Zipkin })]
     [InlineData("otlp,zipkin,console", new[] { TracesExporter.Otlp, TracesExporter.Zipkin, TracesExporter.Console })]
     [InlineData("none,zipkin", new[] { TracesExporter.Zipkin })]
     [InlineData("otlp,none", new[] { TracesExporter.Otlp })]
+    [InlineData("non-supported", new TracesExporter[0])]
     [InlineData("non-supported,none", new TracesExporter[0])]
     [InlineData("zipkin,non-supported,none", new[] { TracesExporter.Zipkin })]
-    internal void TracesExporter_SupportedValues(string tracesExporters, TracesExporter[] expectedTracesExporters)
-    {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporters);
-
-        var settings = Settings.FromDefaultSources<TracerSettings>(false);
-
-        settings.TracesExporters.Should().Equal(expectedTracesExporters);
-    }
-
-    [Theory]
-    [InlineData("non-supported", new TracesExporter[0])]
     [InlineData("otlp,otlp", new[] { TracesExporter.Otlp })]
     [InlineData("otlp, ,console", new[] { TracesExporter.Otlp, TracesExporter.Console })]
     [InlineData("otlp, , console", new[] { TracesExporter.Otlp })]
     [InlineData("otlp,,,", new[] { TracesExporter.Otlp })]
-    internal void TracesExporter_FailFastOff(string tracesExporters, TracesExporter[] expectedTracesExporters)
+    internal void TracesExporters(string tracesExporters, TracesExporter[] expectedTracesExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporters);
 
@@ -172,7 +161,7 @@ public class SettingsTests : IDisposable
     [InlineData("otlp, ,console")]
     [InlineData("otlp, console")]
     [InlineData("otlp,,,")]
-    internal void TracesExporter_FailFastOn(string tracesExporters)
+    internal void TracesExporters_FailFast(string tracesExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Traces.Exporter, tracesExporters);
 
@@ -184,31 +173,20 @@ public class SettingsTests : IDisposable
     [Theory]
     [InlineData("", new[] { MetricsExporter.Otlp })]
     [InlineData("none", new MetricsExporter[0])]
-    [InlineData("non-supported", new MetricsExporter[0])]
     [InlineData("otlp", new[] { MetricsExporter.Otlp })]
     [InlineData("prometheus", new[] { MetricsExporter.Prometheus })]
     [InlineData("console", new[] { MetricsExporter.Console })]
     [InlineData("otlp,prometheus,console", new[] { MetricsExporter.Otlp, MetricsExporter.Prometheus, MetricsExporter.Console })]
     [InlineData("prometheus,none", new[] { MetricsExporter.Prometheus })]
-    [InlineData("prometheus,non-supported,none", new[] { MetricsExporter.Prometheus })]
-    [InlineData("non-supported,none", new MetricsExporter[0])]
-    [InlineData("otlp,non-supported,none", new[] { MetricsExporter.Otlp })]
-    internal void MetricExporter_SupportedValues(string metricExporters, MetricsExporter[] expectedMetricsExporters)
-    {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporters);
-
-        var settings = Settings.FromDefaultSources<MetricSettings>(false);
-
-        settings.MetricExporters.Should().Equal(expectedMetricsExporters);
-    }
-
-    [Theory]
     [InlineData("non-supported", new MetricsExporter[0])]
+    [InlineData("non-supported,none", new MetricsExporter[0])]
+    [InlineData("prometheus,non-supported,none", new[] { MetricsExporter.Prometheus })]
+    [InlineData("otlp,non-supported,none", new[] { MetricsExporter.Otlp })]
     [InlineData("otlp,otlp", new[] { MetricsExporter.Otlp })]
     [InlineData("otlp, ,console", new[] { MetricsExporter.Otlp, MetricsExporter.Console })]
     [InlineData("otlp, , console", new[] { MetricsExporter.Otlp })]
     [InlineData("otlp,,,", new[] { MetricsExporter.Otlp })]
-    internal void MetricExporter_FailFastOff(string metricExporters, MetricsExporter[] expectedMetricsExporters)
+    internal void MetricExporters(string metricExporters, MetricsExporter[] expectedMetricsExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporters);
 
@@ -223,7 +201,7 @@ public class SettingsTests : IDisposable
     [InlineData("otlp, ,console")]
     [InlineData("otlp, console")]
     [InlineData("otlp,,,")]
-    internal void MetricExporter_FailFastOn(string metricExporters)
+    internal void MetricExporters_FailFast(string metricExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Metrics.Exporter, metricExporters);
 
@@ -235,30 +213,19 @@ public class SettingsTests : IDisposable
     [Theory]
     [InlineData("", new[] { LogExporter.Otlp })]
     [InlineData("none", new LogExporter[0])]
-    [InlineData("non-supported", new LogExporter[0])]
     [InlineData("otlp", new[] { LogExporter.Otlp })]
     [InlineData("console", new[] { LogExporter.Console })]
     [InlineData("otlp,none", new[] { LogExporter.Otlp })]
     [InlineData("otlp,console", new[] { LogExporter.Otlp, LogExporter.Console })]
     [InlineData("none,otlp", new[] { LogExporter.Otlp })]
+    [InlineData("non-supported", new LogExporter[0])]
     [InlineData("non-supported,none", new LogExporter[0])]
     [InlineData("non-supported,none,otlp", new[] { LogExporter.Otlp })]
-    internal void LogExporter_SupportedValues(string logExporters, LogExporter[] expectedLogExporters)
-    {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporters);
-
-        var settings = Settings.FromDefaultSources<LogSettings>(false);
-
-        settings.LogExporters.Should().Equal(expectedLogExporters);
-    }
-
-    [Theory]
-    [InlineData("non-supported", new LogExporter[0])]
     [InlineData("otlp,otlp", new[] { LogExporter.Otlp })]
     [InlineData("otlp, ,console", new[] { LogExporter.Otlp, LogExporter.Console })]
     [InlineData("otlp, console", new[] { LogExporter.Otlp })]
     [InlineData("otlp,,,", new[] { LogExporter.Otlp })]
-    internal void LogExporter_FailFastOff(string logExporters, LogExporter[] expectedLogExporters)
+    internal void LogExporters(string logExporters, LogExporter[] expectedLogExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporters);
 
@@ -273,7 +240,7 @@ public class SettingsTests : IDisposable
     [InlineData("otlp, ,console")]
     [InlineData("otlp, console")]
     [InlineData("otlp,,,")]
-    internal void LogExporter_FailFastOn(string logExporters)
+    internal void LogExporters_FailFast(string logExporters)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Logs.Exporter, logExporters);
 
@@ -285,30 +252,19 @@ public class SettingsTests : IDisposable
     [Theory]
     [InlineData(null, new Propagator[0])]
     [InlineData("", new Propagator[0])]
-    [InlineData("not-supported", new Propagator[0])]
-    [InlineData("not-supported1,not-supported2", new Propagator[0])]
     [InlineData("tracecontext", new[] { Propagator.W3CTraceContext })]
     [InlineData("baggage", new[] { Propagator.W3CBaggage })]
     [InlineData("b3multi", new[] { Propagator.B3Multi })]
     [InlineData("b3", new[] { Propagator.B3Single })]
-    [InlineData("not-supported,b3", new[] { Propagator.B3Single })]
     [InlineData("tracecontext,baggage,b3multi,b3", new[] { Propagator.W3CTraceContext, Propagator.W3CBaggage, Propagator.B3Multi, Propagator.B3Single })]
-    internal void Propagators_SupportedValues(string? propagators, Propagator[] expectedPropagators)
-    {
-        Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, propagators);
-
-        var settings = Settings.FromDefaultSources<SdkSettings>(false);
-
-        settings.Propagators.Should().BeEquivalentTo(expectedPropagators);
-    }
-
-    [Theory]
     [InlineData("not-supported", new Propagator[0])]
+    [InlineData("not-supported1,not-supported2", new Propagator[0])]
+    [InlineData("not-supported,b3", new[] { Propagator.B3Single })]
     [InlineData("tracecontext,tracecontext", new[] { Propagator.W3CTraceContext })]
     [InlineData("tracecontext, ,b3multi", new[] { Propagator.W3CTraceContext, Propagator.B3Multi })]
     [InlineData("tracecontext, b3multi", new[] { Propagator.W3CTraceContext })]
     [InlineData("tracecontext,,,", new[] { Propagator.W3CTraceContext })]
-    internal void Propagators_FailFastOff(string? propagators, Propagator[] expectedPropagators)
+    internal void Propagators(string? propagators, Propagator[] expectedPropagators)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, propagators);
 
@@ -323,7 +279,7 @@ public class SettingsTests : IDisposable
     [InlineData("tracecontext, ,b3multi")]
     [InlineData("tracecontext, baggage")]
     [InlineData("tracecontext,,,")]
-    internal void Propagators_FailFastOn(string propagators)
+    internal void Propagators_FailFast(string propagators)
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.Sdk.Propagators, propagators);
 


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/3534

## What

| Description                     | Input Example         | Fail Fast Disabled                                                | Fail Fast Enabled                                                  |
|---------------------------------|-----------------------|-------------------------------------------------------------------|---------------------------------------------------------------------|
| Spaces around list elements.    | otlp, console         | Log warning, that the value `console` is not supported, only OTLP protocol is used | Log warning + crash application                                   |
| Duplicated entries.              | otlp,console,otlp    | Log warning about duplicated entries. Remove duplicated records. | Log warning about duplicated entries, Crash application            |
| Empty element                    | otlp, ,console        | Treat it as any non-supported exporter. Warn log only             | Same as fail fast disabled + crash application                      |

Also refactor Sdk settings
<!-- Describe changes proposed in this pull request. -->

## Tests

SettingsTests.cs

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
