### PR TITLE
[kafka] remove unnecessary boxing

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceAsyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceAsyncIntegration.cs
@@ -39,7 +39,7 @@ public static class ProducerProduceAsyncIntegration
         var activity = KafkaInstrumentation.StartProducerActivity(topicPartition.DuckCast<ITopicPartition>(), message, instance.DuckCast<INamedClient>()!);
         if (activity is not null)
         {
-            KafkaInstrumentation.InjectContext<TTopicPartition>(message, activity);
+            KafkaInstrumentation.InjectContext<TTopicPartition, TMessage>(message, activity);
             return new CallTargetState(activity);
         }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceSyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceSyncIntegration.cs
@@ -40,7 +40,7 @@ public static class ProducerProduceSyncIntegration
         var activity = KafkaInstrumentation.StartProducerActivity(topicPartition.DuckCast<ITopicPartition>(), message, instance.DuckCast<INamedClient>()!);
         if (activity is not null)
         {
-            KafkaInstrumentation.InjectContext<TTopicPartition>(message, activity);
+            KafkaInstrumentation.InjectContext<TTopicPartition, TMessage>(message, activity);
             // Store delivery handler as state.
             return new CallTargetState(activity, deliveryHandler);
         }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
@@ -58,10 +58,13 @@ internal static class KafkaInstrumentation
         return activity;
     }
 
-    public static Activity? StartProducerActivity(
-        ITopicPartition partition,
-        IKafkaMessage message,
-        INamedClient producer)
+    public static Activity? StartProducerActivity<TTopicPartition, TMessage, TClient>(
+        TTopicPartition partition,
+        TMessage message,
+        TClient producer)
+    where TTopicPartition : ITopicPartition
+    where TMessage : IKafkaMessage
+    where TClient : INamedClient
     {
         string? spanName = null;
         if (!string.IsNullOrEmpty(partition.Topic))
@@ -87,7 +90,8 @@ internal static class KafkaInstrumentation
         return activity;
     }
 
-    public static void InjectContext<TTopicPartition>(IKafkaMessage message, Activity activity)
+    public static void InjectContext<TTopicPartition, TMessage>(TMessage message, Activity activity)
+    where TMessage : IKafkaMessage
     {
         message.Headers ??= MessageHeadersHelper<TTopicPartition>.Create();
         Propagators.DefaultTextMapPropagator.Inject(
@@ -161,7 +165,8 @@ internal static class KafkaInstrumentation
         return Enumerable.Empty<string>();
     }
 
-    private static void MessageHeaderValueSetter(IKafkaMessage msg, string key, string val)
+    private static void MessageHeaderValueSetter<TMessage>(TMessage msg, string key, string val)
+    where TMessage : IKafkaMessage
     {
         msg.Headers?.Remove(key);
         msg.Headers?.Add(key, Encoding.UTF8.GetBytes(val));


### PR DESCRIPTION
## Why && What

Ducktyping library creates [structs implementing an interface](https://github.com/DataDog/dd-trace-dotnet/blob/master/docs/development/DuckTyping.md#proxy-types) if proxy definition type is an interface.

This PR adds generic constraints to remove unnecessary boxing.

## Tests

Existing tests.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
