### PR TITLE
[Out-of-process-collection] Fix NuGet package validation by enabling deterministic builds in CI

### DIFF
--- a/.github/workflows/release-nextgen-forwarder-packages.yml
+++ b/.github/workflows/release-nextgen-forwarder-packages.yml
@@ -45,7 +45,7 @@ jobs:
         run: dotnet restore
 
       - name: Build projects
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build --no-restore --configuration Release /p:ContinuousIntegrationBuild=true
 
       - name: Run tests
         run: dotnet test --no-build --configuration Release --verbosity normal
@@ -63,7 +63,8 @@ jobs:
             /p:PackageVersion=${{ inputs.version }} `
             /p:AssemblyVersion=${{ inputs.version }} `
             /p:FileVersion=${{ inputs.version }} `
-            /p:Version=${{ inputs.version }}
+            /p:Version=${{ inputs.version }} `
+            /p:ContinuousIntegrationBuild=true
 
       - name: Pack OpenTelemetry.OutOfProcess.Forwarder.Configuration
         run: |
@@ -74,7 +75,8 @@ jobs:
             /p:PackageVersion=${{ inputs.version }} `
             /p:AssemblyVersion=${{ inputs.version }} `
             /p:FileVersion=${{ inputs.version }} `
-            /p:Version=${{ inputs.version }}
+            /p:Version=${{ inputs.version }} `
+            /p:ContinuousIntegrationBuild=true
 
       - name: Install dotnet-validate
         run: dotnet tool install --global dotnet-validate --version 0.0.1-preview.304


### PR DESCRIPTION
## Why

<!-- Explain why the changes are needed.  -->

The `release-nextgen-forwarder-packages` workflow was failing during NuGet package validation with the following error:

• Deterministic (dll/exe): ❌ Non deterministic Ensure that the following property is enabled for CI builds and you're using at least the 2.1.300 SDK: <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

## What

<!-- Describe changes proposed in this pull request. -->

- Modified `.github/workflows/release-nextgen-forwarder-packages.yml`:
  - Updated `dotnet build` and pack command to include `/p:ContinuousIntegrationBuild=true`

## Verification
✅ Tested locally and confirmed that:
- Both `OpenTelemetry.OutOfProcess.Forwarder` and `OpenTelemetry.OutOfProcess.Forwarder.Configuration` packages now pass all validation checks
- Source Link validation: ✅ Valid
- Deterministic compilation: ✅ Valid (was failing before)
- Compiler flags: ✅ Valid

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
