### PR TITLE
Add missing SHA546 digest for CentOs Stream 9

### DIFF
--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream9@sha256:dfc4616f518ab5f0a6e95a6cb168dadbed4704b7b30d3a10846bc2c4c1c61f07
 
 # Install dotnet sdk
 RUN dnf install -y \


### PR DESCRIPTION
## Why & What

Add missing SHA546 digest for CentOs Stream 9

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
