### PR TITLE
[Infra] Show diff colours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,5 +132,6 @@ jobs:
         shell: bash
         run: |
           git status
-          git diff
+          git config color.diff always
+          git --no-pager diff
           [[ -z "$(git status --porcelain)" ]]


### PR DESCRIPTION
## Why

Show colours for `git diff` in CI to make them easier to read for those who can see red-green colours (e.g. would have been useful [here](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/20952426087/job/60209202808)).

## What

Enable git config setting to always show diff colours, and also explicitly disable the pager if a diff is large.

## Tests

None - copied from a workflow where I already do this ([code](https://github.com/martincostello/github-automation/blob/ca61019dfac819fab08e5f6a8c29c2874e018180/.github/workflows/dotnet-bumper.yml#L197-L198)).

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~
