### PR TITLE
Use PreserveNewest for copy instructions of instrumenation scripts.

### DIFF
--- a/nuget/OpenTelemetry.AutoInstrumentation/build/opentelemetry.autoinstrumentation.props
+++ b/nuget/OpenTelemetry.AutoInstrumentation/build/opentelemetry.autoinstrumentation.props
@@ -5,8 +5,8 @@
 <ItemGroup>
   <Content Update="@(Content)">
     <Visible Condition="'%(NuGetItemType)' == 'Content' and '%(NuGetPackageId)' == 'opentelemetry.autoinstrumentation'">False</Visible>
-    <CopyToOutputDirectory Condition="'%(NuGetItemType)' == 'Content' and '%(NuGetPackageId)' == 'opentelemetry.autoinstrumentation'">Always</CopyToOutputDirectory>
-    <CopyToPublishDirectory Condition="'%(NuGetItemType)' == 'Content' and '%(NuGetPackageId)' == 'opentelemetry.autoinstrumentation'">Always</CopyToPublishDirectory>
+    <CopyToOutputDirectory Condition="'%(NuGetItemType)' == 'Content' and '%(NuGetPackageId)' == 'opentelemetry.autoinstrumentation'">PreserveNewest</CopyToOutputDirectory>
+    <CopyToPublishDirectory Condition="'%(NuGetItemType)' == 'Content' and '%(NuGetPackageId)' == 'opentelemetry.autoinstrumentation'">PreserveNewest</CopyToPublishDirectory>
   </Content>
 </ItemGroup>
 </Project>


### PR DESCRIPTION
Continuation/Fix for #3538

Using `Always` has a higher chance of breaking incremental builds then `PreserveNewest`.
