### PR TITLE
Fix clang version on centos-stream9

### DIFF
--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -20,7 +20,7 @@ RUN update-crypto-policies --set LEGACY
 # Install dependencies
 RUN dnf install -y \
     cmake-3.26.5-2.el9 \
-    clang-18.1.8-3.el9 \
+    clang-20.1.3-1.el9 \
     git-2.43.5-1.el9
 
 WORKDIR /project


### PR DESCRIPTION
Various PRs are failing due to the old version not being available, updating the version to fix.