### PR TITLE
[repo] use public arm runners

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -17,7 +17,7 @@ jobs:
             base-image: alpine
             os-type: linux-musl
             architecture: x64
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             base-image: alpine
             os-type: linux-musl
             architecture: arm64

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Download Ubuntu arm64 Artifacts from build job
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # tag: v4.1.8
         with:
-          name: bin-otel-linux-arm64
-          path: bin/ci-artifacts/bin-otel-linux-arm64
+          name: bin-ubuntu-22.04-arm
+          path: bin/ci-artifacts/bin-ubuntu-22.04-arm
 
       - name: Download Alpine x64 Artifacts from build job
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # tag: v4.1.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,24 +19,15 @@ jobs:
             log-dir: "/var/log/opentelemetry/dotnet"
           - machine: macos-13
             log-dir: "/var/log/opentelemetry/dotnet"
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             log-dir: "/var/log/opentelemetry/dotnet"
     runs-on: ${{ matrix.machine }}
     steps:
-
-      - name: ARM64 Runner Info
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: cat /etc/os-release
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag: v4.2.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
-
-      - name: Setup ARM64 Environment Variables
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: |
-          echo "DOTNET_INSTALL_DIR=~/.dotnet" >> $GITHUB_ENV
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # tag: v4.3.0
@@ -64,15 +55,6 @@ jobs:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
           path: ${{ env.NUGET_PACKAGES }}
 
-      - name: Setup ARM64 Machine
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: |
-          sudo apt-get update && \
-          sudo apt-get install -y \
-              cmake \
-              clang \
-              make
-      
       - name: Run BuildWorkflow
         run: ./build.cmd BuildWorkflow --no-restore ${{ steps.nuget-cache.outputs.cache-hit != 'true' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
       fail-fast: false
       matrix:
         test-tfm: [ net9.0, net8.0, net462 ]
-        machine: [ windows-2022, ubuntu-22.04, macos-13, otel-linux-arm64 ]
+        machine: [ windows-2022, ubuntu-22.04, macos-13, ubuntu-22.04-arm ]
         exclude:
           - test-tfm: net462
             machine: macos-13
           - test-tfm: net462
             machine: ubuntu-22.04
           - test-tfm: net462
-            machine: otel-linux-arm64
+            machine: ubuntu-22.04-arm
         include:
           - machine: windows-2022
             containers: none
@@ -47,7 +47,7 @@ jobs:
             containers: linux
           - machine: macos-13
             containers: none
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             containers: linux
     runs-on: ${{ matrix.machine }}
     steps:
@@ -56,11 +56,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag: v4.2.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
-
-      - name: Setup ARM64 Environment Variables
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: |
-          echo "DOTNET_INSTALL_DIR=~/.dotnet" >> $GITHUB_ENV
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # tag: v4.3.0
@@ -87,15 +82,6 @@ jobs:
         uses: potatoqualitee/mssqlsuite@605af2310e2e22978ebf2c74d5995ba102094b8a # tag: v1.8
         with: 
           install: localdb
-      
-      - name: Setup ARM64 Machine
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: |
-          sudo apt-get update && \
-          sudo apt-get install -y \
-              cmake \
-              clang \
-              make
 
       - name: Run TestWorkflow
         run: ./build.cmd --skip NativeTests --target TestWorkflow --test-target-framework ${{ matrix.test-tfm }} --containers ${{ matrix.containers }}
@@ -216,13 +202,13 @@ jobs:
             base-image: centos-stream9
             build-source: ubuntu-22.04
             os-type: linux-glibc
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             base-image: alpine
             build-source: alpine-arm64
             os-type: linux-musl
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             base-image: debian-arm64
-            build-source: otel-linux-arm64
+            build-source: ubuntu-22.04-arm
             os-type: linux-glibc
     runs-on: ${{ matrix.machine }}
     timeout-minutes: 60
@@ -255,7 +241,7 @@ jobs:
           - machine: ubuntu-22.04
           - machine: macos-13
           - machine: windows-2022
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
     runs-on: ${{ matrix.machine }}
     steps:
       
@@ -263,11 +249,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag: v4.2.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
-
-      - name: Setup ARM64 Environment Variables
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: |
-          echo "DOTNET_INSTALL_DIR=~/.dotnet" >> $GITHUB_ENV
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # tag: v4.3.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -53,15 +53,10 @@ jobs:
             log-dir: "/var/log/opentelemetry/dotnet"
           - machine: macos-13
             log-dir: "/var/log/opentelemetry/dotnet"
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             log-dir: "/var/log/opentelemetry/dotnet"
     runs-on: ${{ matrix.machine }}
     steps:
-        
-      - name: Setup ARM64 Environment Variables
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: |
-          echo "DOTNET_INSTALL_DIR=~/.dotnet" >> $GITHUB_ENV
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # tag: v4.3.0
@@ -102,7 +97,7 @@ jobs:
           - machine: ubuntu-22.04
             base-image: alpine
             net-version: net9.0
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             base-image: alpine
             net-version: net9.0
     runs-on: ${{ matrix.machine }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - run: cd bin-alpine-x64 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-musl-x64.zip . * ; cd ..
       - run: cd bin-alpine-arm64 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip . * ; cd ..
       - run: cd bin-ubuntu-22.04 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip . * ; cd ..
-      - run: cd bin-otel-linux-arm64 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip . * ; cd ..
+      - run: cd bin-ubuntu-22.04-arm ; zip -qq -r ../opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip . * ; cd ..
       - run: cd bin-windows-2022 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-windows.zip . * ; cd ..
       - run: cd bin-macos-13 ; zip -qq -r ../opentelemetry-dotnet-instrumentation-macos.zip . * ; cd ..
       - run: cd bin-nuget-packages ; zip -qq -r ../opentelemetry-dotnet-instrumentation-nuget-packages.zip . * ; cd ..

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -24,18 +24,13 @@ jobs:
             containers: linux
           - machine: macos-13
             containers: none
-          - machine: otel-linux-arm64
+          - machine: ubuntu-22.04-arm
             containers: linux
     runs-on: ${{ matrix.machine }}
     steps:
       
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag: v4.2.2
-
-      - name: Setup ARM64 Environment Variables
-        if: ${{ matrix.machine == 'otel-linux-arm64' }}
-        run: |
-          echo "DOTNET_INSTALL_DIR=~/.dotnet" >> $GITHUB_ENV
 
       - name: Setup .NET
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # tag: v4.3.0

--- a/build/Build.NuGet.Steps.cs
+++ b/build/Build.NuGet.Steps.cs
@@ -52,7 +52,7 @@ partial class Build
                 "bin-alpine-x64/linux-musl-x64",
                 "bin-alpine-arm64/linux-musl-arm64",
                 "bin-ubuntu-22.04/linux-x64",
-                "bin-otel-linux-arm64/linux-arm64",
+                "bin-ubuntu-22.04-arm/linux-arm64",
                 "bin-macos-13/osx-x64",
                 "bin-windows-2022/win-x64",
                 "bin-windows-2022/win-x86"

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ CI tests run against the following operating systems:
 - [macOS Ventura 13 x64](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)
 - [Microsoft Windows Server 2022 x64](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)
 - [Ubuntu 22.04 LTS x64](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)
-- Ubuntu 22.04 LTS ARM64
+- [Ubuntu 22.04 LTS ARM64](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md)
 
 ### Instrumented libraries and frameworks
 


### PR DESCRIPTION
# Changes
Switches ARM64 runners to the public version.

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Follows https://github.com/open-telemetry/opentelemetry-dotnet/pull/6128