### PR TITLE
[Out-of-process-collection] Fix path issue in upload artifact

### DIFF
--- a/.github/workflows/release-nextgen-forwarder-packages.yml
+++ b/.github/workflows/release-nextgen-forwarder-packages.yml
@@ -104,7 +104,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4.6.2
         with:
           name: opentelemetry-nextgen-forwarder-packages
-          path: bin/nextgen-nuget-artifacts/
+          path: |
+            next-gen/bin/nextgen-nuget-artifacts/*.nupkg
+            next-gen/bin/nextgen-nuget-artifacts/*.snupkg
           retention-days: 30
 
       - name: Create GitHub Release Summary


### PR DESCRIPTION
* Fixed a path issue in the upload artifact step of `.github/workflows/release-nextgen-forwarder-packages.yml`.
* Tested the fix on a different branch and confirmed that artifacts are generated with valid source link, complier and deterministic flag: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/16822584597
