### PR TITLE
[Tests] Bump minimal cmake version to 3.10

### DIFF
--- a/test/test-applications/integrations/dependency-libs/TestApplication.ContinuousProfiler.NativeDep/CMakeLists.txt
+++ b/test/test-applications/integrations/dependency-libs/TestApplication.ContinuousProfiler.NativeDep/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required (VERSION 3.8..3.19)
+cmake_minimum_required (VERSION 3.10..3.19)
 cmake_policy(SET CMP0015 NEW)
 
 # ******************************************************


### PR DESCRIPTION
## Why

Follow up: #3812

## What

[Tests] Bump minimal cmake version to 3.10

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
