### PR TITLE
ci(validate-documentation): add caching for lychee

### DIFF
--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -27,12 +27,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag: v4.2.2
 
+    - name: Restore lychee cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      id: cache-restore
+      with:
+        path: .lycheecache
+        key: cache-lychee-${{ github.sha }}
+        restore-keys: cache-lychee-
+
     - name: Run markdown links checks
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'release PR') }}
       uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # tag: v2.4.1
       with:
         fail: true
-        args: "--threads 1 --max-concurrency 1 --verbose --retry-wait-time 5 --max-retries 3 --timeout 60 --no-progress './**/*.md' './**/*.html'"
+        args: "--cache --max-cache-age 1d --threads 1 --max-concurrency 1 --verbose --retry-wait-time 5 --max-retries 3 --timeout 60 --no-progress './**/*.md' './**/*.html'"
 
     - name: Run markdownlint
       uses: streetsidesoftware/cspell-action@69543c3f9f14d4fcc6004c7bee03c4d366f11d64 # tag: v7.0.1
@@ -41,3 +49,10 @@ jobs:
 
     - name: Run cspell
       uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # tag: v20.0.0
+
+    - name: Save lychee cache
+      if: always()
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: .lycheecache
+        key: ${{ steps.cache-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

Adding caching to reduce the amount of requests to Github by the Lychee action in the attempt that we don't hit Github's rate limit.

Fixes #4204 

## What

<!-- Describe changes proposed in this pull request. -->

Add actions cache save and restore for Lychee to utilize with appropriate command line arguments. Went with 1 day for cache invalidation with the thought being the action would run multiple times within a day / Pull Request.

The cache key's off of the `${{ github.sha }}` so if a new commit is made / change to the sha the cache is not restored and a new cache will be saved.

[Lychee's Cache Utilization Docs](https://github.com/lycheeverse/lychee-action?tab=readme-ov-file#usage)
[Lychee's Command Line Parameters](https://github.com/lycheeverse/lychee?tab=readme-ov-file#commandline-parameters)

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

~~- [ ] `CHANGELOG.md` is updated.~~
~~- [ ] Documentation is updated.~~
~~- [ ] New features are covered by tests.~~
