### PR TITLE
[CI] Avoid a warning on `check-native-headers` job

### DIFF
--- a/.github/workflows/format-native.yml
+++ b/.github/workflows/format-native.yml
@@ -41,7 +41,8 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # tag: v5.4.0
         with:
           go-version: '1.23.5'
-          
+          cache: false # Suppress a warning given that there are no go.sum files in the repo
+
       - name: Verify all native files have license headers
         shell: bash
         run: |


### PR DESCRIPTION
The `setup-go` action by default assumes that there is some `go.sum` file on the repo. Suppressing the corresponding warning by disabling caching from `setup-go`.