### PR TITLE
Bump minimal cmake version to 3.10

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required (VERSION 3.8..3.19)
+cmake_minimum_required (VERSION 3.10..3.19)
 cmake_policy(SET CMP0015 NEW)
 
 # ******************************************************


### PR DESCRIPTION
## Why & What

Bump minimal cmake version to 3.10
to avoid warnings in the build logs

```log
  Error: CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
  09:55:27 [ERR] CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
  Error:   Compatibility with CMake < 3.10 will be removed from a future version of
  09:55:27 [ERR]   Compatibility with CMake < 3.10 will be removed from a future version of
  Error:   CMake.
  09:55:27 [ERR]   CMake.
  09:55:27 [ERR] 
  Error:   Update the VERSION argument <min> value or use a ...<max> suffix to tell
  09:55:27 [ERR]   Update the VERSION argument <min> value or use a ...<max> suffix to tell
  Error:   CMake that the project does not need compatibility with older versions.
  09:55:27 [ERR]   CMake that the project does not need compatibility with older versions.
```

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
