### PR TITLE
[Tests]  Switch dotnet msbuild to dotnet test

### DIFF
--- a/build/Build.NuGet.Steps.cs
+++ b/build/Build.NuGet.Steps.cs
@@ -180,14 +180,13 @@ partial class Build
 
             for (var i = 0; i < TestCount; i++)
             {
-                DotNetMSBuild(config => config
+                DotNetTest(config => config
                     .SetConfiguration(BuildConfiguration)
                     .SetFilter(AndFilter(TestNameFilter(), ContainersFilter()))
                     .SetBlameHangTimeout("5m")
                     .EnableTrxLogOutput(GetResultsDirectory(nugetPackagesTestProject))
-                    .SetTargetPath(nugetPackagesTestProject)
-                    .SetRestore(!NoRestore)
-                    .RunTests()
+                    .SetProjectFile(nugetPackagesTestProject)
+                    .SetNoRestore(NoRestore)
                 );
             }
         });

--- a/build/Build.Steps.cs
+++ b/build/Build.Steps.cs
@@ -528,16 +528,15 @@ partial class Build
 
             for (int i = 0; i < TestCount; i++)
             {
-                DotNetMSBuild(config => config
+                DotNetTest(config => config
                     .SetConfiguration(BuildConfiguration)
                     .SetFilter(AndFilter(TestNameFilter(), ContainersFilter()))
                     .SetBlameHangTimeout("5m")
                     .EnableTrxLogOutput(GetResultsDirectory(project))
-                    .SetTargetPath(project)
-                    .SetRestore(!NoRestore)
+                    .SetProjectFile(project)
+                    .SetNoRestore(NoRestore)
                     .When(_ => TestTargetFramework != TargetFramework.NOT_SPECIFIED,
-                        s => s.SetProperty("TargetFramework", TestTargetFramework.ToString()))
-                    .RunTests()
+                        s => s.SetFramework(TestTargetFramework))
                 );
             }
         });

--- a/build/Extensions/DotNetSettingsExtensions.cs
+++ b/build/Extensions/DotNetSettingsExtensions.cs
@@ -44,33 +44,6 @@ internal static class DotNetSettingsExtensions
             .SetResultsDirectory(resultsDirectory);
     }
 
-    public static DotNetMSBuildSettings EnableTrxLogOutput(this DotNetMSBuildSettings settings, string resultsDirectory)
-    {
-        return settings
-            .SetProperty("VSTestLogger", "trx")
-            .SetProperty("VSTestResultsDirectory", resultsDirectory);
-    }
-
-    public static DotNetMSBuildSettings SetBlameHangTimeout(this DotNetMSBuildSettings settings, string timeout)
-    {
-        return settings
-            .SetProperty("VSTestBlameHang", true)
-            .SetProperty("VSTestBlameHangTimeout", timeout);
-    }
-
-    public static DotNetMSBuildSettings RunTests(this DotNetMSBuildSettings settings)
-    {
-        return settings
-            .SetTargets("VSTest")
-            .SetProperty("VSTestNoBuild", true);
-    }
-
-    public static DotNetMSBuildSettings SetFilter(this DotNetMSBuildSettings settings, string filter)
-    {
-        return settings
-            .SetProperty("VSTestTestCaseFilter", filter);
-    }
-
     public static DotNetBuildSettings[] CombineWithBuildInfos(this DotNetBuildSettings settings, IReadOnlyCollection<PackageBuildInfo> buildInfos, TargetFramework targetFramework)
     {
         // NOTE: SetProperty creates internally a new instance!


### PR DESCRIPTION
## Why

Old way to execute was reporting exit code 1 for some runs, even when all tests passed.

## What

[Tests]  Switch dotnet msbuild to dotnet test

## Tests

CI + local execution on Windows

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] New features are covered by tests.
