### PR TITLE
Replace deprecated `OTEL_EXPERIMENTAL_CONFIG_FILE` with `OTEL_CONFIG_FILE` in tests

### DIFF
--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -110,7 +110,7 @@ public abstract class TestHelper
     internal void EnableFileBasedConfigWithDefaultPath(string packageVersion = "")
     {
         SetEnvironmentVariable("OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED", "true");
-        SetEnvironmentVariable("OTEL_EXPERIMENTAL_CONFIG_FILE", Path.Combine(EnvironmentHelper.GetTestApplicationApplicationOutputDirectory(packageVersion), "config.yaml"));
+        SetEnvironmentVariable("OTEL_CONFIG_FILE", Path.Combine(EnvironmentHelper.GetTestApplicationApplicationOutputDirectory(packageVersion), "config.yaml"));
     }
 
     internal (string StandardOutput, string ErrorOutput, int ProcessId) RunTestApplication(TestSettings? testSettings = null)


### PR DESCRIPTION
## Why & What

Use stable environment variable `OTEL_CONFIG_FILE` instead of deprecated `OTEL_EXPERIMENTAL_CONFIG_FILE` in tests

## Tests

Ci

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] ~`CHANGELOG.md` is updated.~
- [ ] ~Documentation is updated.~
- [ ] ~New features are covered by tests.~
