### PR TITLE
Bump Nuke to 8.1.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nuke.globaltool": {
-      "version": "8.1.0",
+      "version": "8.1.1",
       "commands": [
         "nuke"
       ]

--- a/build/Build.Steps.Linux.cs
+++ b/build/Build.Steps.Linux.cs
@@ -20,7 +20,7 @@ partial class Build
                 arguments: $"../ -DCMAKE_BUILD_TYPE=Release -DOTEL_AUTO_VERSION={VersionHelper.GetVersionWithoutSuffixes()} -DOTEL_AUTO_VERSION_MAJOR={major} -DOTEL_AUTO_VERSION_MINOR={minor} -DOTEL_AUTO_VERSION_PATCH={patch}",
                 workingDirectory: buildDirectory);
             Make.Value(
-                arguments: $" ", //space is needed - see https://github.com/nuke-build/nuke/issues/1417
+                arguments: $"",
                 workingDirectory: buildDirectory);
         });
 
@@ -35,7 +35,7 @@ partial class Build
                 arguments: "-S .",
                 workingDirectory: buildDirectory);
             Make.Value(
-                arguments: $" ", //space is needed - see https://github.com/nuke-build/nuke/issues/1417
+                arguments: $"",
                 workingDirectory: buildDirectory);
         });
 

--- a/build/Build.Steps.MacOS.cs
+++ b/build/Build.Steps.MacOS.cs
@@ -19,7 +19,7 @@ partial class Build
                 arguments: $". -DOTEL_AUTO_VERSION={VersionHelper.GetVersionWithoutSuffixes()} -DOTEL_AUTO_VERSION_MAJOR={major} -DOTEL_AUTO_VERSION_MINOR={minor} -DOTEL_AUTO_VERSION_PATCH={patch}",
                 workingDirectory: nativeProjectDirectory);
             Make.Value(
-                arguments: $" ", //space is needed - see https://github.com/nuke-build/nuke/issues/1417
+                arguments: $"",
                 workingDirectory: nativeProjectDirectory);
         });
 
@@ -34,7 +34,7 @@ partial class Build
                 arguments: "-S .",
                 workingDirectory: buildDirectory);
             Make.Value(
-                arguments: $" ", //space is needed - see https://github.com/nuke-build/nuke/issues/1417
+                arguments: $"",
                 workingDirectory: buildDirectory);
         });
 

--- a/build/Directory.Packages.props
+++ b/build/Directory.Packages.props
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
-    <PackageVersion Include="Nuke.Common" Version="8.1.0" />
+    <PackageVersion Include="Nuke.Common" Version="8.1.1" />
     <PackageVersion Include="Nuget.CommandLine" Version="6.11.1" />
   </ItemGroup>
 </Project>

--- a/build/Extensions/DepsJsonExtensions.cs
+++ b/build/Extensions/DepsJsonExtensions.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Text.Json.Nodes;
 using Nuke.Common.IO;
-using Nuke.Common.Utilities.Collections;
 
 namespace Extensions;
 
@@ -89,7 +88,7 @@ internal static class DepsJsonExtensions
                     var newKey = libKey.Replace($"lib/{runtime}", $"lib/{rollForwardRuntime}");
 
                     runtimeObject.Remove(libKey);
-                    runtimeObject.AddPair(newKey, libNode);
+                    runtimeObject.Add(newKey, libNode);
                 }
             }
         }


### PR DESCRIPTION
## Why

https://github.com/nuke-build/nuke/commit/3b05abfd481ff71412626da361632229d84f77e8

## What

Bump Nuke to 8.1.1
Remove workarounds for 8.1.0

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
