### PR TITLE
[tools] Bump Microsoft.Build to 17.2.6

### DIFF
--- a/tools/Directory.Packages.props
+++ b/tools/Directory.Packages.props
@@ -2,9 +2,7 @@
   <Import Project="..\Directory.Packages.props" />
   <ItemGroup>
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-    <PackageVersion Include="Microsoft.Build" Version="17.7.2" />
-    <!-- System.Text.Json - Indirect vulnerable dependency https://github.com/advisories/GHSA-hh2w-p6rv-4g7w from Microsoft.Build -->
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="Microsoft.Build" Version="17.12.6" />
     <PackageVersion Include="NuGet.ProjectModel" Version="6.12.1" />
     <!-- NuGet.ProjectModel - Indirect vulnerable dependency https://github.com/advisories/GHSA-447r-wph3-92pm from NuGet.ProjectModel -->
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />

--- a/tools/LibraryVersionsGenerator/LibraryVersionsGenerator.csproj
+++ b/tools/LibraryVersionsGenerator/LibraryVersionsGenerator.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why & What

[tools] Bump Microsoft.Build to 17.2.6
it allows to drop manual bump of System.Text.Json

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
