### PR TITLE
[Tests] Bump MongoDB.Driver to 2.30.0

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -89,7 +89,7 @@ public static partial class LibraryVersion
             new List<PackageBuildInfo>
             {
                 new("2.28.0"),
-                new("2.29.0"),
+                new("2.30.0"),
             }
         },
         {

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="MySqlConnector" Version="2.3.7" />
     <PackageVersion Include="MySql.Data" Version="9.1.0" />

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -151,7 +151,7 @@ public static partial class LibraryVersion
             theoryData.Add(string.Empty);
 #else
             theoryData.Add("2.28.0");
-            theoryData.Add("2.29.0");
+            theoryData.Add("2.30.0");
 #endif
             return theoryData;
         }


### PR DESCRIPTION
## Why &  What

[Tests] Bump MongoDB.Driver to 2.30.0.

3.0.0+ support: #3738

## Tests

CI

## Checklist

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
