### PR TITLE
Update Centos9 packages

### DIFF
--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -19,8 +19,8 @@ RUN update-crypto-policies --set LEGACY
 
 # Install dependencies
 RUN dnf install -y \
-    cmake-3.26.5-2.el9 \
-    clang-20.1.3-1.el9 \
-    git-2.43.5-1.el9
+    cmake-3.31.8-3.el9 \
+    clang-21.1.8-2.el9 \
+    git-2.52.0-1.el9
 
 WORKDIR /project


### PR DESCRIPTION
## Why

CI started failing due to centos9 steps.

## What

Update Centos9 packages
old versions are no longer available

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
