### PR TITLE
OpenSSF Scorecard - pin docker images to exact digest - ASP.NET Frame…

### DIFF
--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -146,7 +146,7 @@ public class AspNetTests
         };
 
         var webPort = TcpPortProvider.GetOpenPort();
-        await using var container = await IISContainerTestHelper.StartContainerAsync("testapplication-aspnet-netframework", webPort, environmentVariables, Output);
+        await using var container = await IISContainerTestHelper.StartContainerAsync("testapplication-aspnet-netframework-integrated", webPort, environmentVariables, Output);
         await CallTestApplicationEndpoint(webPort);
 
         collector.ResourceExpector.AssertExpectations();
@@ -175,7 +175,7 @@ public class AspNetTests
             ["OTEL_DOTNET_AUTO_METRICS_ASPNET_INSTRUMENTATION_ENABLED"] = "true" // Helps to reduce noise by enabling only AspNet metrics.
         };
         var webPort = TcpPortProvider.GetOpenPort();
-        await using var container = await IISContainerTestHelper.StartContainerAsync("testapplication-aspnet-netframework", webPort, environmentVariables, Output);
+        await using var container = await IISContainerTestHelper.StartContainerAsync("testapplication-aspnet-netframework-integrated", webPort, environmentVariables, Output);
         await CallTestApplicationEndpoint(webPort);
 
         collector.AssertExpectations();
@@ -183,7 +183,7 @@ public class AspNetTests
 
     private static string GetTestImageName(string appPoolMode)
     {
-        return appPoolMode == "Classic" ? "testapplication-aspnet-netframework-classic" : "testapplication-aspnet-netframework";
+        return appPoolMode == "Classic" ? "testapplication-aspnet-netframework-classic" : "testapplication-aspnet-netframework-integrated";
     }
 
     private async Task CallTestApplicationEndpoint(int webPort)

--- a/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Classic.Dockerfile
+++ b/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Classic.Dockerfile
@@ -1,6 +1,0 @@
-# escape=`
-
-FROM testapplication-aspnet-netframework:latest
-RUN Start-IISCommitDelay;`
-    (Get-IISAppPool -Name DefaultAppPool).ManagedPipelineMode = 'Classic';`
-    Stop-IISCommitDelay -Commit $True

--- a/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:84079c734ab5aec702409ef7967ec47af9468c56ff4046882239cabacda78097
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:84079c734ab5aec702409ef7967ec47af9468c56ff4046882239cabacda78097 AS integrated
 ARG configuration=Debug
 ARG platform=x64
 WORKDIR /opentelemetry
@@ -16,3 +16,8 @@ ENV OTEL_DOTNET_AUTO_LOG_DIRECTORY=C:\inetpub\wwwroot\logs `
     OTEL_LOG_LEVEL=debug
 WORKDIR /inetpub/wwwroot
 COPY bin/${configuration}/app.publish .
+
+FROM integrated AS classic
+RUN Start-IISCommitDelay;`
+    (Get-IISAppPool -Name DefaultAppPool).ManagedPipelineMode = 'Classic';`
+    Stop-IISCommitDelay -Commit $True


### PR DESCRIPTION
## Why

Towards https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-dotnet-instrumentation

## What

Pin last Docker images to exact digest.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
