### PR TITLE
Centos Stream 9 test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,9 @@ jobs:
             base-image: debian
             build-source: ubuntu-20.04
             os-type: linux-glibc
+          - machine: ubuntu-20.04
+            base-image: centos-stream9
+            build-source: ubuntu-20.4
           - machine: otel-linux-arm64
             base-image: alpine
             build-source: alpine-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
             os-type: linux-glibc
           - machine: ubuntu-20.04
             base-image: centos-stream9
-            build-source: ubuntu-20.4
+            build-source: ubuntu-20.04
             os-type: linux-glibc
           - machine: otel-linux-arm64
             base-image: alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,7 @@ jobs:
           - machine: ubuntu-20.04
             base-image: centos-stream9
             build-source: ubuntu-20.4
+            os-type: linux-glibc
           - machine: otel-linux-arm64
             base-image: alpine
             build-source: alpine-arm64

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y \
     dotnet-sdk-6.0
 
 # https://github.com/dotnet/runtime/issues/65874
-RUN update-crypto-pololicies --set LEGACY
+RUN update-crypto-policies --set LEGACY
 
 # Install dependencies
 RUN dnf install -y \

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
 # Install dotnet sdk
-RUN dnf install \
+RUN dnf install -y \
     dotnet-sdk-8.0 \
     dotnet-sdk-7.0 \
     dotnet-sdk-6.0
@@ -10,7 +10,8 @@ RUN dnf install \
 RUN update-crypto-pololicies --set LEGACY
 
 # Install dependencies
-RUN dnf install cmake-3.26.5-2.el9 \
+RUN dnf install -y \
+    cmake-3.26.5-2.el9 \
     clang-18.1.8-3.el9
 
 WORKDIR /project

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,9 +1,10 @@
 FROM quay.io/centos/centos:stream9
 
 # Install dotnet sdk
-RUN dnf install dotnet-sdk-8.0 \
-    dnf install dotnet-sdk-7.0 \
-    dnf install dotnet-sdk-6.0
+RUN dnf install \
+    dotnet-sdk-8.0 \
+    dotnet-sdk-7.0 \
+    dotnet-sdk-6.0
 
 # https://github.com/dotnet/runtime/issues/65874
 RUN update-crypto-pololicies --set LEGACY

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,0 +1,15 @@
+FROM quay.io/centos/centos:stream9
+
+# Install dotnet sdk
+RUN dnf install dotnet-sdk-8.0 \
+    dnf install dotnet-sdk-7.0 \
+    dnf install dotnet-sdk-6.0
+
+# https://github.com/dotnet/runtime/issues/65874
+RUN update-crypto-pololicies --set LEGACY
+
+# Install dependencies
+RUN dnf install cmake-3.26.5-2.el9 \
+    clang-18.1.8-3.el9
+
+WORKDIR /project

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -12,6 +12,7 @@ RUN update-crypto-policies --set LEGACY
 # Install dependencies
 RUN dnf install -y \
     cmake-3.26.5-2.el9 \
-    clang-18.1.8-3.el9
+    clang-18.1.8-3.el9 \
+    git-2.43.5-1.el9
 
 WORKDIR /project

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@ CI tests run against the following operating systems:
 - [Debian ARM64](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/debian-arm64.dockerfile)
 - [CentOS 7 x64](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/centos-build.dockerfile)
   (.NET 8 is not supported)
+- [CentOS Stream 9 x64](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/centos-stream9.dockerfile)
 - [macOS Monterey 12 x64](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)
 - [Microsoft Windows Server 2022 x64](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)
 - [Ubuntu 20.04 LTS x64](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md)


### PR DESCRIPTION
## Why

Replaces Centos tests in the future (after Centos deprecates).

## What

Runs tests on Centos Stream 9.

## Tests

using quay.io/centos/centos:stream9 base image.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
