### PR TITLE
Make AspNetCoreBootstrapper all FrameworkReference assets private

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -89,7 +89,14 @@ it assumes that the code is run from the root of the repository and the CI
 artifacts we added to `~/Downloads/`:
 
 ```PowerShell
-$artifacts = @("bin-alpine", "bin-centos", "bin-macos-13", "bin-windows-2022")
+$artifacts = @(
+    "bin-alpine-x64",
+    "bin-alpine-arm64",
+    "bin-ubuntu-22.04",
+    "bin-ubuntu-22.04-arm",
+    "bin-macos-13",
+    "bin-windows-2022"
+)
 $destFolder = "./bin/ci-artifacts/"
 $zipFilesFolder = "~/Downloads/"
 

--- a/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper/OpenTelemetry.AutoInstrumentation.AspNetCoreBootstrapper.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Related to #3911

It doesn't fix the issue because of the `OpenTelemetry.Instrumentation.AspNetCore` package has the typical framework reference, but our own package should be in proper form.