### PR TITLE
Enable NugetAudit

### DIFF
--- a/Common.props
+++ b/Common.props
@@ -3,6 +3,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
   <!-- StyleCop -->

--- a/test/test-applications/nuget-packages/TestApplication.NugetSample/TestApplication.NugetSample.csproj
+++ b/test/test-applications/nuget-packages/TestApplication.NugetSample/TestApplication.NugetSample.csproj
@@ -5,13 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Tag v1.11.0 is not available on the main branch. It leads to create CI/local builds with 1.10.0-aplha.something version
-    These versions are wronlgy detected as vulnerable by NuGet Audit. It can be removed when we release next version from main. -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-vc29-vg52-6643" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="$(NuGetPackageVersion)" Condition=" '$(NuGetPackageVersion)' != '' " />
-    <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.11.0" Condition=" '$(NuGetPackageVersion)' == '' " />
+    <PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.12.0" Condition=" '$(NuGetPackageVersion)' == '' " />
   </ItemGroup>
 </Project>

--- a/tools/DependencyListGenerator/DependencyListGenerator.csproj
+++ b/tools/DependencyListGenerator/DependencyListGenerator.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="NuGet.ProjectModel" />
+    <!-- System.Security.Cryptography.Pkcs is an indirect reference from NuGet.ProjectModel. Fixes https://github.com/advisories/GHSA-447r-wph3-92pm -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 

--- a/tools/Directory.Packages.props
+++ b/tools/Directory.Packages.props
@@ -4,6 +4,8 @@
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Microsoft.Build" Version="17.14.8" />
     <PackageVersion Include="NuGet.ProjectModel" Version="6.14.0" />
+    <!-- System.Security.Cryptography.Pkcs is an indirect reference from NuGet.ProjectModel. Fixes https://github.com/advisories/GHSA-447r-wph3-92pm -->
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="6.0.5"/>
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.14" />
     <PackageVersion Include="Valleysoft.DockerfileModel" Version="1.2.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />


### PR DESCRIPTION
## Why

Preparation for .NET10.
Historically, we have did this exercise for .NET9. Later, this feature was disabled in one of .NET SDK versions.

## What

Enable NugetAudit and avoid any further changes in .NET SDK.

Release request to remove exceptions from NuGet.Packaging tracked under https://github.com/NuGet/Home/issues/14452

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
