### PR TITLE
Add missing upload test logs step to test-build-container job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,13 @@ jobs:
         docker run -e OS_TYPE=${{ matrix.os-type }} --rm --mount type=bind,source="${GITHUB_WORKSPACE}",target=/project mybuildimage \
           /bin/sh -c 'git config --global --add safe.directory /project && ./build.sh TestWorkflow --containers none'
 
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4.6.2
+      with:
+        name: test-logs-container-${{ matrix.machine }}-${{ matrix.base-image }}
+        path: test-artifacts/
+
   test-nuget-packages:
     needs: build-nuget-packages
     strategy:

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9@sha256:11e44d30c45661567009402629a7eeb3579739957fe3827d469a353d0fe1801f
+FROM quay.io/centos/centos:stream9@sha256:2e45f6e402a9370603b2cb5514eb0080784b4cddbfbdb34831dbb55d20cf3ae3
 
 # Install dotnet sdk
 RUN dnf install -y \


### PR DESCRIPTION
## Why

The `test-build-container` job in the CI workflow was missing the "Upload test logs" step that other test jobs have. This means test logs from container-based tests weren't being preserved as artifacts. This change would help in making debugging easier through the means of logs.

Fixes #4415

## What

Added the missing "Upload test logs" step to the test-build-container job in .github/workflows/ci.yml following the existing format in other jobs. Here the new step:
- Runs even if tests fail (if: always())
- Follows existing naming convention
- Points to the test-artifacts/ path

## Tests

This change affects CI workflow configuration only

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

These are not applicable as his is an internal CI workflow change
- [ X] `CHANGELOG.md` is updated.
- [ X] Documentation is updated.
- [ X] New features are covered by tests.
