### PR TITLE
Fix C4703

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/method_rewriter.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/method_rewriter.cpp
@@ -174,7 +174,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     mdToken  callTargetStateToken  = mdTokenNil;
     mdToken  exceptionToken        = mdTokenNil;
     mdToken  callTargetReturnToken = mdTokenNil;
-    ILInstr* firstInstruction;
+    ILInstr* firstInstruction      = nullptr;
     tracerTokens->ModifyLocalSigAndInitialize(&reWriterWrapper, caller, &callTargetStateIndex, &exceptionIndex,
                                               &callTargetReturnIndex, &returnValueIndex, &callTargetStateToken,
                                               &exceptionToken, &callTargetReturnToken, &firstInstruction);


### PR DESCRIPTION
## Why

Trying to build locally with MSBuild from VS2026.

## What

Fix C4703
potentially uninitialized local pointer variable 'firstInstruction' used

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
