### PR TITLE
[integration-tests] remove usage of external services

### DIFF
--- a/test/IntegrationTests/CustomSdkTests.cs
+++ b/test/IntegrationTests/CustomSdkTests.cs
@@ -25,6 +25,7 @@ public class CustomSdkTests : TestHelper
     [Trait("Containers", "Linux")]
     public void SubmitsTraces()
     {
+        using var testServer = TestHttpServer.CreateDefaultTestServer(Output);
         using var collector = new MockSpansCollector(Output);
         SetExporter(collector);
 
@@ -43,7 +44,7 @@ public class CustomSdkTests : TestHelper
 
         RunTestApplication(new()
         {
-            Arguments = $"--redis {_redis.Port}"
+            Arguments = $"--redis-port {_redis.Port} --test-server-port {testServer.Port}"
         });
 
         collector.AssertExpectations();
@@ -55,6 +56,7 @@ public class CustomSdkTests : TestHelper
     [Trait("Containers", "Linux")]
     public void SubmitsMetrics()
     {
+        using var testServer = TestHttpServer.CreateDefaultTestServer(Output);
         using var collector = new MockMetricsCollector(Output);
         SetExporter(collector);
 
@@ -73,7 +75,7 @@ public class CustomSdkTests : TestHelper
 
         var process = StartTestApplication(new()
         {
-            Arguments = $"--redis {_redis.Port}"
+            Arguments = $"--redis-port {_redis.Port} --test-server-port {testServer.Port}"
         });
 
         try

--- a/test/IntegrationTests/Helpers/MockCorrelationCollector.cs
+++ b/test/IntegrationTests/Helpers/MockCorrelationCollector.cs
@@ -25,6 +25,7 @@ public class MockCorrelationCollector : IDisposable
     {
         _listener = new(
             helper,
+            nameof(MockCorrelationCollector),
             new PathHandler(HandleLogHttpRequests, "/v1/logs"),
             new PathHandler(HandleSpanHttpRequests, "/v1/traces"));
     }

--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -31,7 +31,7 @@ public class MockLogsCollector : IDisposable
 #if NETFRAMEWORK
         _listener = new(output, HandleHttpRequests, host, "/v1/logs/");
 #else
-        _listener = new(output, new PathHandler(HandleHttpRequests, "/v1/logs"));
+        _listener = new(output, nameof(MockLogsCollector), new PathHandler(HandleHttpRequests, "/v1/logs"));
 #endif
     }
 

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -30,7 +30,7 @@ public class MockMetricsCollector : IDisposable
 #if NETFRAMEWORK
         _listener = new(output, HandleHttpRequests, host, "/v1/metrics/");
 #else
-        _listener = new(output, new PathHandler(HandleHttpRequests, "/v1/metrics"));
+        _listener = new(output, nameof(MockMetricsCollector), new PathHandler(HandleHttpRequests, "/v1/metrics"));
 #endif
     }
 

--- a/test/IntegrationTests/Helpers/MockProfilesCollector.cs
+++ b/test/IntegrationTests/Helpers/MockProfilesCollector.cs
@@ -24,7 +24,7 @@ public class MockProfilesCollector : IDisposable
     public MockProfilesCollector(ITestOutputHelper output)
     {
         _output = output;
-        _listener = new(output, new PathHandler(HandleHttpRequests, "/v1development/profiles"));
+        _listener = new(output, nameof(MockProfilesCollector), new PathHandler(HandleHttpRequests, "/v1development/profiles"));
     }
 
     /// <summary>

--- a/test/IntegrationTests/Helpers/MockSpansCollector.cs
+++ b/test/IntegrationTests/Helpers/MockSpansCollector.cs
@@ -31,7 +31,7 @@ public class MockSpansCollector : IDisposable
 #if NETFRAMEWORK
         _listener = new TestHttpServer(output, HandleHttpRequests, host, "/v1/traces/");
 #else
-        _listener = new TestHttpServer(output, new PathHandler(HandleHttpRequests, "/v1/traces"));
+        _listener = new TestHttpServer(output, nameof(MockSpansCollector), new PathHandler(HandleHttpRequests, "/v1/traces"));
 #endif
     }
 

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -32,7 +32,7 @@ public class MockZipkinCollector : IDisposable
 #if NETFRAMEWORK
         _listener = new TestHttpServer(output, HandleHttpRequests, host, "/api/v2/spans/");
 #else
-        _listener = new TestHttpServer(output, new PathHandler(HandleHttpRequests, "/api/v2/spans"));
+        _listener = new TestHttpServer(output, nameof(MockZipkinCollector), new PathHandler(HandleHttpRequests, "/api/v2/spans"));
 #endif
     }
 

--- a/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
+++ b/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
@@ -53,17 +53,15 @@ public class TestHttpServer : IDisposable
     /// </summary>
     public int Port { get; }
 
+    public static TestHttpServer CreateDefaultTestServer(ITestOutputHelper output)
+    {
+        return new TestHttpServer(output, "TestDefault", new PathHandler(HandleTestRequest, "/test"));
+    }
+
     public void Dispose()
     {
         WriteOutput($"Shutting down");
         _listener.Dispose();
-    }
-
-#pragma warning disable SA1204
-    public static TestHttpServer CreateDefaultTestServer(ITestOutputHelper output)
-#pragma warning restore SA1204
-    {
-        return new TestHttpServer(output, "TestDefault", new PathHandler(HandleTestRequest, "/test"));
     }
 
     private static Task HandleTestRequest(HttpContext ctx)

--- a/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
+++ b/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
@@ -7,6 +7,7 @@ using System.Net;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
@@ -14,11 +15,13 @@ namespace IntegrationTests.Helpers;
 public class TestHttpServer : IDisposable
 {
     private readonly ITestOutputHelper _output;
+    private readonly string _name;
     private readonly IWebHost _listener;
 
-    public TestHttpServer(ITestOutputHelper output, params PathHandler[] pathHandlers)
+    public TestHttpServer(ITestOutputHelper output, string name, params PathHandler[] pathHandlers)
     {
         _output = output;
+        _name = name;
 
         _listener = new WebHostBuilder()
             .UseKestrel(options =>
@@ -56,10 +59,22 @@ public class TestHttpServer : IDisposable
         _listener.Dispose();
     }
 
+#pragma warning disable SA1204
+    public static TestHttpServer CreateDefaultTestServer(ITestOutputHelper output)
+#pragma warning restore SA1204
+    {
+        return new TestHttpServer(output, "TestDefault", new PathHandler(HandleTestRequest, "/test"));
+    }
+
+    private static Task HandleTestRequest(HttpContext ctx)
+    {
+        ctx.Response.StatusCode = 200;
+        return Task.CompletedTask;
+    }
+
     private void WriteOutput(string msg)
     {
-        const string name = nameof(TestHttpServer);
-        _output.WriteLine($"[{name}]: {msg}");
+        _output.WriteLine($"[{_name}-{nameof(TestHttpServer)}]: {msg}");
     }
 }
 

--- a/test/test-applications/integrations/TestApplication.CustomSdk/Program.cs
+++ b/test/test-applications/integrations/TestApplication.CustomSdk/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Globalization;
 using System.Net.Http;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -79,7 +80,7 @@ public static class Program
 
                 using var client = new HttpClient();
                 client.Timeout = TimeSpan.FromSeconds(5);
-                var port = int.Parse(args[3]);
+                var port = int.Parse(args[3], CultureInfo.InvariantCulture);
                 await client.GetStringAsync($"http://localhost:{port}/test", cancellation.Token);
             }
 
@@ -142,7 +143,7 @@ public static class Program
 
     private static async Task PingRedis(string[] args)
     {
-        var redisPort = int.Parse(GetRedisPort(args));
+        var redisPort = int.Parse(GetRedisPort(args), CultureInfo.InvariantCulture);
 
         var connectionString = $"127.0.0.1:{redisPort}";
 

--- a/test/test-applications/integrations/TestApplication.CustomSdk/Program.cs
+++ b/test/test-applications/integrations/TestApplication.CustomSdk/Program.cs
@@ -24,6 +24,11 @@ public static class Program
 
     public static async Task Main(string[] args)
     {
+        if (args.Length != 4)
+        {
+            throw new InvalidOperationException("Usage: TestApplication.CustomSdk.exe --redis-port <redis-port> --test-server-port <test-server-port>");
+        }
+
         ConsoleHelper.WriteSplashScreen(args);
 
         // When export of NServiceBus metrics is tested, which are updated on receive side,
@@ -74,7 +79,8 @@ public static class Program
 
                 using var client = new HttpClient();
                 client.Timeout = TimeSpan.FromSeconds(5);
-                await client.GetStringAsync("https://httpbin.org/get", cancellation.Token);
+                var port = int.Parse(args[3]);
+                await client.GetStringAsync($"http://localhost:{port}/test", cancellation.Token);
             }
 
             // The "LONG_RUNNING" environment variable is used by tests that access/receive
@@ -136,9 +142,9 @@ public static class Program
 
     private static async Task PingRedis(string[] args)
     {
-        var redisPort = GetRedisPort(args);
+        var redisPort = int.Parse(GetRedisPort(args));
 
-        var connectionString = $@"127.0.0.1:{redisPort}";
+        var connectionString = $"127.0.0.1:{redisPort}";
 
         using var connection = await ConnectionMultiplexer.ConnectAsync(connectionString);
         var db = connection.GetDatabase();


### PR DESCRIPTION
## Why
There were recently multiple test failures caused by external services being down.

## What
Removes dependency on external services from integration tests.
Starts local http server for testing purposes during tests.

Note: external service is still used in NuGet package tests - will be addressed in a separate PR.