### PR TITLE
Docs: Make PowerShell 5.1 usage more prominent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -240,9 +240,17 @@ uses environment variables as parameters:
 
 On Windows, you should install OpenTelemetry .NET Automatic Instrumentation
 and instrument your .NET application using the provided PowerShell module.
+
+> [!WARNING]
+> The PowerShell module works only on PowerShell 5.1
+which is the one installed by default on Windows.
+
 Example usage (run as administrator):
 
 ```powershell
+# PowerShell 5.1 is required
+#Requires -PSEdition Desktop
+
 # Download the module
 $module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.11.0/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
@@ -287,10 +295,6 @@ Unregister-OpenTelemetryForWindowsService -WindowsServiceName MyServiceName
 Update-OpenTelemetryCore
 Register-OpenTelemetryForWindowsService -WindowsServiceName MyServiceName -OTelServiceName MyOtelServiceName
 ```
-
-> [!WARNING]
-> The PowerShell module works only on PowerShell 5.1
-which is the one installed by default on Windows.
 
 ## Instrument a container
 


### PR DESCRIPTION
## Why

https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2018#issuecomment-2983383073

Relates to #2018 and https://github.com/open-telemetry/opentelemetry.io/pull/7140.

## What

Make requirement to use Windows PowerShell to install zero-code instrumentation for .NET on Windows more prominent.

## Tests

Manual check that the directive causes the script to fail in pwsh and not in PowerShell.

```pwsh
#Requires -PSEdition Desktop
echo "Success"
```

With pwsh:

```terminal
❯ .\test.ps1
.\test.ps1: The script 'test.ps1' cannot be run because it contained a "#requires" statement for PowerShell editions 'Desktop'. The edition of PowerShell that is required by the script does not match the currently running PowerShell Core edition.
```

With PowerShell:

```terminal
PS D:\Coding> .\test.ps1
Success
```

## Checklist

- [ ] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [ ] New features are covered by tests.
