### PR TITLE
[Tests] Fix IntegrationTests: Skipping test case with duplicate ID

### DIFF
--- a/test/IntegrationTests/LibraryVersions.cs
+++ b/test/IntegrationTests/LibraryVersions.cs
@@ -12,7 +12,7 @@ public static partial class LibraryVersion
 {
     public static TheoryData<string> GetPlatformVersions(string integrationName)
     {
-        var anyPlatformVersions = LookupMap[integrationName];
+        var anyPlatformVersions = new TheoryData<string>(LookupMap[integrationName]);
         var platformKey = $"{integrationName}_{EnvironmentTools.GetPlatform()}";
 
         if (LookupMap.TryGetValue(platformKey, out var platformVersions))


### PR DESCRIPTION
## Why & What

Fixes warnings in log similar to 
`[[xUnit.net](http://xunit.net/) 00:00:00.11] IntegrationTests: Skipping test case with duplicate ID '8cc00d831156d4267105110c2750743a233b4674' ('IntegrationTests.KafkaTests.NoSpansForPartitionEOF(packageVersion: "1.4.0")' and 'IntegrationTests.KafkaTests.NoSpansForPartitionEOF(packageVersion: "1.4.0")'`

Kafka tests was adding 1.4.0 to collection twice, it should be treated as immutable in this dictionary. 

## Tests

CI + local test

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
