### PR TITLE
[Continuous Profiler] Include resources in OTLP protocol

### DIFF
--- a/test/IntegrationTests/ContinuousProfilerTests.cs
+++ b/test/IntegrationTests/ContinuousProfilerTests.cs
@@ -26,10 +26,10 @@ public class ContinuousProfilerTests : TestHelper
         SetExporter(collector);
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_PLUGINS", "TestApplication.ContinuousProfiler.AllocationPlugin, TestApplication.ContinuousProfiler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
         SetEnvironmentVariable("OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES", "TestApplication.ContinuousProfiler");
-        RunTestApplication();
+        var (_, _, processId) = RunTestApplication();
 
         collector.Expect(profileData => profileData.ResourceProfiles.Any(resourceProfiles => resourceProfiles.ScopeProfiles.Any(scopeProfile => scopeProfile.Profiles.Any(profile => ContainAttributes(profile, "allocation") && profile.Sample[0].Value[0] != 0.0))));
-        collector.ResourceExpector.Expect("todo.resource.detector.key", "todo.resource.detector.value");
+        collector.ResourceExpector.ExpectStandardResources(processId, "TestApplication.ContinuousProfiler");
 
         collector.AssertExpectations();
         collector.ResourceExpector.AssertExpectations();
@@ -48,9 +48,10 @@ public class ContinuousProfilerTests : TestHelper
 
         collector.ExpectCollected(ExpectCollected, "Expect Collected failed");
         collector.Expect(profileData => profileData.ResourceProfiles.Any(resourceProfiles => resourceProfiles.ScopeProfiles.Any(scopeProfile => scopeProfile.Profiles.Any(profile => ContainStackTraceForClassHierarchy(profile, expectedStackTrace) && ContainAttributes(profile, "cpu")))));
-        collector.ResourceExpector.Expect("todo.resource.detector.key", "todo.resource.detector.value");
 
-        RunTestApplication();
+        var (_, _, processId) = RunTestApplication();
+
+        collector.ResourceExpector.ExpectStandardResources(processId, "TestApplication.ContinuousProfiler");
 
         collector.AssertCollected();
         collector.AssertExpectations();

--- a/test/IntegrationTests/Helpers/OtlpResourceExpectorExtensions.cs
+++ b/test/IntegrationTests/Helpers/OtlpResourceExpectorExtensions.cs
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+
+namespace IntegrationTests.Helpers;
+
+internal static class OtlpResourceExpectorExtensions
+{
+    public static void ExpectStandardResources(this OtlpResourceExpector resourceExpector, int processId, string serviceName)
+    {
+        resourceExpector.Expect("service.name", serviceName); // this is set via env var and App.config, but env var has precedence
+#if NETFRAMEWORK
+        resourceExpector.Expect("deployment.environment", "test"); // this is set via App.config
+#endif
+        resourceExpector.Expect("telemetry.sdk.name", "opentelemetry");
+        resourceExpector.Expect("telemetry.sdk.language", "dotnet");
+        resourceExpector.Expect("telemetry.sdk.version", typeof(OpenTelemetry.Resources.Resource).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0]);
+        resourceExpector.Expect("telemetry.distro.name", "opentelemetry-dotnet-instrumentation");
+        resourceExpector.Expect("telemetry.distro.version", typeof(OpenTelemetry.AutoInstrumentation.Constants).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion.Split('+')[0]);
+
+        resourceExpector.Expect("process.pid", processId);
+        resourceExpector.Expect("host.name", Environment.MachineName);
+
+#if NETFRAMEWORK
+        resourceExpector.Expect("process.runtime.name", ".NET Framework");
+#else
+        resourceExpector.Expect("process.runtime.name", ".NET");
+#endif
+
+        var expectedPlatform = EnvironmentTools.GetOS() switch
+        {
+            "win" => "windows",
+            "osx" => "darwin",
+            "linux" => "linux",
+            _ => throw new PlatformNotSupportedException($"Unknown platform")
+        };
+        resourceExpector.Expect("os.type", expectedPlatform);
+        resourceExpector.Exist("os.build_id");
+        resourceExpector.Exist("os.description");
+        resourceExpector.Exist("os.name");
+        resourceExpector.Exist("os.version");
+    }
+}

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler.ContextTracking/TestApplication.ContinuousProfiler.ContextTracking.csproj
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler.ContextTracking/TestApplication.ContinuousProfiler.ContextTracking.csproj
@@ -10,13 +10,14 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="all" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <Compile Include="..\TestApplication.ContinuousProfiler\Exporter\AllocationSample.cs">
         <Link>Exporter\AllocationSample.cs</Link>
       </Compile>
@@ -25,6 +26,9 @@
       </Compile>
       <Compile Include="..\TestApplication.ContinuousProfiler\Exporter\OtlpOverHttpExporter.cs">
         <Link>Exporter\OtlpOverHttpExporter.cs</Link>
+      </Compile>
+      <Compile Include="..\TestApplication.ContinuousProfiler\Exporter\ResourcesProvider.cs">
+        <Link>Exporter\ResourcesProvider.cs</Link>
       </Compile>
       <Compile Include="..\TestApplication.ContinuousProfiler\Exporter\SampleBuilder.cs">
         <Link>Exporter\SampleBuilder.cs</Link>

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/ResourcesProvider.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Exporter/ResourcesProvider.cs
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Resources;
+
+namespace TestApplication.ContinuousProfiler;
+
+internal class ResourcesProvider
+{
+    public static Resource Resource { get; private set; } = Resource.Empty;
+
+    public static void Configure(ResourceBuilder builder)
+    {
+        Resource = builder.Build();
+    }
+}

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Plugins/AllocationPlugin.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Plugins/AllocationPlugin.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpenTelemetry.Resources;
+
 namespace TestApplication.ContinuousProfiler;
 
 public class AllocationPlugin
@@ -16,5 +18,12 @@ public class AllocationPlugin
         object continuousProfilerExporter = new OtlpOverHttpExporter();
 
         return Tuple.Create(threadSamplingEnabled, threadSamplingInterval, allocationSamplingEnabled, maxMemorySamplesPerMinute, exportInterval, exportTimeout, continuousProfilerExporter);
+    }
+
+    public ResourceBuilder ConfigureResource(ResourceBuilder builder)
+    {
+        // TODO hack to fetch resources from the SDK and store them to be able to sent to OTLP Profiling
+        ResourcesProvider.Configure(builder);
+        return builder;
     }
 }

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/Plugins/ThreadPlugin.cs
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/Plugins/ThreadPlugin.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpenTelemetry.Resources;
+
 namespace TestApplication.ContinuousProfiler;
 
 public class ThreadPlugin
@@ -16,5 +18,12 @@ public class ThreadPlugin
         object continuousProfilerExporter = new OtlpOverHttpExporter();
 
         return Tuple.Create(threadSamplingEnabled, threadSamplingInterval, allocationSamplingEnabled, maxMemorySamplesPerMinute, exportInterval, exportTimeout, continuousProfilerExporter);
+    }
+
+    public ResourceBuilder ConfigureResource(ResourceBuilder builder)
+    {
+        // TODO hack to fetch resources from the SDK and store them to be able to sent to OTLP Profiling
+        ResourcesProvider.Configure(builder);
+        return builder;
     }
 }

--- a/test/test-applications/integrations/TestApplication.ContinuousProfiler/TestApplication.ContinuousProfiler.csproj
+++ b/test/test-applications/integrations/TestApplication.ContinuousProfiler/TestApplication.ContinuousProfiler.csproj
@@ -26,10 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="all" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

Improving OTLP Exporter for profiling

## What

[Continuous Profiler] Include resources in OTLP protocol.
It takes the resources from the plugin hook and store it locally.
The exporter for resources does not support all cases, but it is enough for current, demonstrating purposes.

## Tests

CI + modified test.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
