### PR TITLE
Fix NU1510 warnings

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.AdditionalDeps/Directory.Build.props
+++ b/src/OpenTelemetry.AutoInstrumentation.AdditionalDeps/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU1510</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" NoWarn="NU1510" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

Fixes #4776.

## What

Ignore NU1510 warnings on reference to System.Diagnostics.DiagnosticSource.

## Tests

None.

## Checklist

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~
