### PR TITLE
[tests] fix flaky test - increase expected range

### DIFF
--- a/test/IntegrationTests/SelectiveSamplerTests.cs
+++ b/test/IntegrationTests/SelectiveSamplerTests.cs
@@ -53,7 +53,7 @@ public class SelectiveSamplerTests : TestHelper
 
         // Test app sleeps for 0.5s, sampling interval set to 0.05s
         Output.WriteLine($"Count: {threadSamples.Count}");
-        Assert.InRange(threadSamples.Count, 7, 10);
+        Assert.InRange(threadSamples.Count, 7, 12);
 
         var threadNames = threadSamples.Select(sample => sample.ThreadName).Distinct(StringComparer.InvariantCultureIgnoreCase);
 


### PR DESCRIPTION
## Why && What

Fixes #4312 

Additional samples collected in failing runs come from handling activity start/stop notifications.

As an alternative to increasing range, we could consider:
- limiting asserted samples only to ones with `Thread.Sleep` at the top (but would made us unaware of other possibly produced samples, of which there shouldn't be any apart from these related to handling start/stop notifications)
- changing auto-instrumentation log level from `debug` to e.g. `info` (when debug logging is enabled, we subscribe to additional events from the SDK, and log activity start/stop)
