### PR TITLE
NServiceBus - metrics support 9.1.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Support for Operating System resource detector.
 - Support for [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client/)
   traces instrumentation for versions `6.0.0`-`6.*.*`
+- Support for NServiceBus 9.1+ metrics instrumentations.
 - Added support for OTEL_TRACES_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_LOGS_EXPORTER
   to handle comma-separated list.
 - The environment variables `OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`,

--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -129,7 +129,8 @@ public static partial class LibraryVersion
             new List<PackageBuildInfo>
             {
                 new("8.0.0"),
-                new("9.0.2", supportedFrameworks: new string[] {"net8.0"}),
+                new("9.1.0", supportedFrameworks: new string[] {"net8.0"}),
+                new("9.1.1", supportedFrameworks: new string[] {"net8.0"}),
             }
         },
         {

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/EnvironmentConfigurationMetricHelper.cs
@@ -29,7 +29,12 @@ internal static class EnvironmentConfigurationMetricHelper
                 MetricInstrumentation.HttpClient => Wrappers.AddHttpClientInstrumentation(builder, lazyInstrumentationLoader),
                 MetricInstrumentation.NetRuntime => Wrappers.AddRuntimeInstrumentation(builder, pluginManager),
                 MetricInstrumentation.Process => Wrappers.AddProcessInstrumentation(builder),
-                MetricInstrumentation.NServiceBus => builder.AddMeter("NServiceBus.Core"),
+                MetricInstrumentation.NServiceBus => builder
+#if NET6_0_OR_GREATER
+                    .AddMeter("NServiceBus.Core.Pipeline.Incoming") // NServiceBus 9.1.0+
+#endif
+                    .AddMeter("NServiceBus.Core"), // NServiceBus [8,0.0, 9.1.0)
+
 #if NET6_0_OR_GREATER
                 MetricInstrumentation.AspNetCore => Wrappers.AddAspNetCoreInstrumentation(builder, lazyInstrumentationLoader),
 #endif

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="MySqlConnector" Version="2.3.7" />
     <PackageVersion Include="MySql.Data" Version="9.0.0" />
-    <PackageVersion Include="NServiceBus" Version="9.0.2" />
+    <PackageVersion Include="NServiceBus" Version="9.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
     <PackageVersion Include="NuGet.Versioning" Version="6.5.0" />

--- a/test/IntegrationTests/CustomSdkTests.cs
+++ b/test/IntegrationTests/CustomSdkTests.cs
@@ -66,7 +66,11 @@ public class CustomSdkTests : TestHelper
         collector.ResourceExpector.Expect("test_attr", "added_manually");
 
         collector.Expect("OpenTelemetry.Instrumentation.Http");
+#if NET8_0_OR_GREATER
+        collector.Expect("NServiceBus.Core.Pipeline.Incoming");
+#else
         collector.Expect("NServiceBus.Core");
+#endif
         collector.Expect("TestApplication.CustomSdk");
 
         EnableBytecodeInstrumentation();

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -218,7 +218,10 @@ public static partial class LibraryVersion
 #else
             theoryData.Add("8.0.0");
 #if NET8_0
-            theoryData.Add("9.0.2");
+            theoryData.Add("9.1.0");
+#endif
+#if NET8_0
+            theoryData.Add("9.1.1");
 #endif
 #endif
             return theoryData;

--- a/test/IntegrationTests/NServiceBusTests.cs
+++ b/test/IntegrationTests/NServiceBusTests.cs
@@ -43,7 +43,19 @@ public class NServiceBusTests : TestHelper
     {
         using var collector = new MockMetricsCollector(Output);
         SetExporter(collector);
+
+#if NET8_0_OR_GREATER
+        if (string.IsNullOrEmpty(packageVersion) || Version.Parse(packageVersion) >= new Version(9, 1))
+        {
+            collector.Expect("NServiceBus.Core.Pipeline.Incoming");
+        }
+        else
+        {
+            collector.Expect("NServiceBus.Core");
+        }
+#else
         collector.Expect("NServiceBus.Core");
+#endif
 
         SetEnvironmentVariable("LONG_RUNNING", "true");
         SetEnvironmentVariable("OTEL_METRIC_EXPORT_INTERVAL", "100");

--- a/test/test-applications/integrations/TestApplication.CustomSdk/Program.cs
+++ b/test/test-applications/integrations/TestApplication.CustomSdk/Program.cs
@@ -121,7 +121,11 @@ public static class Program
             // lazily-loaded metric instrumentation
             .AddMeter("OpenTelemetry.Instrumentation.*")
             // bytecode metric instrumentation
+#if NET8_0_OR_GREATER
+            .AddMeter("NServiceBus.Core.Pipeline.Incoming")
+#else
             .AddMeter("NServiceBus.Core")
+#endif
             // custom metric
             .AddMeter("TestApplication.CustomSdk")
             .ConfigureResource(builder =>

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -169,6 +169,7 @@ internal static class PackageVersionDefinitions
             Versions = new List<PackageVersion>
             {
                 new("8.0.0"),
+                new("9.1.0", supportedTargetFrameworks: new[] { "net8.0" }, supportedExecutionFrameworks: new[] { "net8.0" }), // breaking change, new Meter name
                 new("*", supportedTargetFrameworks: new[] { "net8.0" }, supportedExecutionFrameworks: new[] { "net8.0" })
             }
         },


### PR DESCRIPTION
## Why

Handles https://github.com/Particular/NServiceBus/releases/tag/9.1.0 - especially https://github.com/Particular/NServiceBus/pull/7095

## What

NServiceBus - metrics support 9.1.0+

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
