### PR TITLE
Remove non-ASCII dash

### DIFF
--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserResourceTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserResourceTests.cs
@@ -90,7 +90,7 @@ public class ParserResourceTests
     public void Parse_EnvVarYaml_ShouldPopulateModelCompletely()
     {
         Environment.SetEnvironmentVariable("OTEL_SDK_DISABLED", "true");
-        Environment.SetEnvironmentVariable("OTEL_SERVICE_NAME", "my‑service");
+        Environment.SetEnvironmentVariable("OTEL_SERVICE_NAME", "my-service");
         Environment.SetEnvironmentVariable("OTEL_RESOURCE_ATTRIBUTES", "key=value");
 
         var config = YamlParser.ParseYaml<YamlConfiguration>("Configurations/FileBased/Files/TestResourceFileEnvVars.yaml");
@@ -98,6 +98,6 @@ public class ParserResourceTests
         Assert.Equal("1.0-rc.1", config.FileFormat);
         var serviceAttr = config.Resource?.Attributes?.First(a => a.Name == "service.name");
         Assert.NotNull(serviceAttr);
-        Assert.Equal("my‑service", serviceAttr.Value);
+        Assert.Equal("my-service", serviceAttr.Value);
     }
 }


### PR DESCRIPTION
## Why

Visual Studio Code warns about non-ASCII values potentially creating confusion.

## What

Use an ASCII dash for the test.

Spotted in Visual Studio Code while working on #4756.

## Tests

None.

## Checklist

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~
