### PR TITLE
Bump Testcontainers to 4.7.0

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -59,7 +59,7 @@
     <PackageVersion Include="System.ServiceModel.NetTcp" Version="8.1.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
-    <PackageVersion Include="Testcontainers" Version="4.6.0" />
+    <PackageVersion Include="Testcontainers" Version="4.7.0" />
     <PackageVersion Include="Verify.Xunit" Version="20.8.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/test/IntegrationTests/AzureCollection.cs
+++ b/test/IntegrationTests/AzureCollection.cs
@@ -47,7 +47,7 @@ public class AzureFixture : IAsyncLifetime
             .WithImage(AzureStorageImage)
             .WithName($"azure-storage-{port}")
             .WithPortBinding(port, BlobServicePort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(BlobServicePort));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(BlobServicePort));
 
         var container = containersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/MongoDBCollection.cs
+++ b/test/IntegrationTests/MongoDBCollection.cs
@@ -49,7 +49,7 @@ public class MongoDBFixture : IAsyncLifetime
             .WithImage(MongoDBImage)
             .WithName($"mongo-db-{port}")
             .WithPortBinding(port, MongoDBPort)
-            .WithWaitStrategy(waitForOs.UntilPortIsAvailable(MongoDBPort));
+            .WithWaitStrategy(waitForOs.UntilInternalTcpPortIsAvailable(MongoDBPort));
 
         var container = mongoContainersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/MySqlCollection.cs
+++ b/test/IntegrationTests/MySqlCollection.cs
@@ -48,7 +48,7 @@ public class MySqlFixture : IAsyncLifetime
             .WithName($"mysql-{port}")
             .WithPortBinding(port, MySqlPort)
             .WithEnvironment("MYSQL_ALLOW_EMPTY_PASSWORD", "true")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MySqlPort));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(MySqlPort));
 
         var container = containersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/OracleCollection.cs
+++ b/test/IntegrationTests/OracleCollection.cs
@@ -70,7 +70,7 @@ public class OracleFixture : IAsyncLifetime
             .WithEnvironment("APP_USER_PASSWORD", Password)
             .WithName($"oracle-{port}")
             .WithPortBinding(port, OraclePort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(OraclePort))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(OraclePort))
             .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("./healthcheck.sh"));
 
         var container = containersBuilder.Build();

--- a/test/IntegrationTests/PostgresCollection.cs
+++ b/test/IntegrationTests/PostgresCollection.cs
@@ -48,7 +48,7 @@ public class PostgresFixture : IAsyncLifetime
             .WithName($"postgres-{port}")
             .WithPortBinding(port, PostgresPort)
             .WithEnvironment("POSTGRES_HOST_AUTH_METHOD", "trust")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(PostgresPort));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(PostgresPort));
 
         var container = containersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/RabbitMqCollection.cs
+++ b/test/IntegrationTests/RabbitMqCollection.cs
@@ -65,7 +65,7 @@ public class RabbitMqFixture : IAsyncLifetime
             .WithImage(RabbitMqImage)
             .WithName($"rabbitmq-{port}")
             .WithPortBinding(port, RabbitMqPort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(RabbitMqPort));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(RabbitMqPort));
 
         var container = containersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/RedisCollection.cs
+++ b/test/IntegrationTests/RedisCollection.cs
@@ -49,7 +49,7 @@ public class RedisFixture : IAsyncLifetime
             .WithImage(RedisImage)
             .WithName($"redis-{port}")
             .WithPortBinding(port, RedisPort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(RedisPort));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(RedisPort));
 
         var container = containersBuilder.Build();
         await container.StartAsync();

--- a/test/IntegrationTests/SqlServerCollection.cs
+++ b/test/IntegrationTests/SqlServerCollection.cs
@@ -76,7 +76,7 @@ public class SqlServerFixture : IAsyncLifetime
             .WithPortBinding(Port, DatabasePort)
             .WithEnvironment("SA_PASSWORD", Password)
             .WithEnvironment("ACCEPT_EULA", "Y")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(DatabasePort))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(DatabasePort))
             .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new UntilAsyncOperationIsSucceeded(DatabaseLoginOperation, 15)));
 
         var container = databaseContainersBuilder.Build();


### PR DESCRIPTION
## Why

Fixes: #4427
handles obsolete method from https://github.com/testcontainers/testcontainers-dotnet/pull/1495/files

## What

Bump Testcontainers to 4.7.0

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
