### PR TITLE
.NET Fx - transitive dependenycy - bump System.Diagnostics.DiagnosticSource to 9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `Microsoft.Extensions.Options` updated from `9.0.0` to `9.0.1`,
   - `Microsoft.Extensions.Primitives` updated from `9.0.0` to `9.0.1`,
   - `System.IO.Pipelines` updated from `9.0.0` to `9.0.1`,
+  - `System.Diagnostics.DiagnosticSource` updated from `9.0.0` to `9.0.1`,
   - `System.Text.Encodings.Web` update from `9.0.0` to `9.0.1`,
   - `System.Text.Json` update from `9.0.0` to `9.0.1`.
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -64,7 +64,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.1" />
     <PackageVersion Include="System.Buffers" Version="4.6.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
     <PackageVersion Include="System.IO.Pipelines" Version="9.0.1" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="System.Numerics.Vectors" Version="4.6.0" />

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_assembly_redirection.h
@@ -74,7 +74,7 @@ void CorProfiler::InitNetFxAssemblyRedirectsMap()
         { L"System.Data.Common", {4, 2, 0, 0} },
         { L"System.Diagnostics.Contracts", {4, 0, 1, 0} },
         { L"System.Diagnostics.Debug", {4, 0, 11, 0} },
-        { L"System.Diagnostics.DiagnosticSource", {9, 0, 0, 0} },
+        { L"System.Diagnostics.DiagnosticSource", {9, 0, 0, 1} },
         { L"System.Diagnostics.FileVersionInfo", {4, 0, 2, 0} },
         { L"System.Diagnostics.Process", {4, 1, 2, 0} },
         { L"System.Diagnostics.StackTrace", {4, 1, 0, 0} },


### PR DESCRIPTION
## Why & What

.NET Fx - transitive dependenycy - bump System.Diagnostics.DiagnosticSource to 9.0.1

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
