### PR TITLE
Meaningful  initializer logs

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Loading/GenericInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/GenericInitializer.cs
@@ -7,8 +7,8 @@ internal class GenericInitializer : InstrumentationInitializer
 {
     private readonly Action<ILifespanManager> _initialize;
 
-    public GenericInitializer(string assemblyName, Action<ILifespanManager> initialize)
-        : base(assemblyName)
+    public GenericInitializer(string assemblyName, string initializerName, Action<ILifespanManager> initialize)
+        : base(assemblyName, initializerName)
     {
         _initialize = initialize;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetCoreInitializer.cs
@@ -16,7 +16,7 @@ internal class AspNetCoreInitializer : InstrumentationInitializer
     private readonly TracerSettings _tracerSettings;
 
     public AspNetCoreInitializer(PluginManager pluginManager, TracerSettings tracerSettings)
-        : base("Microsoft.AspNetCore.Http")
+        : base("Microsoft.AspNetCore.Http", nameof(AspNetCoreInitializer))
     {
         _pluginManager = pluginManager;
         _tracerSettings = tracerSettings;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetInitializer.cs
@@ -22,8 +22,8 @@ internal sealed class AspNetInitializer
     {
         _pluginManager = pluginManager;
         _tracerSettings = tracerSettings;
-        lazyInstrumentationLoader.Add(new AspNetMvcInitializer(InitializeOnFirstCall));
-        lazyInstrumentationLoader.Add(new AspNetWebApiInitializer(InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new AspNetMvcInitializer(InitializeOnFirstCall, "AspNetMvcInitializerForTraces"));
+        lazyInstrumentationLoader.Add(new AspNetWebApiInitializer(InitializeOnFirstCall, "AspNetWebApiInitializerForTraces"));
     }
 
     private void InitializeOnFirstCall(ILifespanManager lifespanManager)

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMetricsInitializer.cs
@@ -15,8 +15,8 @@ internal sealed class AspNetMetricsInitializer
     public AspNetMetricsInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, PluginManager pluginManager)
     {
         _pluginManager = pluginManager;
-        lazyInstrumentationLoader.Add(new AspNetMvcInitializer(InitializeOnFirstCall));
-        lazyInstrumentationLoader.Add(new AspNetWebApiInitializer(InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new AspNetMvcInitializer(InitializeOnFirstCall, "AspNetMvcInitializerForMetrics"));
+        lazyInstrumentationLoader.Add(new AspNetWebApiInitializer(InitializeOnFirstCall, "AspNetWebApiInitializerForMetrics"));
     }
 
     private void InitializeOnFirstCall(ILifespanManager lifespanManager)

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMvcInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetMvcInitializer.cs
@@ -9,8 +9,8 @@ internal class AspNetMvcInitializer : InstrumentationInitializer
 {
     private readonly Action<ILifespanManager> _initialize;
 
-    public AspNetMvcInitializer(Action<ILifespanManager> initialize)
-        : base("System.Web.Mvc")
+    public AspNetMvcInitializer(Action<ILifespanManager> initialize, string initializerName)
+        : base("System.Web.Mvc", initializerName)
     {
         _initialize = initialize;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetWebApiInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/AspNetWebApiInitializer.cs
@@ -9,8 +9,8 @@ internal class AspNetWebApiInitializer : InstrumentationInitializer
 {
     private readonly Action<ILifespanManager> _initialize;
 
-    public AspNetWebApiInitializer(Action<ILifespanManager> initialize)
-        : base("System.Web.Http")
+    public AspNetWebApiInitializer(Action<ILifespanManager> initialize, string initializerName)
+        : base("System.Web.Http", initializerName)
     {
         _initialize = initialize;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/EntityFrameworkCoreInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/EntityFrameworkCoreInitializer.cs
@@ -13,7 +13,7 @@ internal class EntityFrameworkCoreInitializer : InstrumentationInitializer
     private readonly TracerSettings _tracerSettings;
 
     public EntityFrameworkCoreInitializer(PluginManager pluginManager, TracerSettings tracerSettings)
-        : base("Microsoft.EntityFrameworkCore")
+        : base("Microsoft.EntityFrameworkCore", nameof(EntityFrameworkCoreInitializer))
     {
         _pluginManager = pluginManager;
         _tracerSettings = tracerSettings;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/GraphQLInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/GraphQLInitializer.cs
@@ -15,7 +15,7 @@ internal class GraphQLInitializer : InstrumentationInitializer
     private readonly TracerSettings _tracerSettings;
 
     public GraphQLInitializer(PluginManager pluginManager, TracerSettings tracerSettings)
-    : base("GraphQL")
+    : base("GraphQL", nameof(GraphQLInitializer))
     {
         _pluginManager = pluginManager;
         _tracerSettings = tracerSettings;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/GrpcClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/GrpcClientInitializer.cs
@@ -15,7 +15,7 @@ internal class GrpcClientInitializer : InstrumentationInitializer
     private readonly TracerSettings _tracerSettings;
 
     public GrpcClientInitializer(PluginManager pluginManager, TracerSettings tracerSettings)
-        : base("Grpc.Net.Client")
+        : base("Grpc.Net.Client", nameof(GrpcClientInitializer))
     {
         _pluginManager = pluginManager;
         _tracerSettings = tracerSettings;

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientInitializer.cs
@@ -25,10 +25,10 @@ internal class HttpClientInitializer
         _pluginManager = pluginManager;
         _tracerSettings = tracerSettings;
 
-        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net.Http", InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net.Http", "HttpClientInitializerForSystemNetHttp", InitializeOnFirstCall));
 
 #if NETFRAMEWORK
-        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net", InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net", "HttpClientInitializerForSystemNet", InitializeOnFirstCall));
 #endif
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/HttpClientMetricsInitializer.cs
@@ -9,10 +9,10 @@ internal class HttpClientMetricsInitializer
 
     public HttpClientMetricsInitializer(LazyInstrumentationLoader lazyInstrumentationLoader)
     {
-        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net.Http", InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net.Http", "HttpClientMetricsInitializer", InitializeOnFirstCall));
 
 #if NETFRAMEWORK
-        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net", InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Net", "HttpClientMetricsInitializerForSystemNet", InitializeOnFirstCall));
 #endif
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/OracleMdaInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/OracleMdaInitializer.cs
@@ -11,7 +11,7 @@ internal class OracleMdaInitializer : InstrumentationInitializer
     private readonly TracerSettings _tracerSettings;
 
     public OracleMdaInitializer(TracerSettings tracerSettings)
-        : base("Oracle.ManagedDataAccess")
+        : base("Oracle.ManagedDataAccess", nameof(OracleMdaInitializer))
     {
         _tracerSettings = tracerSettings;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/QuartzInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/QuartzInitializer.cs
@@ -10,7 +10,7 @@ internal class QuartzInitializer : InstrumentationInitializer
     private readonly PluginManager _pluginManager;
 
     public QuartzInitializer(PluginManager pluginManager)
-        : base("Quartz")
+        : base("Quartz", nameof(QuartzInitializer))
     {
         _pluginManager = pluginManager;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientInitializer.cs
@@ -5,13 +5,13 @@ namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
 
 internal abstract class SqlClientInitializer
 {
-    protected SqlClientInitializer(LazyInstrumentationLoader lazyInstrumentationLoader)
+    protected SqlClientInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, string initializerNamePrefix)
     {
-        lazyInstrumentationLoader.Add(new GenericInitializer("System.Data.SqlClient", InitializeOnFirstCall));
-        lazyInstrumentationLoader.Add(new GenericInitializer("Microsoft.Data.SqlClient", InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Data.SqlClient", $"{initializerNamePrefix}ForSystemDataSqlClient", InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new GenericInitializer("Microsoft.Data.SqlClient", $"{initializerNamePrefix}ForMicrosoftDataSqlClient", InitializeOnFirstCall));
 
 #if NETFRAMEWORK
-        lazyInstrumentationLoader.Add(new GenericInitializer("System.Data", InitializeOnFirstCall));
+        lazyInstrumentationLoader.Add(new GenericInitializer("System.Data", $"{initializerNamePrefix}ForSystemData", InitializeOnFirstCall));
 #endif
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientMetricsInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientMetricsInitializer.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Reflection;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 
 namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
@@ -13,7 +12,7 @@ internal sealed class SqlClientMetricsInitializer : SqlClientInitializer
     private int _initialized;
 
     public SqlClientMetricsInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, PluginManager pluginManager)
-        : base(lazyInstrumentationLoader)
+        : base(lazyInstrumentationLoader, nameof(SqlClientMetricsInitializer))
     {
         _pluginManager = pluginManager;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientTracerInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientTracerInitializer.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Reflection;
-using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 
 namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;
@@ -14,7 +12,7 @@ internal sealed class SqlClientTracerInitializer : SqlClientInitializer
     private int _initialized;
 
     public SqlClientTracerInitializer(LazyInstrumentationLoader lazyInstrumentationLoader, PluginManager pluginManager)
-        : base(lazyInstrumentationLoader)
+        : base(lazyInstrumentationLoader, nameof(SqlClientTracerInitializer))
     {
         _pluginManager = pluginManager;
     }

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/InstrumentationInitializer.cs
@@ -9,12 +9,15 @@ namespace OpenTelemetry.AutoInstrumentation.Loading;
 /// </summary>
 internal abstract class InstrumentationInitializer
 {
-    protected InstrumentationInitializer(string requiredAssemblyName)
+    protected InstrumentationInitializer(string requiredAssemblyName, string initializerName)
     {
         RequiredAssemblyName = requiredAssemblyName;
+        InitializerName = initializerName;
     }
 
     public string RequiredAssemblyName { get; }
+
+    public string InitializerName { get; }
 
     public abstract void Initialize(ILifespanManager lifespanManager);
 }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
@@ -43,7 +43,7 @@ public class LazyInstrumentationLoaderTests
         public const string DummyAssemblyName = "Dummy.Assembly";
 
         public DummyInitializer()
-            : base(DummyAssemblyName)
+            : base(DummyAssemblyName, nameof(DummyInitializer))
         {
         }
 


### PR DESCRIPTION
## Why

Hard to understand what happened during initialization phase.
There were a lot of repeating logs, such as (I removed all not related to the initialization process).

```log
[2025-10-16T06:26:36.0870762Z] [Debug] 'GenericInitializer' started 
[2025-10-16T06:26:36.2175307Z] [Debug] 'GenericInitializer' started 
[2025-10-16T06:26:36.3895079Z] [Debug] 'GenericInitializer' started 
[2025-10-16T06:26:36.4051366Z] [Debug] 'GenericInitializer' started 
```

## What

No more 'GenericInitializer' started. Each initializer have own, dedicated name.
The only downside is that we need to create it manually instead of taking type name.

## Tests

CI + local execution

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
