### PR TITLE
disable automatic dotnet format job temporarily

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -1,17 +1,18 @@
 name: dotnet format
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-    - '**.cs'
-    - '.editorconfig'
-  pull_request:
-    branches: [ main ]
-    paths:
-    - '**.cs'
-    - '.editorconfig'
-  merge_group:
+# Uncomment after fix for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/3841 is available
+#  push:
+#    branches: [ main ]
+#    paths:
+#    - '**.cs'
+#    - '.editorconfig'
+#  pull_request:
+#    branches: [ main ]
+#    paths:
+#    - '**.cs'
+#    - '.editorconfig'
+#  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why

Temp workaround for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/3841
