### PR TITLE
[Out-of-process-collection] Adjust styles and cleanup

### DIFF
--- a/next-gen/.editorconfig
+++ b/next-gen/.editorconfig
@@ -15,71 +15,62 @@ file_header_template = Copyright The OpenTelemetry Authors\nSPDX-License-Identif
 # Dotnet code style settings:
 [*.{cs}]
 # Sort using and Import directives with System.* appearing first
-dotnet_sort_system_directives_first = true : warning
+dotnet_sort_system_directives_first                               = true : warning
 
 # Use file-scoped namespace
 csharp_style_namespace_declarations = file_scoped:warning
 
 # Avoid "this." if not necessary
-dotnet_style_qualification_for_field = true : suggestion
-dotnet_style_qualification_for_property = true : suggestion
-dotnet_style_qualification_for_method = true : suggestion
-dotnet_style_qualification_for_event = true : suggestion
+dotnet_style_qualification_for_field                              = false : warning
+dotnet_style_qualification_for_property                           = false : warning
+dotnet_style_qualification_for_method                             = false : warning
+dotnet_style_qualification_for_event                              = false : warning
 
 # Expression-level preferences
 csharp_style_unused_value_assignment_preference = discard_variable : silent
 csharp_style_unused_value_expression_statement_preference = discard_variable : silent
 
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
-
-# name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+csharp_style_var_for_built_in_types                               = false : warning
+csharp_style_var_when_type_is_apparent                            = true : warning
+csharp_style_var_elsewhere                                        = false : silent
 
 # Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods = when_on_single_line : suggestion
-csharp_style_expression_bodied_constructors = false : warning
-csharp_style_expression_bodied_operators = when_on_single_line : warning
+csharp_style_expression_bodied_methods                            = when_on_single_line : suggestion
+csharp_style_expression_bodied_constructors                       = false : warning
+csharp_style_expression_bodied_operators                          = when_on_single_line : warning
 
 # Name all constant fields using PascalCase
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
 
-dotnet_naming_symbols.constant_fields.applicable_kinds = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
 
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_style.pascal_case_style.capitalization              = pascal_case
 
 # static fields should be s_PascalCase
-dotnet_naming_rule.static_fields_should_have_prefix.severity = none
-dotnet_naming_rule.static_fields_should_have_prefix.symbols = static_fields
-dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
+dotnet_naming_rule.static_fields_should_have_prefix.severity      = warning
+dotnet_naming_rule.static_fields_should_have_prefix.symbols       = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style         = static_prefix_style
 
-dotnet_naming_symbols.static_fields.applicable_kinds = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_kinds              = field
+dotnet_naming_symbols.static_fields.required_modifiers            = static
 
-dotnet_naming_style.static_prefix_style.required_prefix = s_
-dotnet_naming_style.static_prefix_style.capitalization = pascal_case
+dotnet_naming_style.static_prefix_style.required_prefix           = s_
+dotnet_naming_style.static_prefix_style.capitalization            = pascal_case
 
 # private fields should be _PascalCase
-dotnet_naming_rule.pascal_case_for_private_fields.severity = warning
-dotnet_naming_rule.pascal_case_for_private_fields.symbols = private_fields
-dotnet_naming_rule.pascal_case_for_private_fields.style = pascal_case_underscore_style
+dotnet_naming_rule.pascal_case_for_private_fields.severity        = warning
+dotnet_naming_rule.pascal_case_for_private_fields.symbols         = private_fields
+dotnet_naming_rule.pascal_case_for_private_fields.style           = pascal_case_underscore_style
 
-dotnet_naming_symbols.private_fields.applicable_kinds = field
-dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.applicable_kinds             = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities   = private
 
-dotnet_naming_style.pascal_case_underscore_style.required_prefix = _
-dotnet_naming_style.pascal_case_underscore_style.capitalization = pascal_case
+dotnet_naming_style.pascal_case_underscore_style.required_prefix  = _
+dotnet_naming_style.pascal_case_underscore_style.capitalization   = pascal_case
 
 # Remove unnecessary expression value
 dotnet_diagnostic.IDE0058.severity = none

--- a/next-gen/CodeAnalysis.ruleset
+++ b/next-gen/CodeAnalysis.ruleset
@@ -4,11 +4,14 @@
     <Rule Id="CA1303" Action="None" /> <!-- Do not pass literals as localized parameters -->
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML comments -->
+
     <Rule Id="SA1101" Action="None" /> <!-- Prefix local calls with this -->
 
-    <Rule Id="SA1204" Action="None" /> <!-- Static Elements Must Appear Before Instance Elements -->
+    <Rule Id="SA1204" Action="Info" /> <!-- Static elements should appear before instance elements -->
 
     <Rule Id="SA1306" Action="None" /> <!-- Field should begin with lower-case letter -->
+    <Rule Id="SA1307" Action="None" /> <!-- Accessible fields should begin with upper-case letter -->
     <Rule Id="SA1308" Action="None" /> <!-- Field should not begin with the prefix 's_' -->
     <Rule Id="SA1309" Action="None" /> <!-- Field names should not begin with underscore -->
     <Rule Id="SA1311" Action="None" /> <!-- Static readonly fields should begin with upper-case letter -->
@@ -20,6 +23,5 @@
     <Rule Id="SA1600" Action="None" /> <!-- Elements should be documented -->
     <Rule Id="SA1601" Action="None" /> <!-- Partial elements should be documented -->
     <Rule Id="SA1602" Action="None" /> <!-- Enumeration items should be documented -->
-    <Rule Id="SA1652" Action="None" /> <!-- Enable Xml Documentation Output -->
   </Rules>
 </RuleSet>

--- a/next-gen/Directory.Build.props
+++ b/next-gen/Directory.Build.props
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).FullName)</RepoRoot>
+    <IsTestProject>$(MSBuildProjectName.Contains('.Test'))</IsTestProject>
+
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(RepoRoot)\KeyPair.snk</AssemblyOriginatorKeyFile>
 
@@ -18,7 +20,7 @@
 
     <TargetFrameworks>net9.0</TargetFrameworks>
     <TestTargetFrameworks>net9.0</TestTargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition="'$(IsTestProject)' != 'true'">true</GenerateDocumentationFile>
 
     <NuGetAudit>true</NuGetAudit>
     <NuGetAuditMode>all</NuGetAuditMode>
@@ -36,8 +38,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
-  
-  <ItemGroup Condition="'$(MSBuildProjectDirectory)' == '$(SolutionDir)src' Or $(MSBuildProjectDirectory.StartsWith('$(SolutionDir)src\'))">
+
+  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
 
@@ -59,7 +61,6 @@
 
     <AdditionalFiles Include=".publicApi\PublicAPI.*.txt" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" Visible="false" />
-    <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" Link="GlobalSuppressions.solution.cs" />
   </ItemGroup>
 
   <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)' != '' AND '$(BuildNumber)' != ''">

--- a/next-gen/GlobalSuppressions.cs
+++ b/next-gen/GlobalSuppressions.cs
@@ -1,8 +1,0 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Reviewed.")]
-[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1652:EnableXmlDocumentationOutput", Justification = "Reviewed.")]
-[assembly: SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1025:Code must not contain multiple whitespace in a row", Justification = "Reviewed. Used for pretty formatting.")]
-[assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Reviewed.")]
-[assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:StaticElementsMustAppearBeforeInstanceElements", Justification = "Reviewed.")]

--- a/next-gen/global.json
+++ b/next-gen/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "9.0.100"
+    "version": "9.0.105"
   }
 }

--- a/next-gen/src/OpenTelemetry.AutoInstrumentation.Sdk/OpenTelemetry.AutoInstrumentation.Sdk.csproj
+++ b/next-gen/src/OpenTelemetry.AutoInstrumentation.Sdk/OpenTelemetry.AutoInstrumentation.Sdk.csproj
@@ -21,8 +21,4 @@
     <Protobuf Include="**/*.proto" Access="internal" ProtoRoot="OpenTelemetryProtocol" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="C:\repo\opentelemetry-dotnet-instrumentation\next-gen\GlobalSuppressions.cs" />
-  </ItemGroup>
-
 </Project>

--- a/next-gen/src/OpenTelemetry.AutoInstrumentation.Sdk/OpenTelemetryProtocol/Serializer/ProtobufSerializer.cs
+++ b/next-gen/src/OpenTelemetry.AutoInstrumentation.Sdk/OpenTelemetryProtocol/Serializer/ProtobufSerializer.cs
@@ -308,7 +308,7 @@ internal static class ProtobufSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int WriteStringWithTag(byte[] buffer, int writePosition, int fieldNumber, ReadOnlySpan<char> value)
     {
-        var numberOfUtf8CharsInString = GetNumberOfUtf8CharsInString(value);
+        int numberOfUtf8CharsInString = GetNumberOfUtf8CharsInString(value);
         return WriteStringWithTag(buffer, writePosition, fieldNumber, numberOfUtf8CharsInString, value);
     }
 
@@ -338,7 +338,7 @@ internal static class ProtobufSerializer
             }
         }
 #else
-        var bytesWritten = s_Utf8Encoding.GetBytes(value, buffer.AsSpan().Slice(writePosition));
+        int bytesWritten = s_Utf8Encoding.GetBytes(value, buffer.AsSpan().Slice(writePosition));
         Debug.Assert(bytesWritten == numberOfUtf8CharsInString, "bytesWritten did not match numberOfUtf8CharsInString");
 #endif
 

--- a/next-gen/src/OpenTelemetry.AutoInstrumentation.Sdk/OpenTelemetryProtocol/Tracing/OtlpSpanExporterAsync.cs
+++ b/next-gen/src/OpenTelemetry.AutoInstrumentation.Sdk/OpenTelemetryProtocol/Tracing/OtlpSpanExporterAsync.cs
@@ -33,7 +33,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
         in TBatch batch,
         CancellationToken cancellationToken)
     {
-        var writer = _Writer;
+        OtlpSpanWriter writer = _Writer;
 
         if (!batch.WriteTo(writer))
         {
@@ -68,15 +68,15 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
 
             var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
             {
-                Buffer = this.Request.Buffer,
-                WritePosition = this._BufferState.WritePosition,
+                Buffer = _BufferState.Buffer,
+                WritePosition = _BufferState.WritePosition,
             };
 
             otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Resource, ProtobufWireType.LEN);
             int resourceLengthPosition = otlpTagWriterState.WritePosition;
             otlpTagWriterState.WritePosition += OtlpBufferState.ReserveSizeForLength;
 
-            foreach (var attribute in resource.Attributes)
+            foreach (KeyValuePair<string, object> attribute in resource.Attributes)
             {
                 ProcessResourceAttribute(ref otlpTagWriterState, attribute);
             }
@@ -111,8 +111,8 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
             {
                 var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
                 {
-                    Buffer = this.Request.Buffer,
-                    WritePosition = this._BufferState.WritePosition,
+                    Buffer = _BufferState.Buffer,
+                    WritePosition = _BufferState.WritePosition,
                     TagCount = 0,
                     DroppedTagCount = 0,
                 };
@@ -125,7 +125,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
 
                     ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, instrumentationScope.Attributes[i].Key, instrumentationScope.Attributes[i].Value);
 
-                    var instrumentationScopeAttributesLength = otlpTagWriterState.WritePosition - (instrumentationScopeAttributesLengthPosition + OtlpBufferState.ReserveSizeForLength);
+                    int instrumentationScopeAttributesLength = otlpTagWriterState.WritePosition - (instrumentationScopeAttributesLengthPosition + OtlpBufferState.ReserveSizeForLength);
                     ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, instrumentationScopeAttributesLengthPosition, instrumentationScopeAttributesLength);
                 }
 
@@ -224,7 +224,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
                 DroppedTagCount = 0,
             };
 
-            foreach (ref readonly var tag in tags)
+            foreach (ref readonly KeyValuePair<string, object?> tag in tags)
             {
                 otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Attributes, ProtobufWireType.LEN);
                 int spanAttributesLengthPosition = otlpTagWriterState.WritePosition;
@@ -240,7 +240,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
 
         internal static int WriteSpanEvents(byte[] buffer, int writePosition, ReadOnlySpan<SpanEvent> events)
         {
-            foreach (ref readonly var evnt in events)
+            foreach (ref readonly SpanEvent evnt in events)
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Events, ProtobufWireType.LEN);
                 int spanEventsLengthPosition = writePosition;
@@ -249,7 +249,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
                 writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Name, evnt.Name);
                 writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Time_Unix_Nano, (ulong)evnt.TimestampUtc.ToUnixTimeNanoseconds());
 
-                ref readonly var attributes = ref SpanEvent.GetAttributesReference(in evnt);
+                ref readonly TagList attributes = ref SpanEvent.GetAttributesReference(in evnt);
 
                 writePosition = WriteEventAttributes(buffer, writePosition, attributes);
                 ProtobufSerializer.WriteReservedLength(buffer, spanEventsLengthPosition, writePosition - (spanEventsLengthPosition + OtlpBufferState.ReserveSizeForLength));
@@ -268,7 +268,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
                 DroppedTagCount = 0,
             };
 
-            foreach (var tag in attributes)
+            foreach (KeyValuePair<string, object?> tag in attributes)
             {
                 otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Attributes, ProtobufWireType.LEN);
                 int eventAttributesLengthPosition = otlpTagWriterState.WritePosition;
@@ -284,10 +284,10 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
 
         internal static int WriteSpanLinks(byte[] buffer, int writePosition, ReadOnlySpan<SpanLink> links)
         {
-            foreach (ref readonly var link in links)
+            foreach (ref readonly SpanLink link in links)
             {
-                ref readonly var context = ref SpanLink.GetSpanContextReference(in link);
-                ref readonly var attributes = ref SpanLink.GetAttributesReference(in link);
+                ref readonly ActivityContext context = ref SpanLink.GetSpanContextReference(in link);
+                ref readonly TagList attributes = ref SpanLink.GetAttributesReference(in link);
 
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Links, ProtobufWireType.LEN);
                 int spanLinksLengthPosition = writePosition;
@@ -323,7 +323,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
                 DroppedTagCount = 0,
             };
 
-            foreach (var tag in attributes)
+            foreach (KeyValuePair<string, object?> tag in attributes)
             {
                 otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Link_Attributes, ProtobufWireType.LEN);
                 int linkAttributesLengthPosition = otlpTagWriterState.WritePosition;
@@ -345,7 +345,7 @@ internal sealed class OtlpSpanExporterAsync : OtlpExporterAsync<OtlpBufferState,
 
             if (statusCode == ActivityStatusCode.Error && statusDescription != null)
             {
-                var descriptionSpan = statusDescription.AsSpan();
+                ReadOnlySpan<char> descriptionSpan = statusDescription.AsSpan();
                 int numberOfUtf8CharsInString = ProtobufSerializer.GetNumberOfUtf8CharsInString(descriptionSpan);
                 int serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
 

--- a/next-gen/test/.editorconfig
+++ b/next-gen/test/.editorconfig
@@ -1,3 +1,10 @@
-[*Tests.cs]
+[*.{cs}]
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types                               = false : suggestion
+csharp_style_var_when_type_is_apparent                            = true : suggestion
+csharp_style_var_elsewhere                                        = false : silent
+
+# Suppress Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = suggestion
 # Suppress 'static readonly' fields over constant array warnings
-dotnet_diagnostic.CA1861.severity = none
+dotnet_diagnostic.CA1861.severity = suggestion

--- a/next-gen/test/OpenTelemetry.AutoInstrumentation.Sdk.Tests/OpenTelemetry.AutoInstrumentation.Sdk.Tests.csproj
+++ b/next-gen/test/OpenTelemetry.AutoInstrumentation.Sdk.Tests/OpenTelemetry.AutoInstrumentation.Sdk.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <NoWarn>$(NoWarn);IDE1006;CS1591;CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,13 +12,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Net.Client" />
-    <PackageReference Include="Google.Protobuf" />
-    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\OpenTelemetry.AutoInstrumentation.Sdk\OpenTelemetry.AutoInstrumentation.Sdk.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.AutoInstrumentation.Sdk\OpenTelemetry.AutoInstrumentation.Sdk.csproj" />
   </ItemGroup>
 
 </Project>

--- a/next-gen/test/OpenTelemetry.AutoInstrumentation.Sdk.Tests/ProtobufOtlpSpanExporterAsyncTests.cs
+++ b/next-gen/test/OpenTelemetry.AutoInstrumentation.Sdk.Tests/ProtobufOtlpSpanExporterAsyncTests.cs
@@ -12,17 +12,17 @@ namespace OpenTelemetry.AutoInstrumentation.Sdk.Tests;
 
 public sealed class ProtobufOtlpSpanExporterAsyncTests : IDisposable
 {
-    private readonly ActivityListener activityListener;
-
     static ProtobufOtlpSpanExporterAsyncTests()
     {
         Activity.DefaultIdFormat = ActivityIdFormat.W3C;
         Activity.ForceDefaultIdFormat = true;
     }
 
+    private readonly ActivityListener _ActivityListener;
+
     public ProtobufOtlpSpanExporterAsyncTests()
     {
-        this.activityListener = new ActivityListener
+        _ActivityListener = new ActivityListener
         {
             ShouldListenTo = _ => true,
             Sample = (ref ActivityCreationOptions<ActivityContext> options) => options.Parent.TraceFlags.HasFlag(ActivityTraceFlags.Recorded)
@@ -30,12 +30,12 @@ public sealed class ProtobufOtlpSpanExporterAsyncTests : IDisposable
                 : ActivitySamplingResult.AllData,
         };
 
-        ActivitySource.AddActivityListener(this.activityListener);
+        ActivitySource.AddActivityListener(_ActivityListener);
     }
 
     public void Dispose()
     {
-        this.activityListener.Dispose();
+        _ActivityListener.Dispose();
     }
 
     [Fact]

--- a/next-gen/test/OpenTelemetry.AutoInstrumentation.Sdk.Tests/Serializer/OtlpArrayTagWriterTests.cs
+++ b/next-gen/test/OpenTelemetry.AutoInstrumentation.Sdk.Tests/Serializer/OtlpArrayTagWriterTests.cs
@@ -14,26 +14,26 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
         Activity.ForceDefaultIdFormat = true;
     }
 
-    private readonly ProtobufOtlpTagWriter.OtlpArrayTagWriter arrayTagWriter;
-    private readonly ActivityListener activityListener;
+    private readonly ProtobufOtlpTagWriter.OtlpArrayTagWriter _ArrayTagWriter;
+    private readonly ActivityListener _ActivityListener;
 
     public OtlpArrayTagWriterTests()
     {
-        this.arrayTagWriter = new ProtobufOtlpTagWriter.OtlpArrayTagWriter();
-        this.activityListener = new ActivityListener
+        _ArrayTagWriter = new ProtobufOtlpTagWriter.OtlpArrayTagWriter();
+        _ActivityListener = new ActivityListener
         {
             ShouldListenTo = _ => true,
             Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
         };
 
-        ActivitySource.AddActivityListener(this.activityListener);
+        ActivitySource.AddActivityListener(_ActivityListener);
     }
 
     [Fact]
     public void BeginWriteArray_InitializesArrayState()
     {
         // Act
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
+        var arrayState = _ArrayTagWriter.BeginWriteArray();
 
         // Assert
         Assert.NotNull(arrayState.Buffer);
@@ -45,10 +45,10 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void WriteNullValue_AddsNullValueToBuffer()
     {
         // Arrange
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
+        var arrayState = _ArrayTagWriter.BeginWriteArray();
 
         // Act
-        this.arrayTagWriter.WriteNullValue(ref arrayState);
+        _ArrayTagWriter.WriteNullValue(ref arrayState);
 
         // Assert
         // Check that the buffer contains the correct tag and length for a null value
@@ -62,10 +62,10 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void WriteIntegralValue_WritesIntegralValueToBuffer(long value)
     {
         // Arrange
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
+        var arrayState = _ArrayTagWriter.BeginWriteArray();
 
         // Act
-        this.arrayTagWriter.WriteIntegralValue(ref arrayState, value);
+        _ArrayTagWriter.WriteIntegralValue(ref arrayState, value);
 
         // Assert
         Assert.True(arrayState.WritePosition > 0);
@@ -78,10 +78,10 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void WriteFloatingPointValue_WritesFloatingPointValueToBuffer(double value)
     {
         // Arrange
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
+        var arrayState = _ArrayTagWriter.BeginWriteArray();
 
         // Act
-        this.arrayTagWriter.WriteFloatingPointValue(ref arrayState, value);
+        _ArrayTagWriter.WriteFloatingPointValue(ref arrayState, value);
 
         // Assert
         Assert.True(arrayState.WritePosition > 0);
@@ -93,10 +93,10 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void WriteBooleanValue_WritesBooleanValueToBuffer(bool value)
     {
         // Arrange
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
+        var arrayState = _ArrayTagWriter.BeginWriteArray();
 
         // Act
-        this.arrayTagWriter.WriteBooleanValue(ref arrayState, value);
+        _ArrayTagWriter.WriteBooleanValue(ref arrayState, value);
 
         // Assert
         Assert.True(arrayState.WritePosition > 0);
@@ -108,10 +108,10 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void WriteStringValue_WritesStringValueToBuffer(string value)
     {
         // Arrange
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
+        var arrayState = _ArrayTagWriter.BeginWriteArray();
 
         // Act
-        this.arrayTagWriter.WriteStringValue(ref arrayState, value.AsSpan());
+        _ArrayTagWriter.WriteStringValue(ref arrayState, value.AsSpan());
 
         // Assert
         Assert.True(arrayState.WritePosition > 0);
@@ -121,8 +121,8 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void TryResize_SucceedsInitially()
     {
         // Act
-        this.arrayTagWriter.BeginWriteArray();
-        bool result = this.arrayTagWriter.TryResize();
+        _ArrayTagWriter.BeginWriteArray();
+        bool result = _ArrayTagWriter.TryResize();
 
         // Assert
         Assert.True(result);
@@ -132,13 +132,13 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void TryResize_RepeatedResizingStopsAtMaxBufferSize()
     {
         // Arrange
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
+        var arrayState = _ArrayTagWriter.BeginWriteArray();
         bool resizeResult = true;
 
         // Act: Repeatedly attempt to resize until reaching maximum buffer size
         while (resizeResult)
         {
-            resizeResult = this.arrayTagWriter.TryResize();
+            resizeResult = _ArrayTagWriter.TryResize();
         }
 
         // Assert
@@ -148,7 +148,7 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void Dispose()
     {
         // Clean up the thread buffer after each test
-        ProtobufOtlpTagWriter.OtlpArrayTagWriter.ThreadBuffer = null;
-        this.activityListener.Dispose();
+        ProtobufOtlpTagWriter.OtlpArrayTagWriter.s_ThreadBuffer = null;
+        _ActivityListener.Dispose();
     }
 }


### PR DESCRIPTION
[Note: This PR is going into the `out-of-process-collection` branch]

This PR adjusts what was done on #4148 w.r.t to styles. I tried to loosen the rules to make it easier to port code from the opentelemetry-dotnet repo for @rajkumar-rangaraj (and team) but preserve some of the more important things enforced in this code.

When bringing over code now there should be some warnings on over-use of `var` but that is easy to cleanup with code fixes. Private fields in this repo should be "_PascalCase" that is easy to fix up with a rename. Having that rule makes using "this." everywhere silly so there are style warnings for that but also easy to cleanup with code fix. Things like ordering & underscores in method names won't complain in tests now. Over-use of "var" (aka "var" everywhere) is also allowed in tests. XML comments are no longer required for tests.