### PR TITLE
Fix BuildTasks StackExchangeRedis package version + sanity test

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
+++ b/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
@@ -7,7 +7,7 @@
         Condition="!$(SkippedInstrumentations.Contains('StackExchange.Redis')) AND !$(TargetFramework.StartsWith('net4'))"
         TargetNuGetPackageVersionRange="[2.6.122, 3.0.0)"
         InstrumentationNuGetPackageId="OpenTelemetry.Instrumentation.StackExchangeRedis"
-        InstrumentationNuGetPackageVersion="1.11.0-beta.1" />
+        InstrumentationNuGetPackageVersion="1.12.0-beta.1" />
 
     </ItemGroup>
 

--- a/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests.csproj
+++ b/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests.csproj
@@ -5,6 +5,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\IntegrationTests\Helpers\EnvironmentTools.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Packages referenced by the BuildTasks are not transferred to the test library so add them here so it can be used by the tests. -->
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/TargetsPackageVersionTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/TargetsPackageVersionTests.cs
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Xml.Linq;
+using IntegrationTests.Helpers;
+using Xunit;
+
+namespace OpenTelemetry.AutoInstrumentation.BuildTasks.Tests;
+
+public class TargetsPackageVersionTests
+{
+    [Fact]
+    public void VerifyInstrumentationNuGetPackageVersions()
+    {
+        var solutionDirectory = EnvironmentTools.GetSolutionDirectory();
+        var targetsFile = Path.Combine(solutionDirectory, "src", "OpenTelemetry.AutoInstrumentation.BuildTasks", "OpenTelemetry.AutoInstrumentation.BuildTasks.targets");
+
+        var targetsDocument = XDocument.Load(targetsFile);
+        var targetPackages = targetsDocument.Descendants("InstrumentationTarget")
+            .Select(x => (Name: x.Attribute("InstrumentationNuGetPackageId")?.Value, Version: x.Attribute("InstrumentationNuGetPackageVersion")?.Value)).ToList();
+        Assert.NotEmpty(targetPackages);
+
+        var propsFile = Path.Combine(solutionDirectory, "src", "Directory.Packages.props");
+        var propsDocument = XDocument.Load(propsFile);
+        var propsDependencies = propsDocument.Descendants("PackageVersion")
+            .Select(x => (Name: x.Attribute("Include")?.Value, Version: x.Attribute("Version")?.Value)).ToList();
+
+        foreach (var targetPackage in targetPackages)
+        {
+            var propsDependency = Assert.Single(propsDependencies, d => d.Name == targetPackage.Name);
+            Assert.Equal(propsDependency.Version, targetPackage.Version);
+        }
+    }
+}


### PR DESCRIPTION
## Why

Our global defined dependency versions is not synced with targets file.
It happened couple of time (fortunately, nobody was complaining).

## What

Fix BuildTasks StackExchangeRedis package version + sanity test

## Tests

Added new sanity test + CI.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests
