### PR TITLE
Fix examples/demo on arm64

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest # macos-latest runs on arm64 architecture
+          - ubuntu-24.04-arm64
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ ubuntu-latest, macos-latest ] # macos-latest runs is arm64 architecture
     steps:
 
     - name: Checkout

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-24.04-arm64
+          - ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,7 +16,12 @@ permissions:
 
 jobs:
   build:
-    runs-on: [ ubuntu-latest, macos-latest ] # macos-latest runs is arm64 architecture
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest # macos-latest runs is arm64 architecture
+    runs-on: ${{ matrix.os }}
     steps:
 
     - name: Checkout

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest # macos-latest runs is arm64 architecture
+          - macos-latest # macos-latest runs on arm64 architecture
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/examples/demo/Dockerfile
+++ b/examples/demo/Dockerfile
@@ -2,9 +2,11 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0.302-jammy@sha256:838644c2dd735cdf0ba3c6ec2
 
 # install OpenTelemetry .NET Automatic Instrumentation
 ARG OTEL_VERSION=1.11.0
+ENV OTEL_DOTNET_AUTO_HOME=/otel-dotnet-auto
 ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${OTEL_VERSION}/otel-dotnet-auto-install.sh otel-dotnet-auto-install.sh
 RUN apt-get update && apt-get install -y unzip && \
-    OTEL_DOTNET_AUTO_HOME="/otel-dotnet-auto" sh otel-dotnet-auto-install.sh
+    sh otel-dotnet-auto-install.sh
+RUN chmod +x /otel-dotnet-auto/instrument.sh
 
 WORKDIR /app
 COPY . .

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -5,8 +5,6 @@ services:
       context: ./Client
       dockerfile: ../Dockerfile # installs OpenTelemetry .NET Automatic Instrumentation
     entrypoint: "/otel-dotnet-auto/instrument.sh ./out/Examples.Client http://service:5000"
-    # env_file:
-    #   - otel-dotnet.env # enables OpenTelemetry .NET Automatic Instrumentation
     environment:
       # OpenTelemetry environmental variables:
       OTEL_SERVICE_NAME: "client"
@@ -20,8 +18,6 @@ services:
       context: ./Service
       dockerfile: ../Dockerfile # installs OpenTelemetry .NET Automatic Instrumentation
     entrypoint: "/otel-dotnet-auto/instrument.sh ./out/Examples.Service --urls http://*:5000"
-    # env_file:
-    #   - otel-dotnet.env # enable OpenTelemetry .NET Automatic Instrumentation
     environment:
       DB_CONNECTION: "Server=sqlserver,1433;User=sa;Password=yourStrong(!)Password;TrustServerCertificate=True;"
       # OpenTelemetry environmental variables:

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -4,9 +4,9 @@ services:
     build:
       context: ./Client
       dockerfile: ../Dockerfile # installs OpenTelemetry .NET Automatic Instrumentation
-    entrypoint: "./out/Examples.Client http://service:5000"
-    env_file:
-      - otel-dotnet.env # enables OpenTelemetry .NET Automatic Instrumentation
+    entrypoint: "/otel-dotnet-auto/instrument.sh ./out/Examples.Client http://service:5000"
+    # env_file:
+    #   - otel-dotnet.env # enables OpenTelemetry .NET Automatic Instrumentation
     environment:
       # OpenTelemetry environmental variables:
       OTEL_SERVICE_NAME: "client"
@@ -19,9 +19,9 @@ services:
     build:
       context: ./Service
       dockerfile: ../Dockerfile # installs OpenTelemetry .NET Automatic Instrumentation
-    entrypoint: "./out/Examples.Service --urls http://*:5000"
-    env_file:
-      - otel-dotnet.env # enable OpenTelemetry .NET Automatic Instrumentation
+    entrypoint: "/otel-dotnet-auto/instrument.sh ./out/Examples.Service --urls http://*:5000"
+    # env_file:
+    #   - otel-dotnet.env # enable OpenTelemetry .NET Automatic Instrumentation
     environment:
       DB_CONNECTION: "Server=sqlserver,1433;User=sa;Password=yourStrong(!)Password;TrustServerCertificate=True;"
       # OpenTelemetry environmental variables:
@@ -35,6 +35,8 @@ services:
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04
+    # This image is not available for ARM64 architecture
+    platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=yourStrong(!)Password

--- a/examples/demo/otel-dotnet.env
+++ b/examples/demo/otel-dotnet.env
@@ -1,8 +1,0 @@
-# enable OpenTelemetry .NET Automatic Instrumentation
-CORECLR_ENABLE_PROFILING="1"
-CORECLR_PROFILER='{918728DD-259F-4A6A-AC2B-B85E1B658318}'
-CORECLR_PROFILER_PATH="/otel-dotnet-auto/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so"
-DOTNET_ADDITIONAL_DEPS="/otel-dotnet-auto/AdditionalDeps"
-DOTNET_SHARED_STORE="/otel-dotnet-auto/store"
-DOTNET_STARTUP_HOOKS="/otel-dotnet-auto/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll"
-OTEL_DOTNET_AUTO_HOME="/otel-dotnet-auto"


### PR DESCRIPTION
`examples/demo` was hard-coding the architecture, but, since the demo was created we can let the `instrument.sh` script handle the setting of the environment variables.

Fix #3586

* Changed the respective Dockerfile and compose to use the `instrument.sh` to launch the application to be instrumented.
* Removed the old env file that is not needed anymore
* Added `ubuntu-24.04-arm` runner to the `example/demo` GH workflow to ensure arm64 coverage 