### PR TITLE
Update messaging attributes from 1.23 to 1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Changed
 
+- Update messaging attributes from [v1.23.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/messaging/messaging-spans.md) to [v1.28.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/messaging/messaging-spans.md)
+
 #### Dependency updates
 
 ### Deprecated

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MessagingAttributes.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MessagingAttributes.cs
@@ -3,24 +3,25 @@
 
 namespace OpenTelemetry.AutoInstrumentation.Instrumentations;
 
-// https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/messaging/messaging-spans.md#messaging-attributes
+// https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/messaging/messaging-spans.md#messaging-attributes
 internal static class MessagingAttributes
 {
     internal static class Keys
     {
         public const string MessagingSystem = "messaging.system";
-        public const string MessagingOperation = "messaging.operation";
+        public const string MessagingOperationName = "messaging.operation.name";
+        public const string MessagingOperationType = "messaging.operation.type";
+        public const string MessagingConsumerGroupName = "messaging.consumer.group.name";
         public const string DestinationName = "messaging.destination.name";
         public const string ClientId = "messaging.client_id";
         public const string MessageBodySize = "messaging.message.body.size";
         public const string MessageId = "messaging.message.id";
         public const string ConversationId = "messaging.message.conversation_id";
+        public const string Partition = "messaging.destination.partition.id";
 
-        // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/messaging/kafka.md#span-attributes
+        // https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/messaging/kafka.md#span-attributes
         internal static class Kafka
         {
-            public const string ConsumerGroupId = "messaging.kafka.consumer.group";
-            public const string Partition = "messaging.kafka.destination.partition";
             public const string MessageKey = "messaging.kafka.message.key";
             public const string PartitionOffset = "messaging.kafka.message.offset";
             public const string IsTombstone = "messaging.kafka.message.tombstone";
@@ -35,15 +36,28 @@ internal static class MessagingAttributes
 
     internal static class Values
     {
-        public const string KafkaMessagingSystemName = "kafka";
-        public const string PublishOperationName = "publish";
-        public const string ReceiveOperationName = "receive";
-        public const string DeliverOperationName = "deliver";
+        public const string SendOperation = "send";
+        public const string ReceiveOperation = "receive";
+        public const string ProcessOperation = "process";
+
+        internal static class Kafka
+        {
+            public const string MessagingSystemName = "kafka";
+
+            public const string CommitOperationName = "commit";
+            public const string PublishOperationName = "commit";
+            public const string PollOperationName = "poll";
+            public const string ConsumeOperationName = "consume";
+        }
 
         internal static class RabbitMq
         {
             public const string MessagingSystemName = "rabbitmq";
             public const string DefaultExchangeName = "amq.default";
+
+            public const string CommitOperationName = "ack";
+            public const string PollOperationName = "nack";
+            public const string ConsumeOperationName = "reject";
         }
     }
 }


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

## What

- Updated messaging attributes to follow the 1.28 semantic convention changes, including new attributes and revised attribute definitions.

## Tests

Ci

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [x] New features are covered by tests.
