### PR TITLE
Bump OpenTelemetry.Instrumentation.SqlClient to 1.10.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `OpenTelemetry.Instrumentation.Process` from `0.5.0-beta.7` to `1.10.0-beta.1`,
   - `OpenTelemetry.Instrumentation.Quartz` from `1.0.0-beta.3` to `1.10.0-beta.1`,
   - `OpenTelemetry.Instrumentation.Runtime` from `1.9.0` to `1.10.0`,
+  - `OpenTelemetry.Instrumentation.SqlClient` from `1.9.0-beta.1` to `1.10.0-beta.1`,
   - `OpenTelemetry.Instrumentation.Wcf` from `1.0.0-rc.18` to `1.10.0-beta.1`,
   - `OpenTelemetry.Resources.Azure` from `1.0.0-beta.9` to `1.10.0-beta.1`,
   - `OpenTelemetry.Resources.Container` from `1.0.0-beta.9` to `1.10.0-beta.1`,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -123,7 +123,7 @@ public class MyPlugin
 | OpenTelemetry.Instrumentation.GrpcNetClient.GrpcClientTraceInstrumentationOptions         | OpenTelemetry.Instrumentation.GrpcNetClient       | 1.10.0-beta.1 |
 | OpenTelemetry.Instrumentation.Http.HttpClientTraceInstrumentationOptions                  | OpenTelemetry.Instrumentation.Http                | 1.10.0        |
 | OpenTelemetry.Instrumentation.Quartz.QuartzInstrumentationOptions                         | OpenTelemetry.Instrumentation.Quartz              | 1.10.0-beta.1 |
-| OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions              | OpenTelemetry.Instrumentation.SqlClient           | 1.9.0-beta.1  |
+| OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions              | OpenTelemetry.Instrumentation.SqlClient           | 1.10.0-beta.1 |
 | OpenTelemetry.Instrumentation.StackExchangeRedis.StackExchangeRedisInstrumentationOptions | OpenTelemetry.Instrumentation.StackExchangeRedis  | 1.10.0-beta.1 |
 | OpenTelemetry.Instrumentation.Wcf.WcfInstrumentationOptions                               | OpenTelemetry.Instrumentation.Wcf                 | 1.10.0-beta.1 |
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Shims.OpenTracing" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.10.0-beta.1" />

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -52,7 +52,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"OpenTelemetry.Instrumentation.Process", {1, 10, 0, 265} },
         { L"OpenTelemetry.Instrumentation.Quartz", {1, 10, 0, 266} },
         { L"OpenTelemetry.Instrumentation.Runtime", {1, 10, 0, 257} },
-        { L"OpenTelemetry.Instrumentation.SqlClient", {1, 9, 0, 43} },
+        { L"OpenTelemetry.Instrumentation.SqlClient", {1, 10, 0, 267} },
         { L"OpenTelemetry.Instrumentation.Wcf", {1, 10, 0, 269} },
         { L"OpenTelemetry.Resources.Azure", {1, 10, 0, 270} },
         { L"OpenTelemetry.Resources.Host", {1, 10, 0, 272} },


### PR DESCRIPTION
## Why & What

Bump OpenTelemetry.Instrumentation.SqlClient to 1.10.0-beta.1
Handles changes from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2305

Metric support will be handled in scope of #3873

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
