### PR TITLE
NuGet Audit fix - testing application - part 1

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -118,8 +118,7 @@ public static partial class LibraryVersion
             "TestApplication.Npgsql",
             new List<PackageBuildInfo>
             {
-                new("6.0.11"),
-                new("8.0.4"),
+                new("8.0.5"),
             }
         },
         {

--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -19,8 +19,7 @@ public static partial class LibraryVersion
             "TestApplication.Azure",
             new List<PackageBuildInfo>
             {
-                new("12.13.0"),
-                new("12.22.0"),
+                new("12.22.2"),
             }
         },
         {

--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -35,10 +35,8 @@ public static partial class LibraryVersion
             "TestApplication.EntityFrameworkCore",
             new List<PackageBuildInfo>
             {
-                new("6.0.33"),
-                new("7.0.20"),
-                new("8.0.2", supportedFrameworks: new string[] {"net8.0"}),
-                new("8.0.8", supportedFrameworks: new string[] {"net8.0"}),
+                new("6.0.35"),
+                new("8.0.10", supportedFrameworks: new string[] {"net8.0"}),
             }
         },
         {

--- a/next-gen/docs/getting-started-dotnet-monitor-logs/getting-started-dotnet-monitor-logs.csproj
+++ b/next-gen/docs/getting-started-dotnet-monitor-logs/getting-started-dotnet-monitor-logs.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting"  VersionOverride="8.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Logging"  VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" VersionOverride="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="8.0.1" />
   </ItemGroup>  
 
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Packages.props" />
   <ItemGroup>
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.2" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.15.6" />
     <PackageVersion Include="Confluent.Kafka" Version="2.5.3" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="MySql.Data" Version="9.0.0" />
     <PackageVersion Include="NServiceBus" Version="9.2.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Npgsql" Version="8.0.4" />
+    <PackageVersion Include="Npgsql" Version="8.0.5" />
     <PackageVersion Include="NuGet.Versioning" Version="6.5.0" />
     <PackageVersion Include="OpenTracing" Version="0.12.1" />
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.5.1" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.Build" Version="15.9.20" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -23,8 +23,8 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="MongoDB.Driver" Version="2.29.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -49,13 +49,9 @@ public static partial class LibraryVersion
 #if DEFAULT_TEST_PACKAGE_VERSIONS
             theoryData.Add(string.Empty);
 #else
-            theoryData.Add("6.0.33");
-            theoryData.Add("7.0.20");
+            theoryData.Add("6.0.35");
 #if NET8_0
-            theoryData.Add("8.0.2");
-#endif
-#if NET8_0
-            theoryData.Add("8.0.8");
+            theoryData.Add("8.0.10");
 #endif
 #endif
             return theoryData;

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -21,8 +21,7 @@ public static partial class LibraryVersion
 #if DEFAULT_TEST_PACKAGE_VERSIONS
             theoryData.Add(string.Empty);
 #else
-            theoryData.Add("12.13.0");
-            theoryData.Add("12.22.0");
+            theoryData.Add("12.22.2");
 #endif
             return theoryData;
         }

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -200,8 +200,7 @@ public static partial class LibraryVersion
 #if DEFAULT_TEST_PACKAGE_VERSIONS
             theoryData.Add(string.Empty);
 #else
-            theoryData.Add("6.0.11");
-            theoryData.Add("8.0.4");
+            theoryData.Add("8.0.5");
 #endif
             return theoryData;
         }

--- a/test/test-applications/integrations/TestApplication.EntityFrameworkCore/TestApplication.EntityFrameworkCore.csproj
+++ b/test/test-applications/integrations/TestApplication.EntityFrameworkCore/TestApplication.EntityFrameworkCore.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="7.0.20" Condition=" '$(LibraryVersion)' == '' and '$(TargetFramework)' != 'net8.0' "/>
 
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Condition=" '$(TargetFramework)' != 'net8.0' " />
   </ItemGroup>
 </Project>

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -40,9 +40,9 @@ internal static class PackageVersionDefinitions
             TestApplicationName = "TestApplication.EntityFrameworkCore",
             Versions = new List<PackageVersion>
             {
-                new("6.0.33"),
-                new("7.0.20"),
-                new("8.0.2", supportedTargetFrameworks: new[] { "net8.0" }, supportedExecutionFrameworks: new[] { "net8.0" }),
+                new("6.0.35"),
+                // new("7.0.20"), all versions contains references to vulnerable packages https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+                new("8.0.10", supportedTargetFrameworks: new[] { "net8.0" }, supportedExecutionFrameworks: new[] { "net8.0" }),
                 new("*", supportedTargetFrameworks: new[] { "net8.0" }, supportedExecutionFrameworks: new[] { "net8.0" })
             }
         },

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -16,7 +16,8 @@ internal static class PackageVersionDefinitions
             TestApplicationName = "TestApplication.Azure",
             Versions = new List<PackageVersion>
             {
-                new("12.13.0"),
+                // new("12.13.0"), // all lower versions than 12.22.2 contains references impacted by https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+                new("12.22.2"),
                 new("*")
             }
         },

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -159,7 +159,8 @@ internal static class PackageVersionDefinitions
             Versions = new List<PackageVersion>
             {
                 // new("6.0.0"), - high vulnerability https://github.com/advisories/GHSA-x9vc-6hfv-hg8c, <= 6.0.10, <= 7.0.6, and <= 8.0.2 test should be skipped
-                new("6.0.11"),
+                // new("6.0.11"), - transitive vulnerabilities https://github.com/advisories/GHSA-8g4q-xg66-9fp4 <= 6.0.12, <=7.0.8, <=8.0.4 test should be skipped
+                new("8.0.5"),
                 new("*")
             }
         },


### PR DESCRIPTION
## Why

.NET 9 changes default settings to

```xml
  <PropertyGroup>
    <NuGetAudit>true</NuGetAudit>
    <<NuGetAuditMode>all</NuGetAuditMode>
    <NuGetAuditLevel>low</NuGetAuditLevel>
  </PropertyGroup>
```

## What

It is first round of fixing new set of issues (only by fixing direct dependencies).
More to be implemented. Probably we should wait couple days/weeks. I have seen couple of fixes to libraries referencing `System.Text.Json`.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
