### PR TITLE
tweak otel-dotnet-auto-install.sh arch detection

### DIFF
--- a/script-templates/otel-dotnet-auto-install.sh.template
+++ b/script-templates/otel-dotnet-auto-install.sh.template
@@ -34,6 +34,7 @@ if [ -z "$ARCHITECTURE" ]; then
   case $(uname -m) in
     x86_64)  ARCHITECTURE="x64" ;;
     aarch64) ARCHITECTURE="arm64" ;;
+    arm64) ARCHITECTURE="arm64" ;;
   esac
 fi
 


### PR DESCRIPTION
On a mac, `uname -m` returns `arm64`.

## Why

<!-- Explain why the changes are needed.  -->

Fixes #

## What

<!-- Describe changes proposed in this pull request. -->

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
