### PR TITLE
Bump Ubuntu runners from 20.04 to 22.04 

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             base-image: alpine
             os-type: linux-musl
             architecture: x64

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Download Ubuntu x64 Artifacts from build job
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # tag: v4.1.8
         with:
-          name: bin-ubuntu-20.04
-          path: bin/ci-artifacts/bin-ubuntu-20.04
+          name: bin-ubuntu-22.04
+          path: bin/ci-artifacts/bin-ubuntu-22.04
 
       - name: Download Ubuntu arm64 Artifacts from build job
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # tag: v4.1.8

--- a/.github/workflows/build-ubuntu1604-native-container.yml
+++ b/.github/workflows/build-ubuntu1604-native-container.yml
@@ -11,7 +11,7 @@ jobs:
   build-ubuntu1604-native-container:
     strategy:
       fail-fast: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - machine: windows-2022
             log-dir: "/c/ProgramData/OpenTelemetry .NET AutoInstrumentation/logs"
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             log-dir: "/var/log/opentelemetry/dotnet"
           - machine: macos-13
             log-dir: "/var/log/opentelemetry/dotnet"
@@ -77,14 +77,14 @@ jobs:
         run: ./build.cmd BuildWorkflow --no-restore ${{ steps.nuget-cache.outputs.cache-hit != 'true' }}
 
       - name: Download native Ubuntu 16.04 Artifacts from build job
-        if: ${{ matrix.machine == 'ubuntu-20.04' }}
+        if: ${{ matrix.machine == 'ubuntu-22.04' }}
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # tag: v4.1.8
         with:
           name: bin-ubuntu1604-native
           path: bin/ci-artifacts/bin-ubuntu1604-native
 
       - name: Replace Ubuntu native code by Ubuntu 16.04 artifacts
-        if: ${{ matrix.machine == 'ubuntu-20.04' }}
+        if: ${{ matrix.machine == 'ubuntu-22.04' }}
         run: |
           rm ./bin/tracer-home/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
           cp ./bin/ci-artifacts/bin-ubuntu1604-native/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so ./bin/tracer-home/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,18 @@ jobs:
       fail-fast: false
       matrix:
         test-tfm: [ net9.0, net8.0, net462 ]
-        machine: [ windows-2022, ubuntu-20.04, macos-13, otel-linux-arm64 ]
+        machine: [ windows-2022, ubuntu-22.04, macos-13, otel-linux-arm64 ]
         exclude:
           - test-tfm: net462
             machine: macos-13
           - test-tfm: net462
-            machine: ubuntu-20.04
+            machine: ubuntu-22.04
           - test-tfm: net462
             machine: otel-linux-arm64
         include:
           - machine: windows-2022
             containers: none
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             containers: linux
           - machine: macos-13
             containers: none
@@ -204,17 +204,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             base-image: alpine
             build-source: alpine-x64
             os-type: linux-musl
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             base-image: debian
-            build-source: ubuntu-20.04
+            build-source: ubuntu-22.04
             os-type: linux-glibc
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             base-image: centos-stream9
-            build-source: ubuntu-20.04
+            build-source: ubuntu-22.04
             os-type: linux-glibc
           - machine: otel-linux-arm64
             base-image: alpine
@@ -252,7 +252,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
           - machine: macos-13
           - machine: windows-2022
           - machine: otel-linux-arm64
@@ -300,7 +300,7 @@ jobs:
           path: test-artifacts/
 
   test-jobs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - test-build-managed
       - test-build-native

--- a/.github/workflows/format-native.yml
+++ b/.github/workflows/format-native.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: [ windows-2022, ubuntu-20.04, macos-13 ]
+        machine: [ windows-2022, ubuntu-22.04, macos-13 ]
     runs-on: ${{ matrix.machine }}
     steps:
 
@@ -28,7 +28,7 @@ jobs:
       run: ./scripts/format-native.sh
 
   check-native-headers:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -49,7 +49,7 @@ jobs:
         include:
           - machine: windows-2022
             log-dir: "/c/ProgramData/OpenTelemetry .NET AutoInstrumentation/logs"
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             log-dir: "/var/log/opentelemetry/dotnet"
           - machine: macos-13
             log-dir: "/var/log/opentelemetry/dotnet"
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             base-image: alpine
             net-version: net9.0
           - machine: otel-linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
   create-release:
     name: Create GH release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ build, build-container, build-nuget-packages ]
     permissions:
       contents: write
@@ -46,7 +46,7 @@ jobs:
 
       - run: cd bin-alpine-x64 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-musl-x64.zip . * ; cd ..
       - run: cd bin-alpine-arm64 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip . * ; cd ..
-      - run: cd bin-ubuntu-20.04 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip . * ; cd ..
+      - run: cd bin-ubuntu-22.04 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip . * ; cd ..
       - run: cd bin-otel-linux-arm64 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip . * ; cd ..
       - run: cd bin-windows-2022 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-windows.zip . * ; cd ..
       - run: cd bin-macos-13 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-macos.zip . * ; cd ..

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - machine: windows-2022
             containers: windows
-          - machine: ubuntu-20.04
+          - machine: ubuntu-22.04
             containers: linux
           - machine: macos-13
             containers: none

--- a/build/Build.NuGet.Steps.cs
+++ b/build/Build.NuGet.Steps.cs
@@ -51,7 +51,7 @@ partial class Build
             {
                 "bin-alpine-x64/linux-musl-x64",
                 "bin-alpine-arm64/linux-musl-arm64",
-                "bin-ubuntu-20.04/linux-x64",
+                "bin-ubuntu-22.04/linux-x64",
                 "bin-otel-linux-arm64/linux-arm64",
                 "bin-macos-13/osx-x64",
                 "bin-windows-2022/win-x64",

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,7 +104,7 @@ CI tests run against the following operating systems:
 - [CentOS Stream 9 x64](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/centos-stream9.dockerfile)
 - [macOS Ventura 13 x64](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)
 - [Microsoft Windows Server 2022 x64](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)
-- [Ubuntu 20.04 LTS x64](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md)
+- [Ubuntu 22.04 LTS x64](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)
 - Ubuntu 22.04 LTS ARM64
 
 ### Instrumented libraries and frameworks

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - otel-collector
 
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:2019-CU17-ubuntu-20.04
+    image: mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=yourStrong(!)Password

--- a/test/IntegrationTests/docker/sql-server.Dockerfile
+++ b/test/IntegrationTests/docker/sql-server.Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/mssql/server:2019-CU28-ubuntu-20.04@sha256:d7f2c670f0cd807b4dc466b8887bd2b39a4561f624c154896f5564ea38efd13a
+FROM mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04@sha256:d252932ef839c24c61c1139cc98f69c85ca774fa7c6bfaaa0015b7eb02b9dc87


### PR DESCRIPTION
## Why

https://github.com/actions/runner-images/issues/11101

## What

Drop Ubuntu 20.04 runners
Changed required build before merge for native-format.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- [x] New features are covered by tests.
