### PR TITLE
[docs] fix a link after rename in demo repository

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,6 +54,6 @@
 
    - [`examples/demo/Dockerfile`](../examples/demo/Dockerfile)
    - [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/dotnet/version.txt)
-   - [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/accountingservice/AccountingService.csproj#L20)
+   - [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/accounting/Accounting.csproj#L20)
 
 1. For a stable release, update documentation under [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/zero-code/net).


### PR DESCRIPTION
Link fix after rename from https://github.com/open-telemetry/opentelemetry-demo/pull/1827.
