### PR TITLE
Fix test application console buffer deadlocks by ensuring consistent process stream draining

### DIFF
--- a/test/IntegrationTests/CustomSdkTests.cs
+++ b/test/IntegrationTests/CustomSdkTests.cs
@@ -73,7 +73,7 @@ public class CustomSdkTests : TestHelper
         SetEnvironmentVariable("LONG_RUNNING", "true");
         SetEnvironmentVariable("OTEL_METRIC_EXPORT_INTERVAL", "100");
 
-        var process = StartTestApplication(new()
+        using var process = StartTestApplication(new()
         {
             Arguments = $"--redis-port {_redis.Port} --test-server-port {testServer.Port}"
         });

--- a/test/IntegrationTests/Helpers/InstrumentedProcessHelper.cs
+++ b/test/IntegrationTests/Helpers/InstrumentedProcessHelper.cs
@@ -30,6 +30,26 @@ internal static class InstrumentedProcessHelper
         startInfo.RedirectStandardInput = false;
         startInfo.StandardOutputEncoding = Encoding.Default;
 
-        return Process.Start(startInfo);
+        // 1. Create the specialized process object
+        var process = new IntegrationTestProcess
+        {
+            StartInfo = startInfo
+        };
+
+        // 2. Start it
+        process.Start();
+
+        // 3. IMMEDIATELY attach the helper.
+        // This calls BeginOutputReadLine()/BeginErrorReadLine()
+        // and prevents the process hang if it has a lot of output that no one reads
+        process.AttachedHelper = new ProcessHelper(process);
+
+        return process;
+    }
+
+    internal sealed class IntegrationTestProcess : Process
+    {
+        // This holds the helper that is already draining the process
+        public ProcessHelper? AttachedHelper { get; set; }
     }
 }

--- a/test/IntegrationTests/Helpers/ProcessHelper.cs
+++ b/test/IntegrationTests/Helpers/ProcessHelper.cs
@@ -26,6 +26,18 @@ internal sealed class ProcessHelper : IDisposable
             return;
         }
 
+        // If this is our special process type and it already has a helper...
+        if (process is InstrumentedProcessHelper.IntegrationTestProcess { AttachedHelper: not null } it)
+        {
+            // "Adopt" the state of the existing helper instead of starting a new one
+            Process = it.AttachedHelper.Process;
+            _outputBuffer = it.AttachedHelper._outputBuffer;
+            _errorBuffer = it.AttachedHelper._errorBuffer;
+            _outputMutex = it.AttachedHelper._outputMutex;
+            // Note: In this case, don't call BeginOutputReadLine()/BeginErrorReadLine() again!
+            return;
+        }
+
         Process = process;
         Process.OutputDataReceived += (_, e) => DrainOutput(e.Data, _outputBuffer, isErrorStream: false);
         Process.ErrorDataReceived += (_, e) => DrainOutput(e.Data, _errorBuffer, isErrorStream: true);

--- a/test/IntegrationTests/WcfCoreServerTestHelper.cs
+++ b/test/IntegrationTests/WcfCoreServerTestHelper.cs
@@ -36,8 +36,11 @@ internal sealed class WcfCoreServerTestHelper : WcfServerTestHelperBase
         var tcpPort = TcpPortProvider.GetOpenPort();
 
         SetExporter(collector);
+        // TODO suppress just like in WcfServerTestHelperBase.RunWcfServer; refactor to clarify disposal responsibility
+#pragma warning disable CA2000 // Dispose objects before losing scope.
         var process = InstrumentedProcessHelper.Start(testApplicationPath, $"--tcpPort {tcpPort} --httpPort {httpPort}", EnvironmentHelper);
         return (new ProcessHelper(process), tcpPort, httpPort);
+#pragma warning restore CA2000 // Dispose objects before losing scope.
     }
 }
 #endif


### PR DESCRIPTION
## Why

Some tests may suffer a deadlock when their console output increases (just enough to overflow the buffer which by default is not that big, even a line can cause it)

Discovered while working on https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4783 but is not required for this PR

## What

Introduced IntegrationTestProcess to start reading output streams immediately upon launch. Updated ProcessHelper to reuse existing readers where available, preventing console buffer deadlocks across all test patterns.

## Tests

Existing Integration tests will validate it

## Checklist

- ~[ ] `CHANGELOG.md` is updated.~
- ~[ ] Documentation is updated.~
- ~[ ] New features are covered by tests.~
