### PR TITLE
ci: migrate from actions/attest-build-provenance to actions/attest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       attestations: write
       contents: write
       id-token: write
+      artifact-metadata: write
     timeout-minutes: 10
     steps:
 
@@ -107,7 +108,7 @@ jobs:
           sha256sum "./checksums.txt" --check || exit 1
 
       - name: Attest artifacts
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
             ./*.zip


### PR DESCRIPTION
## Why

Fixes #4880

As of v4, `actions/attest-build-provenance` is a thin wrapper around `actions/attest`, and GitHub recommends migrating to `actions/attest` directly.

## What

- Replaced `actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f` with `actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26` (v4.1.0) in `release.yml`
- Added `artifact-metadata: write` permission to the `create-release` job as recommended in the `actions/attest` docs
- The `subject-path` input is unchanged; it is supported identically by `actions/attest.`

## Tests

This change only affects the release workflow, which is triggered on tag pushes. The migration is a like-for-like replacement with no behavioural changes,`actions/attest` accepts the same `subject-path` input and produces the same attestation output.

## Checklist

- [ ] ~~`CHANGELOG.md` is updated.
- [ ] ~~Documentation is updated.
- [ ] ~~New features are covered by tests.
