### PR TITLE
fix: Refactor AssemblyResolve callbacks to avoid potential deadlock

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.NetFramework.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.NetFramework.cs
@@ -10,16 +10,16 @@ namespace OpenTelemetry.AutoInstrumentation.Loader;
 /// <summary>
 /// A class that attempts to load the OpenTelemetry.AutoInstrumentation .NET assembly.
 /// </summary>
-internal partial class Loader
+internal partial class AssemblyResolver
 {
-    private static string ResolveManagedProfilerDirectory()
+    public static string ResolveManagedProfilerDirectory()
     {
         var tracerHomeDirectory = ReadEnvironmentVariable("OTEL_DOTNET_AUTO_HOME") ?? string.Empty;
         var tracerFrameworkDirectory = "netfx";
         return Path.Combine(tracerHomeDirectory, tracerFrameworkDirectory);
     }
 
-    private static Assembly? AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
+    public static Assembly? AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
     {
         var assemblyName = new AssemblyName(args.Name).Name;
 

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.cs
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+using OpenTelemetry.AutoInstrumentation.Logging;
+
+namespace OpenTelemetry.AutoInstrumentation.Loader;
+
+/// <summary>
+/// A class that attempts to load the OpenTelemetry.AutoInstrumentation .NET assembly.
+/// </summary>
+internal static partial class AssemblyResolver
+{
+    private const string AssemblyResolverLoggerSuffix = "AssemblyResolver";
+    private static readonly string ManagedProfilerDirectory;
+    private static readonly IOtelLogger Logger = OtelLogging.GetLogger(AssemblyResolverLoggerSuffix);
+
+    static AssemblyResolver()
+    {
+        ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
+    }
+
+    private static string? ReadEnvironmentVariable(string key)
+    {
+        try
+        {
+            return Environment.GetEnvironmentVariable(key);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Error while loading environment variable {0}", key);
+        }
+
+        return null;
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/Loader.cs
@@ -12,7 +12,6 @@ namespace OpenTelemetry.AutoInstrumentation.Loader;
 internal partial class Loader
 {
     private const string LoaderLoggerSuffix = "Loader";
-    private static readonly string ManagedProfilerDirectory;
     private static readonly IOtelLogger Logger = OtelLogging.GetLogger(LoaderLoggerSuffix);
 
     private static int _isExiting;
@@ -23,11 +22,9 @@ internal partial class Loader
     /// </summary>
     static Loader()
     {
-        ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
-
         try
         {
-            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve_ManagedProfilerDependencies;
+            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolver.AssemblyResolve_ManagedProfilerDependencies;
         }
         catch (Exception ex)
         {
@@ -91,19 +88,5 @@ internal partial class Loader
             Logger.Error(ex, "Error when loading managed assemblies. {0}", ex.Message);
             throw;
         }
-    }
-
-    private static string? ReadEnvironmentVariable(string key)
-    {
-        try
-        {
-            return Environment.GetEnvironmentVariable(key);
-        }
-        catch (Exception ex)
-        {
-            Logger.Error(ex, "Error while loading environment variable {0}", key);
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
## Why

Fixes #4269

## What

This moves the AssemblyResolve callbacks from being stored in the `OpenTelemetry.AutoInstrumentation.Loader.Loader` class and places them in the `OpenTelemetry.AutoInstrumentation.Loader.AssemblyResolver` class.

Currently, the static constructor of the `OpenTelemetry.AutoInstrumentation.Loader.Loader` type is responsible for both registering the AssemblyResolve callbacks AND executing all of the SDK initialization code, before returning. In the referenced issue, the SDK initialization initiates an HTTP call which then triggers instrumentation and, ultimately, an assembly resolve event. This requires a secondary thread to execute the callback methods stored in the `OpenTelemetry.AutoInstrumentation.Loader.Loader` type, but this creates a deadlock because the first thread still hasn't finished the SDK initialization. This solves the problem by avoiding all reentrancy into the Loader type.

An alternative approach, should this approach not work, is to move the SDK initialization into a static method of the `Loader` type rather than the static constructor. This would prevent the runtime from holding a lock on the `Loader` type since it will have already been successfully initialized. However, this would require updating the IL instructions that we emit into the process in our native components, so I'd rather test a managed only change first.

## Tests

The existing integration tests serve as a regression test that the existing functionality is not affected. This will be tested manually, and if we can find a deterministic way to test this in a test application we can add that to our integration tests as well.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
