### PR TITLE
Bump .NET SDK to 8.0.401/6.0.425

### DIFF
--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Check for NuGet packages cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag: v4.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Check for NuGet packages cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag: v4.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Check for NuGet packages cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag: v4.0.2
@@ -131,9 +131,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Check for NuGet packages cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag: v4.0.2
@@ -171,9 +171,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Check for NuGet packages cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag: v4.0.2
@@ -276,9 +276,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Check for NuGet packages cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag: v4.0.2

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup .NET 8
       uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
       with:
-        dotnet-version: 8.0.303
+        dotnet-version: 8.0.401
 
     - name: dotnet format
       run: dotnet format .\OpenTelemetry.AutoInstrumentation.sln --no-restore --verify-no-changes

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
             
       - name: Test the PowerShell module instructions from README.md
         shell: powershell
@@ -68,9 +68,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Install MacOS CoreUtils
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # tag: v4.0.1
         with:
           dotnet-version: | 
-            6.0.424
+            6.0.425
             7.0.410
-            8.0.303
+            8.0.401
 
       - name: Run BuildTracer and ManagedTests
         run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project "${{ github.event.inputs.testProject }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -21,7 +21,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
     && echo "8b33761700040a9cd7f835f181a7c350b866e42425540c3a1894cc7919b275e3  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 6.0.424 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 6.0.425 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh -v 7.0.410 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 

--- a/docker/centos.dockerfile
+++ b/docker/centos.dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/open-telemetry/opentelemetry-dotnet-instrumentation-centos7-build-image:main
 
 RUN rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
-RUN yum -y install dotnet-sdk-6.0-6.0.424-1 dotnet-sdk-7.0-7.0.410-1
+RUN yum -y install dotnet-sdk-6.0-6.0.425-1 dotnet-sdk-7.0-7.0.410-1
 
 ENV IsCentos=true
 WORKDIR /project

--- a/docker/debian-arm64.dockerfile
+++ b/docker/debian-arm64.dockerfile
@@ -11,7 +11,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && echo "SHA256: $(sha256sum dotnet-install.sh)" \
     && echo "8b33761700040a9cd7f835f181a7c350b866e42425540c3a1894cc7919b275e3  dotnet-install.sh" | sha256sum -c \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 6.0.424 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 6.0.425 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh -v 7.0.410 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 

--- a/test/test-applications/nuget-packages/Directory.Packages.props
+++ b/test/test-applications/nuget-packages/Directory.Packages.props
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- The NuGet package test applications shouldn't use the common build settings -->
-
-  <ItemGroup>
-    <!-- This version is here to avoid compilation warnings. During the build is overriden by nuke tasks. -->
-    <PackageVersion Include="OpenTelemetry.AutoInstrumentation" Version="1.7.0" />
-  </ItemGroup>
 </Project>

--- a/test/test-applications/nuget-packages/TestApplication.SelfContained/TestApplication.SelfContained.csproj
+++ b/test/test-applications/nuget-packages/TestApplication.SelfContained/TestApplication.SelfContained.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.AutoInstrumentation" VersionOverride="$(NuGetPackageVersion)" />
+    <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="$(NuGetPackageVersion)" Condition=" '$(NuGetPackageVersion)' != '' " />
+    <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.7.0" Condition=" '$(NuGetPackageVersion)' == '' " />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

Follow ups to #3573 and #3577

## What

Bump .NET SDK to 8.0.401/6.0.425
Fixes nuget-tests-packages. Previously for tests, it was always using 1.0.0 version (at least with the latest .NET SDK).

## Tests

CI

## Checklist

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
