### PR TITLE
Release v1.13.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,23 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 
+### Changed
+
+#### Dependency updates
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [1.13.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.13.0-beta.1)
+
+### Added
+
 - Extend support for [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client/)
   traces instrumentation for versions `5.*`.
+- Experimental support for [span-based sampling](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/4227).
 
 ### Changed
 
@@ -36,12 +51,6 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `System.IO.Pipelines` from `9.0.6` to `9.0.8`,
   - `System.Text.Encodings.Web` update from `9.0.2` to `9.0.8`.
   - `System.Text.Json` update from `9.0.2` to `9.0.8`.
-
-### Deprecated
-
-### Removed
-
-### Fixed
 
 ## [1.12.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.12.0)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ to .NET applications without having to modify their source code.
 > [!WARNING]
 > The following documentation refers to the in-development version
 of OpenTelemetry .NET Automatic Instrumentation. Docs for the latest version
-([1.12.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
+([1.13.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
 can be found in [opentelemetry.io](https://opentelemetry.io/docs/zero-code/net/)
-or [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.12.0/docs/README.md).
+or [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.13.0-beta.1/docs/README.md).
 
 ---
 
@@ -185,7 +185,7 @@ Example usage:
 
 ```sh
 # Download the bash script
-curl -sSfL https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.12.0/otel-dotnet-auto-install.sh -O
+curl -sSfL https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.13.0-beta.1/otel-dotnet-auto-install.sh -O
 
 # Install core files
 sh ./otel-dotnet-auto-install.sh
@@ -225,7 +225,7 @@ uses environment variables as parameters:
 | `TMPDIR`                | (deprecated) prefer `DOWNLOAD_DIR`                                              | No       | `$(mktemp -d)`              |
 | `DOWNLOAD_DIR`          | Folder to download the archive to. Will use local archive if it already exists  | No       | `$TMPDIR` or `$(mktemp -d)` |
 | `LOCAL_PATH`            | Full path the archive to use for installation. (ideal for air-gapped scenarios) | No       | *Calculated*                |
-| `VERSION`               | Version to download                                                             | No       | `1.12.0`                    |
+| `VERSION`               | Version to download                                                             | No       | `1.13.0-beta.1`             |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -253,7 +253,7 @@ Example usage (run as administrator):
 #Requires -PSEdition Desktop
 
 # Download the module
-$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.12.0/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.13.0-beta.1/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
 


### PR DESCRIPTION
### Added

- Extend support for [RabbitMQ.Client](https://www.nuget.org/packages/RabbitMQ.Client/)
  traces instrumentation for versions `5.*`.
- Experimental support for [span-based sampling](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/4227).

### Changed

#### Dependency updates

- .NET only, following packages updated
  - `OpenTelemetry.Instrumentation.StackExchangeRedis` from `1.12.0-beta.1` to `1.12.0-beta.2`.
- .NET Framework only, following packages updated
  - `Microsoft.Bcl.AsyncInterfaces` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Configuration` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Configuration.Abstractions` `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Configuration.Binder` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.DependencyInjection` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.DependencyInjection.Abstractions` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Diagnostics.Abstractions` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Logging` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Logging.Abstractions` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Logging.Configuration` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Options` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Options.ConfigurationExtensions` from `9.0.6` to `9.0.8`,
  - `Microsoft.Extensions.Primitives` from `9.0.6` to `9.0.8`,
  - `System.Diagnostics.DiagnosticSource` from `9.0.6` to `9.0.8`,
  - `System.IO.Pipelines` from `9.0.6` to `9.0.8`,
  - `System.Text.Encodings.Web` update from `9.0.2` to `9.0.8`.
  - `System.Text.Json` update from `9.0.2` to `9.0.8`.
  
 ## Tests

- [ ] CI
- [x] MacOS with Linux Containers
- [x] Windows with Linux Containers