### PR TITLE
[Infra] Update .NET install script checksums

### DIFF
--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -18,8 +18,8 @@ ENV gRPC_PluginFullPath=/usr/bin/grpc_csharp_plugin
 
 # Install older sdks using the install script
 RUN curl -sSL --retry 5 https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
-    && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "19b0a7890c371201b944bf0f8cdbb6460d053d63ddbea18cfed3e4199769ce17  dotnet-install.sh" | sha256sum -c \
+    && echo "SHA512: $(sha512sum dotnet-install.sh)" \
+    && echo "f8c59166ed912d6861e93c3efc2840be31ec32897679678a72f781423ebf061348d3b92b16c9541f5b312a34160f452826bb3021efb1414d76bd7e237e4c0e9a  dotnet-install.sh" | sha512sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 8.0.411 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9@sha256:4c755d11df35a63dc8dc0155cfa00713040b76bb8737ac60e608c7111e1de589
+FROM quay.io/centos/centos:stream9@sha256:45650b7974762418b66987d67c063aee0d2fab0ac8fade2db9807b3ec4bbd1af
 
 # Install dotnet sdk
 RUN dnf install -y \

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -5,8 +5,8 @@ RUN dnf install -y \
     libicu-devel
 
 RUN curl -sSL --retry 5 https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
-    && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "19b0a7890c371201b944bf0f8cdbb6460d053d63ddbea18cfed3e4199769ce17  dotnet-install.sh" | sha256sum -c \
+    && echo "SHA512: $(sha512sum dotnet-install.sh)" \
+    && echo "f8c59166ed912d6861e93c3efc2840be31ec32897679678a72f781423ebf061348d3b92b16c9541f5b312a34160f452826bb3021efb1414d76bd7e237e4c0e9a  dotnet-install.sh" | sha512sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 9.0.301 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh -v 8.0.411 --install-dir /usr/share/dotnet --no-path \

--- a/docker/debian-arm64.dockerfile
+++ b/docker/debian-arm64.dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && \
 
 # Install older sdks using the install script as there are no arm64 SDK packages.
 RUN curl -sSL --retry 5 https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
-    && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "19b0a7890c371201b944bf0f8cdbb6460d053d63ddbea18cfed3e4199769ce17  dotnet-install.sh" | sha256sum -c \
+    && echo "SHA512: $(sha512sum dotnet-install.sh)" \
+    && echo "f8c59166ed912d6861e93c3efc2840be31ec32897679678a72f781423ebf061348d3b92b16c9541f5b312a34160f452826bb3021efb1414d76bd7e237e4c0e9a  dotnet-install.sh" | sha512sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 8.0.411 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh

--- a/docker/ubuntu1604.dockerfile
+++ b/docker/ubuntu1604.dockerfile
@@ -32,8 +32,8 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     apt-get install -y --allow-unauthenticated cmake
 
 RUN curl -sSL --retry 5 https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
-    && echo "SHA256: $(sha256sum dotnet-install.sh)" \
-    && echo "19b0a7890c371201b944bf0f8cdbb6460d053d63ddbea18cfed3e4199769ce17  dotnet-install.sh" | sha256sum -c \
+    && echo "SHA512: $(sha512sum dotnet-install.sh)" \
+    && echo "f8c59166ed912d6861e93c3efc2840be31ec32897679678a72f781423ebf061348d3b92b16c9541f5b312a34160f452826bb3021efb1414d76bd7e237e4c0e9a  dotnet-install.sh" | sha512sum -c \
     && chmod +x ./dotnet-install.sh \
     && ./dotnet-install.sh -v 9.0.301 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh


### PR DESCRIPTION
## Why

CI is failing due to updates to `https://dot.net/v1/dotnet-install.sh` (see https://github.com/dotnet/install-scripts/pull/617).

## What

- Update checksum for `https://dot.net/v1/dotnet-install.sh`.
- Switch to SHA512 hashes.

## Tests

None.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~
