### PR TITLE
Revert Workaround dotnet CLI build-server shutdown issue

### DIFF
--- a/test/IntegrationTests/DotNetCliTests.cs
+++ b/test/IntegrationTests/DotNetCliTests.cs
@@ -44,7 +44,7 @@ public sealed class DotNetCliTests : TestHelper, IDisposable
 
         // Stop all build servers to ensure user like experience.
         // Currently there is an issue trying to launch VBCSCompiler background server.
-        RunDotNetCli("build-server shutdown", successMessage: "MSBuild server shut down successfully.");
+        RunDotNetCli("build-server shutdown");
 
         var tfm = $"net{Environment.Version.Major}.0";
         RunDotNetCli($"new console --framework {tfm}");
@@ -74,7 +74,7 @@ Console.WriteLine(response.StatusCode);
         File.WriteAllText("Program.cs", ProgramContent);
     }
 
-    private void RunDotNetCli(string arguments, string successMessage = "")
+    private void RunDotNetCli(string arguments)
     {
         Output.WriteLine($"Running: {DotNetCli} {arguments}");
 
@@ -94,14 +94,7 @@ Console.WriteLine(response.StatusCode);
         Output.WriteResult(helper);
 
         processTimeout.Should().BeFalse("Test application timed out");
-        if (!string.IsNullOrEmpty(successMessage))
-        {
-            helper.StandardOutput.Should().Contain(successMessage, "Test application did not output expected message");
-        }
-        else
-        {
-            process.ExitCode.Should().Be(0, "Test application exited with non-zero exit code");
-        }
+        process.ExitCode.Should().Be(0, "Test application exited with non-zero exit code");
     }
 
     private void RunAppWithDotNetCliAndAssertHttpSpans(string arguments)


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Fixes #3522
Reverts #3520

## What

Revert Workaround dotnet CLI build-server shutdown issue

## Tests

Updated.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
