### PR TITLE
Fix vcxproj for when path contains blanks

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.DLL.vcxproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.DLL.vcxproj
@@ -118,7 +118,7 @@
       <ModuleDefinitionFile>.\OpenTelemetry.AutoInstrumentation.Native.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>IF EXIST $(SolutionDir)\pre-build-events-cpp.bat CALL $(SolutionDir)\pre-build-events-cpp.bat  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
+      <Command>IF EXIST "$(SolutionDir)pre-build-events-cpp.bat" CALL "$(SolutionDir)pre-build-events-cpp.bat"  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Remove potentially locked outputs (dll/pdb/xml)</Message>
@@ -141,7 +141,7 @@
       <ModuleDefinitionFile>.\OpenTelemetry.AutoInstrumentation.Native.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>IF EXIST $(SolutionDir)\pre-build-events-cpp.bat CALL $(SolutionDir)\pre-build-events-cpp.bat  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
+      <Command>IF EXIST "$(SolutionDir)pre-build-events-cpp.bat" CALL "$(SolutionDir)pre-build-events-cpp.bat"  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
       <Message>Remove potentially locked outputs (dll/pdb/xml)</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -168,7 +168,7 @@
       <ModuleDefinitionFile>.\OpenTelemetry.AutoInstrumentation.Native.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>IF EXIST $(SolutionDir)\pre-build-events-cpp.bat CALL $(SolutionDir)\pre-build-events-cpp.bat  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
+      <Command>IF EXIST "$(SolutionDir)pre-build-events-cpp.bat" CALL "$(SolutionDir)pre-build-events-cpp.bat"  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
       <Message>Remove potentially locked outputs (dll/pdb/xml)</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -195,7 +195,7 @@
       <ModuleDefinitionFile>.\OpenTelemetry.AutoInstrumentation.Native.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>IF EXIST $(SolutionDir)\pre-build-events-cpp.bat CALL $(SolutionDir)\pre-build-events-cpp.bat  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
+      <Command>IF EXIST "$(SolutionDir)pre-build-events-cpp.bat" CALL "$(SolutionDir)pre-build-events-cpp.bat"  "$(TargetPath)"  "$(TargetFileName)"  "$(TargetDir)"  "$(TargetName)"</Command>
       <Message>Remove potentially locked outputs (dll/pdb/xml)</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
If the path to `SolutionDir` contains spaces the `CompineNativeSrcWindows` target fails, see https://cloud-native.slack.com/archives/C01NR1YLSE7/p1737152951035299

Fix that by enclosing the path in double-quotes, also removing the extra `\` that was being added to the path.