### PR TITLE
Bump Instrumentation.WCF to 1.0.0-rc.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 #### Dependency updates
 
+- Following packages updated
+  - `OpenTelemetry.Instrumentation.Wcf` from `1.0.0-rc.17` to `1.0.0-rc.18`,
 - .NET Framework only, following packages updated
   - `Google.Protobuf` updated from `3.28.2` to `3.28.3`,
   - `Microsoft.Extensions.DependencyInjection` from `8.0.0` to `8.0.1`,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.17" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.18" />
   </ItemGroup>
 </Project>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -125,7 +125,7 @@ public class MyPlugin
 | OpenTelemetry.Instrumentation.Quartz.QuartzInstrumentationOptions                         | OpenTelemetry.Instrumentation.Quartz              | 1.0.0-beta.3  |
 | OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions              | OpenTelemetry.Instrumentation.SqlClient           | 1.9.0-beta.1  |
 | OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions | OpenTelemetry.Instrumentation.StackExchangeRedis  | 1.9.0-beta.1  |
-| OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions                               | OpenTelemetry.Instrumentation.Wcf                 | 1.0.0-rc.17   |
+| OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions                               | OpenTelemetry.Instrumentation.Wcf                 | 1.0.0-rc.18   |
 
 ### Metrics
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,12 +28,6 @@
     <Authors>OpenTelemetry Authors</Authors>
     <!-- No warning on empty NuGet version suffix even if using pre-release dependencies -->
     <NoWarn>$(NoWarn);NU5104</NoWarn>
-    <!--
-       No warn to mitigate following warnings for transitive dependencies:
-       error NU1902: Warning As Error: Package 'SharpCompress' 0.23.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-jp7f-grcv-6mjf
-       error NU1904: Warning As Error: Package 'System.Drawing.Common' 4.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-rxg9-xrhp-64gj
-    -->
-    <NoWarn>$(NoWarn);NU1902;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="SharpCompress" Version="0.30.1" />
     <PackageVersion Include="Snappier" Version="1.0.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.6.122" />
-    <PackageVersion Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -53,7 +53,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"OpenTelemetry.Instrumentation.Quartz", {1, 0, 0, 50} },
         { L"OpenTelemetry.Instrumentation.Runtime", {1, 9, 0, 57} },
         { L"OpenTelemetry.Instrumentation.SqlClient", {1, 9, 0, 43} },
-        { L"OpenTelemetry.Instrumentation.Wcf", {1, 0, 0, 47} },
+        { L"OpenTelemetry.Instrumentation.Wcf", {1, 0, 0, 214} },
         { L"OpenTelemetry.Resources.Azure", {1, 0, 0, 172} },
         { L"OpenTelemetry.Resources.Host", {0, 1, 0, 139} },
         { L"OpenTelemetry.Resources.OperatingSystem", {0, 1, 0, 152} },


### PR DESCRIPTION
## Why

Handles https://github.com/open-telemetry/opentelemetry-dotnet-contrib/releases/tag/Instrumentation.Wcf-1.0.0-rc.18

Fixes #

## What

Bump Instrumentation.WCF to 1.0.0-rc.18

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.
