### PR TITLE
[infra] Update C# LangVersion to 14.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -10,6 +10,10 @@
     <NukeScriptDirectory>..\</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- 
+        LangVersion needs to be 13.0 as it is used to build native code on Ubuntu16.
+        It can be udated when .NET8/.NET9 supportf will be dropped.
+    -->
     <LangVersion>13.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NuGetAudit>true</NuGetAudit>

--- a/test/test-applications/integrations/Integrations.props
+++ b/test/test-applications/integrations/Integrations.props
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
 
     <BaseIntermediateOutputPath Condition="'$(LibraryVersion)'!=''">..\obj\$(MSBuildProjectName)\$(LibraryVersion)\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="'$(LibraryVersion)'==''">..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>

--- a/test/test-applications/integrations/TestApplication.AspNet.NetFramework/TestApplication.AspNet.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.AspNet.NetFramework/TestApplication.AspNet.NetFramework.csproj
@@ -28,6 +28,10 @@
     </NuGetPackageImportStamp>
     <DockerLaunchAction>LaunchBrowser</DockerLaunchAction>
     <DockerLaunchUrl>http://{ServiceIPAddress}</DockerLaunchUrl>
+    <!-- 
+        LangVersion needs to be 13.0 as it is dependency on Windows 2022 without VS2026.
+    -->
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/test-applications/integrations/TestApplication.Owin.IIS.NetFramework/TestApplication.Owin.IIS.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Owin.IIS.NetFramework/TestApplication.Owin.IIS.NetFramework.csproj
@@ -22,6 +22,10 @@
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
     <TargetFrameworkProfile />
+    <!-- 
+        LangVersion needs to be 13.0 as it is dependency on Windows 2022 without VS2026.
+    -->
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/TestApplication.Wcf.Server.IIS.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/TestApplication.Wcf.Server.IIS.NetFramework.csproj
@@ -23,6 +23,10 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
+    <!-- 
+        LangVersion needs to be 13.0 as it is dependency on Windows 2022 without VS2026.
+    -->
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/test/test-applications/nuget-packages/Directory.Build.props
+++ b/test/test-applications/nuget-packages/Directory.Build.props
@@ -13,7 +13,7 @@
 
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- Keep the same base output path to simplify re-use of test helpers -->

--- a/tools/DependencyListGenerator/DependencyListGenerator.csproj
+++ b/tools/DependencyListGenerator/DependencyListGenerator.csproj
@@ -7,6 +7,11 @@
     <Nullable>disable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\test\test-keypair.snk</AssemblyOriginatorKeyFile>
+    <!-- 
+        LangVersion needs to be 13.0 as it is dependency on _builds.csrpoj. 
+        It can be udated when .NET8/.NET9 supportf will be dropped.
+    -->
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why & What

[infra] Update C# LangVersion to 14.0

_build.csproj needs to stay on 13.0, as it is used to build native code on legacy Ubuntu with net9.0. The same is for SourceGenerator.

Also affected are aour applications build for IIS. Under the hood local MSBuild/VS version is used. It means VS2022 on CI, so it cannot be updated.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
