### PR TITLE
[tests] dispose logger factory created in tests

### DIFF
--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/PluginManagerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/PluginManagerTests.cs
@@ -119,17 +119,20 @@ public class PluginManagerTests
         var settings = GetSettings(pluginAssemblyQualifiedName);
         var pluginManager = new PluginManager(settings);
 
-        var logsAction = () => LoggerFactory.Create(builder =>
+        var logsAction = () =>
         {
-            builder.AddOpenTelemetry(options =>
+            using var loggerFactory = LoggerFactory.Create(builder =>
             {
-                options.IncludeFormattedMessage = false;
-                pluginManager.ConfigureLogsOptions(options);
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeFormattedMessage = false;
+                    pluginManager.ConfigureLogsOptions(options);
 
-                // Verify that plugin changes the state
-                Assert.True(options.IncludeFormattedMessage);
+                    // Verify that plugin changes the state
+                    Assert.True(options.IncludeFormattedMessage);
+                });
             });
-        });
+        };
 
         Assert.Null(Record.Exception(() => logsAction()));
     }


### PR DESCRIPTION
Test failure described in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4275#issuecomment-3018073122 was caused by additional event being logged, that was not expected by the test.

This additional event was a result of finalization of `LoggerProviderSdk`.

Changes from this PR ensure deterministic cleanup of `LoggerProviderSdk`.