### PR TITLE
Update dotnet-install SHA

### DIFF
--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -19,7 +19,7 @@ ENV gRPC_PluginFullPath=/usr/bin/grpc_csharp_plugin
 # Install older sdks using the install script
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "fe864d126da4d20b353e3983f186894a63009ce6fbe3108b0dac35a346331808  dotnet-install.sh" | sha256sum -c \
+    && echo "8b33761700040a9cd7f835f181a7c350b866e42425540c3a1894cc7919b275e3  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 6.0.424 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh -v 7.0.410 --install-dir /usr/share/dotnet --no-path \

--- a/docker/debian-arm64.dockerfile
+++ b/docker/debian-arm64.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 # Install older sdks using the install script as there are no arm64 SDK packages.
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "fe864d126da4d20b353e3983f186894a63009ce6fbe3108b0dac35a346331808  dotnet-install.sh" | sha256sum -c \
+    && echo "8b33761700040a9cd7f835f181a7c350b866e42425540c3a1894cc7919b275e3  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 6.0.424 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh -v 7.0.410 --install-dir /usr/share/dotnet --no-path \


### PR DESCRIPTION
## Why & What

Update dotnet-install SHA.

We are comparing computed checksum to expected checksum when building dockerfiles.
Due to recent change of the script contents, this comparison fails.
Source of the scripts can be found [here](https://github.com/dotnet/install-scripts/blob/bd061adee5bcc6a04509a71e2d2806cde6b21af0/src/dotnet-install.sh), as explained [in the docs](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#recommended-version).

## Tests

CI

## Checklist

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
