### PR TITLE
[tests] add graceful shutdown to mock collectors listener

### DIFF
--- a/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
+++ b/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
@@ -42,7 +42,8 @@ internal sealed class TestHttpServer : IDisposable
                                 x.Run(pathHandler.Delegate);
                             });
                         }
-                    });
+                    })
+                    .UseShutdownTimeout(TimeSpan.FromSeconds(5));
             })
             .Build();
 
@@ -69,7 +70,8 @@ internal sealed class TestHttpServer : IDisposable
 
     public void Dispose()
     {
-        WriteOutput($"Shutting down");
+        WriteOutput("Shutting down");
+        _listener.StopAsync().GetAwaiter().GetResult();
         _listener.Dispose();
     }
 


### PR DESCRIPTION
## What
- add a graceful shutdown to mock collectors listener 
- ensure number of logs received logged by the mock logs collector is accurate