### PR TITLE
Suppress false positive NU1903 on CI/local builds

### DIFF
--- a/test/test-applications/nuget-packages/TestApplication.NugetSample/TestApplication.NugetSample.csproj
+++ b/test/test-applications/nuget-packages/TestApplication.NugetSample/TestApplication.NugetSample.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Tag v1.11.0 is not available on the main branch. It leads to create CI/local builds with 1.10.0-aplha.something version
+    These versions are wronlgy detected as vulnerable by NuGet Audit. It can be removed when we release next version from main. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-vc29-vg52-6643" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="$(NuGetPackageVersion)" Condition=" '$(NuGetPackageVersion)' != '' " />
     <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.11.0" Condition=" '$(NuGetPackageVersion)' == '' " />
   </ItemGroup>


### PR DESCRIPTION
## Why

Tag https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/tree/v1.11.0 was not created on main.

## What

Suppress false positive NU1903 on CI/local builds as we agreed on SIG.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
