### PR TITLE
Add -NoReset option to service registration functions (#4641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 
+- Add `-NoReset` switch parameter to skip service restart in PowerShell registration functions.
+
 ### Changed
+
+- `-NoReset` parameter in `Unregister-OpenTelemetryForIIS` changed from
+  `[bool]` to `[switch]`. Use `-NoReset` instead of `-NoReset $true`.
+  Note: `-NoReset $true` still works, but `-NoReset $false` will not do what you expect.
+  You should omit the parameter for the expected behavior.
 
 #### Dependency updates
 

--- a/docs/iis-instrumentation.md
+++ b/docs/iis-instrumentation.md
@@ -24,7 +24,8 @@ occurred. See this [issue](https://github.com/open-telemetry/opentelemetry-dotne
 for further details.
 
 > [!WARNING]
-> `Register-OpenTelemetryForIIS` performs IIS restart.
+> `Register-OpenTelemetryForIIS` performs IIS restart by default.
+> Use `-NoReset` to skip the restart.
 
 ## Configuration
 

--- a/docs/windows-service-instrumentation.md
+++ b/docs/windows-service-instrumentation.md
@@ -17,7 +17,8 @@ Register-OpenTelemetryForWindowsService -WindowsServiceName "WindowsServiceName"
 ```
 
 > [!WARNING]
-> `Register-OpenTelemetryForWindowsService` performs a service restart.
+> `Register-OpenTelemetryForWindowsService` performs a service restart by default.
+> Use `-NoReset` to skip the restart.
 
 ## Configuration
 

--- a/script-templates/OpenTelemetry.DotNet.Auto.psm1.template
+++ b/script-templates/OpenTelemetry.DotNet.Auto.psm1.template
@@ -473,7 +473,7 @@ function Update-OpenTelemetryCore() {
 
     Uninstall-OpenTelemetryCore
     if ($RegisterIIS) {
-        Unregister-OpenTelemetryForIIS -NoReset $true
+        Unregister-OpenTelemetryForIIS -NoReset
     }
 
     $tempDir = Get-Temp-Directory
@@ -522,9 +522,15 @@ function Register-OpenTelemetryForCurrentSession() {
 <#
     .SYNOPSIS
     Setups IIS environment variables to enable automatic instrumentation.
-    Performs IIS reset after registration.
+    Performs IIS reset after registration by default.
+    .PARAMETER NoReset
+    Does not perform IIS reset.
 #>
 function Register-OpenTelemetryForIIS() {
+    param(
+        [switch]$NoReset
+    )
+
     $installDir = Get-Current-InstallDir
 
     if (-not $installDir) {
@@ -538,7 +544,9 @@ function Register-OpenTelemetryForIIS() {
     Setup-Windows-Service -InstallDir $installDir -WindowsServiceName "W3SVC"
     Setup-Windows-Service -InstallDir $installDir -WindowsServiceName "WAS"
 
-    Reset-IIS
+    if (-not $NoReset) {
+        Reset-IIS
+    }
 }
 
 <#
@@ -549,13 +557,16 @@ function Register-OpenTelemetryForIIS() {
     Actual Windows service name in registry.
     .PARAMETER OTelServiceName
     Specifies OpenTelemetry service name to identify your service.
+    .PARAMETER NoReset
+    Does not perform service restart.
 #>
 function Register-OpenTelemetryForWindowsService() {
     param(
         [Parameter(Mandatory = $true)]
         [string]$WindowsServiceName,
         [Parameter(Mandatory = $true)]
-        [string]$OTelServiceName
+        [string]$OTelServiceName,
+        [switch]$NoReset
     )
 
     $installDir = Get-Current-InstallDir
@@ -565,7 +576,10 @@ function Register-OpenTelemetryForWindowsService() {
     }
 
     Setup-Windows-Service -InstallDir $installDir -WindowsServiceName $WindowsServiceName -OTelServiceName $OTelServiceName
-    Restart-Service -Name $WindowsServiceName -Force
+    
+    if (-not $NoReset) {
+        Restart-Service -Name $WindowsServiceName -Force
+    }
 }
 
 <#
@@ -606,8 +620,7 @@ function Unregister-OpenTelemetryForCurrentSession() {
 #>
 function Unregister-OpenTelemetryForIIS() {
     param(
-        [Parameter(Mandatory = $false)]
-        [bool]$NoReset = $false
+        [switch]$NoReset
     )
 
     Cleanup-Environment-Variables -WindowsServiceName "W3SVC"
@@ -624,15 +637,21 @@ function Unregister-OpenTelemetryForIIS() {
     Performs service restart after removal.
     .PARAMETER WindowsServiceName
     Actual Windows service Name in registry.
+    .PARAMETER NoReset
+    Does not perform service restart.
 #>
 function Unregister-OpenTelemetryForWindowsService() {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$WindowsServiceName
+        [string]$WindowsServiceName,
+        [switch]$NoReset
     )  
 
     Cleanup-Environment-Variables -WindowsServiceName $WindowsServiceName
-    Restart-Service -Name $WindowsServiceName -Force
+    
+    if (-not $NoReset) {
+        Restart-Service -Name $WindowsServiceName -Force
+    }
 }
 
 <#


### PR DESCRIPTION
Affected functions:

## Why

Users want to perform service restart and iisreset manually, separate from registration

Fixes #4641 

## What

Added -NeReset for:

- Register-OpenTelemetryForIIS
- Register-OpenTelemetryForWindowsService
- Unregister-OpenTelemetryForWindowsService

## Tests

Didn't want to add the test for these in the docker test as they would disrupt the flow. I *could* add a call to registration with -NoReset and perform service restart manually, but this would remove the test for the default flow.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [ ] New features are covered by tests.
