### PR TITLE
Fix MongoDB instrumentation for 2.29.0+

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.NetFramework.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.NetFramework.cs
@@ -33,7 +33,30 @@ internal partial class Loader
             return null;
         }
 
-        Logger.Debug("Requester [{0}] requested [{1}]", args?.RequestingAssembly?.FullName ?? "<null>", args?.Name ?? "<null>");
+        Logger.Debug("Requester [{0}] requested [{1}]", args.RequestingAssembly?.FullName ?? "<null>", args.Name ?? "<null>");
+
+        // All MongoDB* are signed and does not follow https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/versioning#assembly-version
+        // There is no possibility to automatically redirect from 2.28.0 to 2.29.0.
+        // Loading assembly and ignoring this version.
+        if (assemblyName.StartsWith("MongoDB", StringComparison.OrdinalIgnoreCase) &&
+            (string.Equals(assemblyName, "MongoDB.Driver.Core", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(assemblyName, "MongoDB.Bson", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(assemblyName, "MongoDB.Libmongocrypt", StringComparison.OrdinalIgnoreCase)))
+        {
+            try
+            {
+                var mongoAssembly = Assembly.Load(assemblyName);
+                Logger.Debug<string, bool>("Assembly.Load(\"{0}\") succeeded={1}", assemblyName, mongoAssembly != null);
+                return mongoAssembly;
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Assembly.Load(\"{0}\") Exception: {1}", assemblyName, ex.Message);
+            }
+
+            return null;
+        }
+
         var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName}.dll");
         if (File.Exists(path))
         {


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3667#issuecomment-2376061482

## What

Fixes loading MongoDB related assemblies.

MongoDB.Driver.Core 2.28.0+ are signed. What is more MongoDB does not follow recommendation about [Assembly Versioning](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/versioning#assembly-version) and Assembly Version is Equal to Library version (2.28.0.0 and 2.29.0.0).

 MongoDB.Driver.Core.Extensions.DiagnosticSources references MongoDB.Driver.Core v2.28.0.
When the test application is using MongoDB.Driver.Core v2.28.0. It leads to following error:

```log
[2024-09-26T06:23:46.2073304Z] [Debug] EventSource=OpenTelemetry-AutoInstrumentation-Loader, Message=Requester [<null>] requested [MongoDB.Driver.Core, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321] 
[2024-09-26T06:23:46.2920125Z] [Debug] EventSource=OpenTelemetry-AutoInstrumentation-Loader, Message=Requester [<null>] requested [MongoDB.Driver.Core, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321] 
[2024-09-26T06:23:46.3390112Z] [Error] Could not load file or assembly 'MongoDB.Driver.Core, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321' or one of its dependencies. The system cannot find the file specified.
Exception: Could not load file or assembly 'MongoDB.Driver.Core, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321' or one of its dependencies. The system cannot find the file specified.
System.IO.FileNotFoundException: Could not load file or assembly 'MongoDB.Driver.Core, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321' or one of its dependencies. The system cannot find the file specified.
File name: 'MongoDB.Driver.Core, Version=2.28.0.0, Culture=neutral, PublicKeyToken=94992a530f44e321'
   at System.Signature.GetSignature(Void* pCorSig, Int32 cCorSig, RuntimeFieldHandleInternal fieldHandle, IRuntimeMethodInfo methodHandle, RuntimeType declaringType)
   at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, Object[] index)
   at OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration.GetInstrumentationOptions()
   at OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration.GetClusterConfiguratorExpression()
   at OpenTelemetry.AutoInstrumentation.Instrumentations.MongoDB.MongoClientIntegration.OnMethodBegin[TTarget,TMongoClientSettings](TTarget instance, TMongoClientSettings settings)
   at OpenTelemetry.AutoInstrumentation.CallTarget.Handlers.BeginMethodHandler`3.Invoke(TTarget instance, TArg1& arg1)
   at MongoDB.Driver.MongoClient..ctor(MongoClientSettings settings)

WRN: Assembly binding logging is turned OFF.
To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.
Note: There is some performance penalty associated with assembly bind failure logging.
To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].
```

Workaround - ignore versioning check and load assembly manually by the name (from the application context).

## Alternatives

1. Fully drop references to `MongoDB.Driver.Core.Extensions.DiagnosticSources` and implement instrumentation as a bytecode (we need it already partially to enable instrumentation). It can be done before release or as the follow up.

2. Revert changes from: #3604 and #3615. It might be not the best option if we check [download statistics from the last 6 weeks](https://www.nuget.org/stats/packages/MongoDB.Driver.Core?groupby=Version). 

3. Implement instrumentation on the MongoDB side, but it not short term solution.

## Tests

Tested locally, as tests for MongoDB on .NET Framework are not executed in the pipeline.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests - as a part of release process.
