### PR TITLE
OpenSSF Scorecard - pin docker images to exact digest

### DIFF
--- a/build/Build.Steps.Windows.cs
+++ b/build/Build.Steps.Windows.cs
@@ -178,7 +178,7 @@ partial class Build
 
             DockerBuild(x => x
                 .SetPath(".")
-                .SetBuildArg($"configuration={BuildConfiguration}", $"windowscontainer_version={WindowsContainerVersion}")
+                .SetBuildArg($"configuration={BuildConfiguration}")
                 .EnableRm()
                 .SetTag(Path.GetFileNameWithoutExtension(project).Replace(".", "-").ToLowerInvariant())
                 .SetProcessWorkingDirectory(project.Directory)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -35,9 +35,6 @@ partial class Build : NukeBuild
     [Parameter("Number of times each dotnet test is run. Default is '1'")]
     readonly int TestCount = 1;
 
-    [Parameter("Windows Server Core container version. Use it if your Windows does not support the default value. Default is 'ltsc2022'")]
-    readonly string WindowsContainerVersion = "ltsc2022";
-
     [Parameter("The location to create the tracer home directory. Default is './bin/tracer-home'")]
     readonly AbsolutePath TracerHome;
 

--- a/test/IntegrationTests/docker/rabbitmq.Dockerfile
+++ b/test/IntegrationTests/docker/rabbitmq.Dockerfile
@@ -1,1 +1,1 @@
-FROM rabbitmq:4.0.7
+FROM rabbitmq:4.0.7@sha256:c9b43f0aef35eeadde52432ca4d3c08967661257817efa8bce20846a4e5c6246

--- a/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Dockerfile
@@ -1,8 +1,6 @@
 # escape=`
 
-ARG windowscontainer_version=ltsc2022
-ARG image_digest=sha256:84079c734ab5aec702409ef7967ec47af9468c56ff4046882239cabacda78097
-FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-${windowscontainer_version}@${image_digest}
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:84079c734ab5aec702409ef7967ec47af9468c56ff4046882239cabacda78097
 ARG configuration=Debug
 ARG platform=x64
 WORKDIR /opentelemetry

--- a/test/test-applications/integrations/TestApplication.Owin.IIS.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.Owin.IIS.NetFramework/Dockerfile
@@ -1,7 +1,6 @@
 # escape=`
 
-ARG windowscontainer_version=ltsc2022
-FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-${windowscontainer_version}
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:84079c734ab5aec702409ef7967ec47af9468c56ff4046882239cabacda78097
 ARG configuration=Debug
 ARG platform=x64
 WORKDIR /opentelemetry

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/Dockerfile
@@ -1,8 +1,6 @@
 # escape=`
 
-ARG windowscontainer_version=ltsc2022
-ARG image_digest=sha256:5ae98afc5e31680c31662897ee453655f103f5923588991017bc561bc6312e08
-FROM mcr.microsoft.com/dotnet/framework/wcf:4.8-windowsservercore-${windowscontainer_version}@${image_digest}
+FROM mcr.microsoft.com/dotnet/framework/wcf:4.8-windowsservercore-ltsc2022@sha256:5ae98afc5e31680c31662897ee453655f103f5923588991017bc561bc6312e08
 ARG configuration=Debug
 ARG platform=x64
 WORKDIR /opentelemetry


### PR DESCRIPTION
## Why

Towards https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-dotnet-instrumentation

## What

Pin part of Docker images to exact digest.
It is droping `WindowsContainerVersion` support from nuke. Not needed for now, when necessary, we should implement it in a bit different version (2 separate Dockerfiles probably).

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
