### PR TITLE
Rule engine - .NET 9 EOS - November 10, 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Fixed deadlock occurring in Assembly Resolver.
   See [#4269](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/4269)
   for details.
-  of Loader class.  [#4269](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/4269)
+- Fixed rule engine check for .NET 9 to reflect longer support for [STS channel](https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/).
 
 ## [1.13.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.13.0-beta.1)
 

--- a/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/EndOfSupportRule.cs
+++ b/src/OpenTelemetry.AutoInstrumentation.StartupHook/RulesEngine/EndOfSupportRule.cs
@@ -24,10 +24,8 @@ internal class EndOfSupportRule : Rule
         switch (netVersion)
         {
             case 8:
-                eosDate = new DateTime(2026, 11, 10);
-                break;
             case 9:
-                eosDate = new DateTime(2026, 05, 12);
+                eosDate = new DateTime(2026, 11, 10);
                 break;
             default:
                 return true; // just return, not able to verify anything here


### PR DESCRIPTION
## Why

https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/

## What

Rule engine - .NET 9 EOS - November 10, 2026

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
