### PR TITLE
Bump System.Buffers to 4.6.0 - .NET Fx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `Microsoft.Extensions.Options` from `8.0.2` to `9.0.0`,
   - `Microsoft.Extensions.Options.ConfigurationExtensions` from `8.0.0` to `9.0.0`,
   - `Microsoft.Extensions.Primitives` from `8.0.0` to `9.0.0`,
+  - `System.Buffers` from `4.5.5` to `4.6.0`,
   - `System.Diagnostics.DiagnosticSource` from `8.0.1` to `9.0.0`,
   - `System.Text.Encodings.Web` from `8.0.0` to `9.0.0`,
   - `System.Text.Json` from `8.0.5` to `9.0.0`.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -80,7 +80,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.0" />
-    <PackageVersion Include="System.Buffers" Version="4.5.1" />
+    <PackageVersion Include="System.Buffers" Version="4.6.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
     <PackageVersion Include="System.IO.Pipelines" Version="9.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -62,7 +62,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"OpenTelemetry.Shims.OpenTracing", {1, 0, 0, 0} },
         { L"OpenTracing", {0, 12, 1, 0} },
         { L"System.AppContext", {4, 1, 2, 0} },
-        { L"System.Buffers", {4, 0, 3, 0} },
+        { L"System.Buffers", {4, 0, 4, 0} },
         { L"System.Collections", {4, 0, 11, 0} },
         { L"System.Collections.Concurrent", {4, 0, 11, 0} },
         { L"System.Collections.NonGeneric", {4, 0, 3, 0} },


### PR DESCRIPTION
## Why &  What

Bump System.Buffers to 4.6.0 - .NET Fx

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
