### PR TITLE
fix: Remove StyleCop suppression SA1306: Field names should begin with a lower-case letter

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.Net.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.Net.cs
@@ -59,7 +59,7 @@ internal partial class AssemblyResolver
     internal static Assembly? AssemblyResolve_ManagedProfilerDependencies(object? sender, ResolveEventArgs args)
     {
         var assemblyName = new AssemblyName(args.Name);
-        Logger.Debug($"Check assembly {assemblyName}");
+        logger.Debug($"Check assembly {assemblyName}");
 
         // On .NET Framework, having a non-US locale can cause mscorlib
         // to enter the AssemblyResolve event when searching for resources
@@ -84,12 +84,12 @@ internal partial class AssemblyResolver
         //    load the originally referenced version
         if (assemblyName.Name != null && assemblyName.Name.StartsWith("OpenTelemetry.AutoInstrumentation", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
         {
-            Logger.Debug("Loading {0} with Assembly.LoadFrom", path);
+            logger.Debug("Loading {0} with Assembly.LoadFrom", path);
             return Assembly.LoadFrom(path);
         }
         else if (File.Exists(path))
         {
-            Logger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
+            logger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
             return DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
         }
         else

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.NetFramework.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.NetFramework.cs
@@ -25,7 +25,7 @@ internal partial class AssemblyResolver
     internal static Assembly? AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
     {
         var assemblyName = new AssemblyName(args.Name).Name;
-        Logger.Debug($"Check assembly {assemblyName}");
+        logger.Debug($"Check assembly {assemblyName}");
 
         // On .NET Framework, having a non-US locale can cause mscorlib
         // to enter the AssemblyResolve event when searching for resources
@@ -37,7 +37,7 @@ internal partial class AssemblyResolver
             return null;
         }
 
-        Logger.Debug("Requester [{0}] requested [{1}]", args.RequestingAssembly?.FullName ?? "<null>", args.Name ?? "<null>");
+        logger.Debug("Requester [{0}] requested [{1}]", args.RequestingAssembly?.FullName ?? "<null>", args.Name ?? "<null>");
 
         // All MongoDB* are signed and does not follow https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/versioning#assembly-version
         // There is no possibility to automatically redirect from 2.28.0 to 2.29.0.
@@ -50,12 +50,12 @@ internal partial class AssemblyResolver
             try
             {
                 var mongoAssembly = Assembly.Load(assemblyName);
-                Logger.Debug<string, bool>("Assembly.Load(\"{0}\") succeeded={1}", assemblyName, mongoAssembly != null);
+                logger.Debug<string, bool>("Assembly.Load(\"{0}\") succeeded={1}", assemblyName, mongoAssembly != null);
                 return mongoAssembly;
             }
             catch (Exception ex)
             {
-                Logger.Debug(ex, "Assembly.Load(\"{0}\") Exception: {1}", assemblyName, ex.Message);
+                logger.Debug(ex, "Assembly.Load(\"{0}\") Exception: {1}", assemblyName, ex.Message);
             }
 
             return null;
@@ -67,12 +67,12 @@ internal partial class AssemblyResolver
             try
             {
                 var loadedAssembly = Assembly.LoadFrom(path);
-                Logger.Debug<string, bool>("Assembly.LoadFrom(\"{0}\") succeeded={1}", path, loadedAssembly != null);
+                logger.Debug<string, bool>("Assembly.LoadFrom(\"{0}\") succeeded={1}", path, loadedAssembly != null);
                 return loadedAssembly;
             }
             catch (Exception ex)
             {
-                Logger.Debug(ex, "Assembly.LoadFrom(\"{0}\") Exception: {1}", path, ex.Message);
+                logger.Debug(ex, "Assembly.LoadFrom(\"{0}\") Exception: {1}", path, ex.Message);
             }
         }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.Loader/AssemblyResolver.cs
@@ -13,8 +13,7 @@ internal partial class AssemblyResolver
 {
     private static readonly string ManagedProfilerDirectory;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1306:Field names should begin with lower-case letter", Justification = "Make code review easy. Will fix in next PR")]
-    private static IOtelLogger Logger = NoopLogger.Instance;
+    private static IOtelLogger logger = NoopLogger.Instance;
 
     /// <summary>
     /// Initializes static members of the <see cref="AssemblyResolver"/> class.
@@ -28,7 +27,7 @@ internal partial class AssemblyResolver
     // called in the static constructor of Loader.
     internal static void SetLoggerNoLock(IOtelLogger otelLogger)
     {
-        Logger = otelLogger;
+        logger = otelLogger;
     }
 
     private static string? ReadEnvironmentVariable(string key)
@@ -39,7 +38,7 @@ internal partial class AssemblyResolver
         }
         catch (Exception ex)
         {
-            Logger.Error(ex, "Error while loading environment variable {0}", key);
+            logger.Error(ex, "Error while loading environment variable {0}", key);
         }
 
         return null;


### PR DESCRIPTION
This pull request follows up on PR #4431. To keep the previous review focused, that PR did not rename the Logger field to comply with the StyleCop requirement.

The only change in this PR is renaming the field from Logger to logger in the AssemblyResolver class. This is a low-risk change and does not introduce any functional modifications.


