### PR TITLE
UnsafeAccessorType native redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
+- Redirect outer assembly-qualified type names in `UnsafeAccessorType`
+  attributes when native profiler assembly redirection is enabled on .NET 10
+  and later.
 - Allow an empty `opamp/development` section in file-based configuration to
   enable the OpAMP client with default settings.
 - Prevent the shell installer from using a predictable path for temporary

--- a/OpenTelemetry.AutoInstrumentation.sln
+++ b/OpenTelemetry.AutoInstrumentation.sln
@@ -268,6 +268,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication.StartupHook
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.AutoInstrumentation.PluginApi", "src\OpenTelemetry.AutoInstrumentation.PluginApi\OpenTelemetry.AutoInstrumentation.PluginApi.csproj", "{C4634F73-077F-41EE-A42E-F2218AE4BD3E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApplication.UnsafeAccessorTypeRedirection", "test\test-applications\integrations\TestApplication.UnsafeAccessorTypeRedirection\TestApplication.UnsafeAccessorTypeRedirection.csproj", "{9B1FD9FA-1D63-477F-B4F9-12D281198292}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1728,6 +1730,22 @@ Global
 		{C4634F73-077F-41EE-A42E-F2218AE4BD3E}.Release|x64.Build.0 = Release|Any CPU
 		{C4634F73-077F-41EE-A42E-F2218AE4BD3E}.Release|x86.ActiveCfg = Release|Any CPU
 		{C4634F73-077F-41EE-A42E-F2218AE4BD3E}.Release|x86.Build.0 = Release|Any CPU
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|Any CPU.Build.0 = Debug|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|ARM64.ActiveCfg = Debug|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|ARM64.Build.0 = Debug|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|x64.ActiveCfg = Debug|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|x64.Build.0 = Debug|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|x86.ActiveCfg = Debug|x86
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Debug|x86.Build.0 = Debug|x86
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|Any CPU.ActiveCfg = Release|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|Any CPU.Build.0 = Release|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|ARM64.ActiveCfg = Release|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|ARM64.Build.0 = Release|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|x64.ActiveCfg = Release|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|x64.Build.0 = Release|x64
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|x86.ActiveCfg = Release|x86
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1829,6 +1847,7 @@ Global
 		{8D74F5D8-FCD8-4763-936C-B849967A93DA} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 		{5A1944CD-8C7A-6D02-5B28-E053B78130CD} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 		{C4634F73-077F-41EE-A42E-F2218AE4BD3E} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{9B1FD9FA-1D63-477F-B4F9-12D281198292} = {E409ADD3-9574-465C-AB09-4324D205CC7C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -221,6 +221,16 @@ public static partial class LibraryVersion
             ]
         },
         {
+            "TestApplication.UnsafeAccessorTypeRedirection",
+            [
+                new("null", supportedFrameworks: [ "net10.0" ], additionalMetaData: new() { { "UnsafeAccessorAssemblyName", "Microsoft.Extensions.DependencyInjection.Abstractions" }, { "UnsafeAccessorComplete", "true" } }),
+                new("9.0.0.0", supportedFrameworks: [ "net10.0" ], additionalMetaData: new() { { "UnsafeAccessorAssemblyName", "Microsoft.Extensions.DependencyInjection.Abstractions" }, { "UnsafeAccessorAssemblyVersion", "9.0.0.0" }, { "UnsafeAccessorComplete", "true" } }),
+                new("10.0.0.0", supportedFrameworks: [ "net10.0" ], additionalMetaData: new() { { "UnsafeAccessorAssemblyName", "Microsoft.Extensions.DependencyInjection.Abstractions" }, { "UnsafeAccessorAssemblyVersion", "10.0.0.0" }, { "UnsafeAccessorComplete", "true" } }),
+                new("11.0.0.0", supportedFrameworks: [ "net10.0" ], additionalMetaData: new() { { "UnsafeAccessorAssemblyName", "Microsoft.Extensions.DependencyInjection.Abstractions" }, { "UnsafeAccessorAssemblyVersion", "11.0.0.0" }, { "UnsafeAccessorComplete", "true" } }),
+                new("1.0.0.0-incomplete", supportedFrameworks: [ "net10.0" ], additionalMetaData: new() { { "UnsafeAccessorAssemblyName", "Microsoft.Extensions.DependencyInjection.Abstractions" }, { "UnsafeAccessorAssemblyVersion", "1.0.0.0" }, { "UnsafeAccessorComplete", "false" } }),
+            ]
+        },
+        {
             "TestApplication.Wcf.Core",
             [
                 new("1.8.1", supportedFrameworks: [ "net10.0", "net9.0", "net8.0" ]),

--- a/docs/assembly-conflict-resolution.md
+++ b/docs/assembly-conflict-resolution.md
@@ -160,6 +160,18 @@ controlled by a version map compiled into the native profiler (see
 and
 [`assembly_redirection_netfx.h`](../src/OpenTelemetry.AutoInstrumentation.Native/assembly_redirection_netfx.h)).
 
+On .NET 10 and later, the profiler also rewrites the outer assembly qualifier
+of type names stored in `UnsafeAccessorType` attributes when that assembly
+appears in the same version map. This includes attributes in
+`System.Private.CoreLib` and in application or library modules. It considers
+only parameter and return-value attributes whose declaring method also has
+`UnsafeAccessor`, because that pairing is what gives `UnsafeAccessorType` its
+native-reflection meaning. A missing or lower `Version` is raised to the mapped
+version; an equal or higher version is preserved. As with `AssemblyRef`, a
+higher version seen before any rewrite becomes the target for later references.
+Only the outer type's assembly qualifier is handled; assembly qualifiers nested
+inside generic type arguments are left unchanged.
+
 > **NOTE**: On .NET, the instrumentation ships the baseline versions of its
 > dependencies for each target framework (for example, for `net8.0` the
 > 8.0.0 versions, for `net9.0` - 9.0.0, etc.) unless known issues
@@ -302,11 +314,13 @@ This can happen in the following scenarios:
   `AssemblyLoadContext.Default.LoadFromAssemblyPath` or `Assembly.LoadFrom`
   to load an assembly into the Default ALC.
 
-- **`UnsafeAccessorType` reflection (.NET 10+)**: Code uses
+- **StartupHook-only: `UnsafeAccessorType` reflection (.NET 10+)**: Code uses
   `UnsafeAccessorType` attributes in assemblies loaded in the Default ALC;
   in this case, types bind to the requesting assembly's load context.
   Once the runtime resolves a type for an `UnsafeAccessor` method in the
   Default ALC, it cannot interact with a different version loaded elsewhere.
+  StartupHook-only deployment cannot rewrite this metadata because the native
+  profiler is not attached.
 
 ### StartupHook-only: the customer application is loaded twice
 
@@ -352,12 +366,16 @@ architectures.
 
 ### Native profiler: conflicting version ordering
 
-The native profiler processes assembly references in module-load order.
-If an earlier module has been redirected to the instrumentation's version
-and a later module references a **higher** version than the
-instrumentation ships, the profiler cannot reconcile the two. This is
-logged as an error. In practice this is rare because the instrumentation
-ships the latest versions of its dependencies.
+The native profiler processes assembly references and `UnsafeAccessorType`
+attribute values in module-load order. CoreLib attributes are considered during
+CoreLib loading; in each later module, `AssemblyRef` entries are considered
+before attribute values. If an earlier reference has been
+redirected to the instrumentation's version and a later reference requests a
+**higher** version than the instrumentation ships, the profiler cannot safely
+revise the earlier metadata. This is logged as an error. An attribute in
+`System.Private.CoreLib` can be that first redirection because CoreLib loads
+before application modules. In practice this is rare because the
+instrumentation ships recent versions of its dependencies.
 
 ### Unexpected resolution request for a higher version than available
 
@@ -403,8 +421,9 @@ starts.
    `COREHOST_TRACEFILE=corehost_verbose_tracing.log` to capture the
    runtime's own assembly-loading decisions.
 3. **Review the native profiler log** — look for
-   `RedirectAssemblyReferences` entries to confirm that IL rewriting
-   happened and which versions were involved.
+   `RedirectAssemblyReferences` and `UnsafeAccessorTypeAttributeUpdater`
+   entries to confirm which metadata was rewritten and which versions were
+   involved.
 
 ### Last resort: `DOTNET_ADDITIONAL_DEPS` and the runtime store
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -225,6 +225,7 @@ add_library("OpenTelemetry.AutoInstrumentation.Native.static" STATIC
         suspension_guards.cpp
         method_rewriter.cpp
         tracer_tokens.cpp
+        unsafe_accessor_type_attribute_updater.cpp
         lib/coreclr/src/pal/prebuilt/idl/corprof_i.cpp
 )
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
@@ -239,6 +239,7 @@
     <ClInclude Include="suspension_guards.h" />
     <ClInclude Include="thread_suspend.h" />
     <ClInclude Include="tracer_tokens.h" />
+    <ClInclude Include="unsafe_accessor_type_attribute_updater.h" />
     <ClInclude Include="util.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>
@@ -275,6 +276,7 @@
     <ClCompile Include="suspension_guards.cpp" />
     <ClCompile Include="thread_suspend.cpp" />
     <ClCompile Include="tracer_tokens.cpp" />
+    <ClCompile Include="unsafe_accessor_type_attribute_updater.cpp" />
     <ClCompile Include="util.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -34,6 +34,7 @@
 #include "version.h"
 #include "continuous_profiler.h"
 #include "member_resolver.h"
+#include "unsafe_accessor_type_attribute_updater.h"
 
 #ifdef MACOS
 #include <mach-o/dyld.h>
@@ -657,8 +658,9 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
         auto             hr = this->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,
                                                              metadata_interfaces.GetAddressOf());
 
-        // Get the IMetaDataAssemblyImport interface to get metadata from the
-        // managed assembly
+        const auto& metadata_import = metadata_interfaces.As<IMetaDataImport2>(IID_IMetaDataImport);
+
+        // Get the IMetaDataAssemblyImport interface to get metadata from the managed assembly.
         const auto& assembly_import   = metadata_interfaces.As<IMetaDataAssemblyImport>(IID_IMetaDataAssemblyImport);
         const auto& assembly_metadata = GetAssemblyImportMetadata(assembly_import);
 
@@ -681,6 +683,32 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
         if (rejit_handler != nullptr)
         {
             rejit_handler->SetCorAssemblyProfiler(&corAssemblyProperty);
+        }
+
+        // Check whether assembly-qualified type names in UnsafeAccessorTypeAttribute need redirection to support
+        // JIT-level reflection, which is otherwise not covered by AssemblyRef redirection.
+        // UnsafeAccessorTypeAttribute appeared in .NET 10 in System.Private.CoreLib, whose metadata is unavailable
+        // during profiler Initialize, so establish the feature gate when CoreLib finishes loading. UnsafeAccessor
+        // methods can be declared by framework or customer libraries, so scan each subsequent module that participates
+        // in assembly redirection.
+        if (assembly_redirection_enabled_ && module_info.assembly.name == system_private_corelib_assemblyName)
+        {
+            unsafe_accessor_type_redirection_enabled_ = assembly_version_redirect_map_current_framework_ != nullptr &&
+                                                        HasUnsafeAccessorTypeAttribute(metadata_import);
+            Logger::Info("UnsafeAccessorTypeAttribute metadata redirection enabled: ",
+                         unsafe_accessor_type_redirection_enabled_ ? "true" : "false");
+            // This one-time CoreLib branch returns below and can never reach the regular AssemblyRef/attribute
+            // redirection path. Keeping this special case local avoids moving writable-metadata work ahead of the
+            // safety exits for other kinds of modules.
+            if (unsafe_accessor_type_redirection_enabled_)
+            {
+                const auto& metadata_emit = metadata_interfaces.As<IMetaDataEmit2>(IID_IMetaDataEmit);
+                const auto& assembly_emit = metadata_interfaces.As<IMetaDataAssemblyEmit>(IID_IMetaDataAssemblyEmit);
+                const auto& module_metadata =
+                    ModuleMetadata(metadata_import, metadata_emit, assembly_import, assembly_emit,
+                                   module_info.assembly.name, module_info.assembly.app_domain_id, &corAssemblyProperty);
+                UpdateUnsafeAccessorTypeAttributes(module_metadata, *assembly_version_redirect_map_current_framework_);
+            }
         }
 
 #ifdef _WIN32
@@ -822,6 +850,11 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
             //  - for .NET Frameworks - the ones under netfx/ folder
             //  - for .NET (Core) - the ones under net/ folder
             RedirectAssemblyReferences(assembly_import, assembly_emit);
+            // Apply the same redirection policy to UnsafeAccessorType attributes in methods declared by this module.
+            if (unsafe_accessor_type_redirection_enabled_)
+            {
+                UpdateUnsafeAccessorTypeAttributes(module_metadata, *assembly_version_redirect_map_current_framework_);
+            }
         }
 
         if (module_info.assembly.name == managed_profiler_name)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -58,6 +58,7 @@ private:
     bool startup_fix_required = false;
 
     bool corlib_module_loaded = false;
+    bool unsafe_accessor_type_redirection_enabled_ = false;
     AppDomainID corlib_app_domain_id = 0;
     bool managed_profiler_loaded_domain_neutral = false;
     std::unordered_set<AppDomainID> managed_profiler_loaded_app_domains;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/unsafe_accessor_type_attribute_updater.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/unsafe_accessor_type_attribute_updater.cpp
@@ -1,0 +1,519 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "unsafe_accessor_type_attribute_updater.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <limits>
+
+#include "logger.h"
+#include "module_metadata.h"
+#include "string_utils.h"
+
+namespace trace
+{
+
+namespace
+{
+
+const WSTRING unsafe_accessor_type_attribute_name = WStr("System.Runtime.CompilerServices.UnsafeAccessorTypeAttribute");
+const WSTRING unsafe_accessor_attribute_name      = WStr("System.Runtime.CompilerServices.UnsafeAccessorAttribute");
+
+// A custom-attribute SerString prefixes its UTF-8 bytes with an ECMA-335 compressed unsigned integer. Use the CLR's
+// codec for that standard 1/2/4-byte representation, but guard its reader because it examines the first byte before
+// validating the supplied length.
+bool TryReadPackedLength(const BYTE* data, size_t size, ULONG& length, size_t& bytes_read)
+{
+    if (data == nullptr || size == 0)
+    {
+        return false;
+    }
+
+    uint32_t   decoded_length = 0;
+    uint32_t   encoded_size   = 0;
+    const auto result         = CorSigUncompressData(data, static_cast<DWORD>(size), &decoded_length, &encoded_size);
+    length                    = static_cast<ULONG>(decoded_length);
+    bytes_read                = encoded_size;
+    return SUCCEEDED(result);
+}
+
+bool WritePackedLength(std::vector<BYTE>& blob, size_t length)
+{
+    constexpr size_t max_packed_length = 0x1FFFFFFF;
+    if (length > max_packed_length)
+    {
+        return false;
+    }
+
+    BYTE       encoded_length[4]{};
+    const auto encoded_size = CorSigCompressData(static_cast<ULONG>(length), encoded_length);
+    blob.insert(blob.end(), encoded_length, encoded_length + encoded_size);
+    return true;
+}
+
+size_t SkipWhitespace(const std::string& value, size_t position)
+{
+    while (position < value.size() && std::isspace(static_cast<unsigned char>(value[position])) != 0)
+    {
+        position++;
+    }
+
+    return position;
+}
+
+size_t TrimmedEnd(const std::string& value, size_t begin, size_t end)
+{
+    while (end > begin && std::isspace(static_cast<unsigned char>(value[end - 1])) != 0)
+    {
+        end--;
+    }
+
+    return end;
+}
+
+bool EqualsIgnoreCase(const std::string& left, const std::string& right)
+{
+    return left.size() == right.size() && std::equal(left.begin(), left.end(), right.begin(),
+                                                     [](char left_char, char right_char)
+                                                     {
+                                                         return std::tolower(static_cast<unsigned char>(left_char)) ==
+                                                                std::tolower(static_cast<unsigned char>(right_char));
+                                                     });
+}
+
+size_t FindAssemblySeparator(const std::string& type_name)
+{
+    // The first unescaped comma at bracket depth zero starts the outer assembly qualifier. Ignore commas inside generic
+    // arguments and escaped type-name commas.
+    size_t bracket_depth = 0;
+    bool   escaped       = false;
+
+    for (size_t i = 0; i < type_name.size(); i++)
+    {
+        const auto current = type_name[i];
+        if (escaped)
+        {
+            escaped = false;
+            continue;
+        }
+
+        if (current == '\\')
+        {
+            escaped = true;
+        }
+        else if (current == '[')
+        {
+            bracket_depth++;
+        }
+        else if (current == ']' && bracket_depth > 0)
+        {
+            bracket_depth--;
+        }
+        else if (current == ',' && bracket_depth == 0)
+        {
+            return i;
+        }
+    }
+
+    return std::string::npos;
+}
+
+bool TryParseVersion(const std::string& value, ASSEMBLYMETADATA& version)
+{
+    // Assembly metadata represents a version as exactly four unsigned 16-bit components.
+    constexpr auto max_component = static_cast<unsigned int>((std::numeric_limits<USHORT>::max)());
+    USHORT*        components[]  = {&version.usMajorVersion, &version.usMinorVersion, &version.usBuildNumber,
+                                    &version.usRevisionNumber};
+    size_t         position      = 0;
+
+    for (size_t i = 0; i < 4; i++)
+    {
+        const auto separator = value.find('.', position);
+        const auto end       = separator == std::string::npos ? value.size() : separator;
+        if (end == position || (i < 3 && separator == std::string::npos) || (i == 3 && separator != std::string::npos))
+        {
+            return false;
+        }
+
+        unsigned int component = 0;
+        for (size_t j = position; j < end; j++)
+        {
+            const auto current = value[j];
+            if (current < '0' || current > '9')
+            {
+                return false;
+            }
+
+            const auto digit = static_cast<unsigned int>(current - '0');
+            if (component > (max_component - digit) / 10)
+            {
+                return false;
+            }
+
+            component = (component * 10) + digit;
+        }
+
+        *components[i] = static_cast<USHORT>(component);
+        position       = end + 1;
+    }
+
+    return true;
+}
+
+std::string VersionString(const AssemblyVersionRedirection& redirect)
+{
+    return std::to_string(redirect.usMajorVersion) + "." + std::to_string(redirect.usMinorVersion) + "." +
+           std::to_string(redirect.usBuildNumber) + "." + std::to_string(redirect.usRevisionNumber);
+}
+
+bool IsUnsafeAccessorTypeAttribute(const ComPtr<IMetaDataImport2>& metadata_import, mdToken constructor)
+{
+    // A constructor is a MethodDef when the attribute is defined in this module and a MemberRef when it is imported.
+    mdToken parent = mdTokenNil;
+    HRESULT hr     = E_FAIL;
+
+    if (TypeFromToken(constructor) == mdtMethodDef)
+    {
+        hr = metadata_import->GetMethodProps(constructor, &parent, nullptr, 0, nullptr, nullptr, nullptr, nullptr,
+                                             nullptr, nullptr);
+    }
+    else if (TypeFromToken(constructor) == mdtMemberRef)
+    {
+        hr = metadata_import->GetMemberRefProps(constructor, &parent, nullptr, 0, nullptr, nullptr, nullptr);
+    }
+
+    if (FAILED(hr))
+    {
+        return false;
+    }
+
+    WCHAR attr_name[kNameMaxSize]{};
+    ULONG attr_name_length = 0;
+    if (TypeFromToken(parent) == mdtTypeDef)
+    {
+        hr = metadata_import->GetTypeDefProps(parent, attr_name, kNameMaxSize, &attr_name_length, nullptr, nullptr);
+    }
+    else if (TypeFromToken(parent) == mdtTypeRef)
+    {
+        hr = metadata_import->GetTypeRefProps(parent, nullptr, attr_name, kNameMaxSize, &attr_name_length);
+    }
+    else
+    {
+        return false;
+    }
+
+    return SUCCEEDED(hr) && attr_name_length > 0 && WSTRING(attr_name) == unsafe_accessor_type_attribute_name;
+}
+
+} // namespace
+
+bool HasUnsafeAccessorTypeAttribute(const ComPtr<IMetaDataImport2>& metadata_import)
+{
+    mdTypeDef attribute_type = mdTypeDefNil;
+    return metadata_import->FindTypeDefByName(unsafe_accessor_type_attribute_name.c_str(), mdTokenNil,
+                                              &attribute_type) == S_OK;
+}
+
+bool TryRewriteUnsafeAccessorTypeName(const std::string&                                       type_name,
+                                      std::unordered_map<WSTRING, AssemblyVersionRedirection>& assembly_redirects,
+                                      std::string&                                             rewritten_type_name,
+                                      WSTRING&                                                 redirected_assembly_name)
+{
+    const auto assembly_separator = FindAssemblySeparator(type_name);
+    if (assembly_separator == std::string::npos)
+    {
+        // A type without an assembly qualifier cannot participate in assembly redirection.
+        return false;
+    }
+
+    const auto assembly_begin = SkipWhitespace(type_name, assembly_separator + 1);
+    const auto assembly_end   = type_name.find(',', assembly_begin);
+    const auto assembly_name_end =
+        TrimmedEnd(type_name, assembly_begin, assembly_end == std::string::npos ? type_name.size() : assembly_end);
+    if (assembly_name_end == assembly_begin)
+    {
+        return false;
+    }
+
+    const auto assembly_name = type_name.substr(assembly_begin, assembly_name_end - assembly_begin);
+    auto       redirect      = assembly_redirects.find(ToWSTRING(assembly_name));
+    if (redirect == assembly_redirects.end())
+    {
+        redirect = std::find_if(assembly_redirects.begin(), assembly_redirects.end(),
+                                [&assembly_name](const auto& entry)
+                                { return EqualsIgnoreCase(ToString(entry.first), assembly_name); });
+    }
+    if (redirect == assembly_redirects.end())
+    {
+        return false;
+    }
+
+    auto qualifier = assembly_end;
+    while (qualifier != std::string::npos)
+    {
+        // Preserve qualifier spelling and order; only replace the value of an existing Version qualifier.
+        const auto qualifier_begin = SkipWhitespace(type_name, qualifier + 1);
+        const auto qualifier_end   = type_name.find(',', qualifier_begin);
+        const auto equals          = type_name.find('=', qualifier_begin);
+        if (equals != std::string::npos && (qualifier_end == std::string::npos || equals < qualifier_end))
+        {
+            const auto key_end = TrimmedEnd(type_name, qualifier_begin, equals);
+            if (EqualsIgnoreCase(type_name.substr(qualifier_begin, key_end - qualifier_begin), "Version"))
+            {
+                const auto value_begin = SkipWhitespace(type_name, equals + 1);
+                const auto value_end =
+                    TrimmedEnd(type_name, value_begin,
+                               qualifier_end == std::string::npos ? type_name.size() : qualifier_end);
+                ASSEMBLYMETADATA existing_version{};
+                if (!TryParseVersion(type_name.substr(value_begin, value_end - value_begin), existing_version))
+                {
+                    // Do not guess at malformed input; leave it for the runtime to reject or resolve.
+                    return false;
+                }
+
+                // Keep the version-ordering policy aligned with CorProfiler::RedirectAssemblyReferences.
+                const auto version_comparison = redirect->second.CompareToAssemblyVersion(existing_version);
+                if (version_comparison <= 0)
+                {
+                    // Never lower a requested version. Before any redirect is committed, let this higher request
+                    // raise the shared target; afterward, changing it could disagree with metadata already rewritten.
+                    if (version_comparison < 0)
+                    {
+                        if (redirect->second.ulRedirectionCount == 0)
+                        {
+                            Logger::Info("UnsafeAccessorTypeAttributeUpdater: redirection update for [",
+                                         redirect->first, "] to_version=", AssemblyVersionStr(existing_version),
+                                         " previous_version_redirection=", redirect->second.VersionStr());
+                            redirect->second.usMajorVersion   = existing_version.usMajorVersion;
+                            redirect->second.usMinorVersion   = existing_version.usMinorVersion;
+                            redirect->second.usBuildNumber    = existing_version.usBuildNumber;
+                            redirect->second.usRevisionNumber = existing_version.usRevisionNumber;
+                            // The unchanged higher reference is now the committed target for subsequent rewrites.
+                            redirect->second.ulRedirectionCount++;
+                        }
+                        else
+                        {
+                            Logger::Error("UnsafeAccessorTypeAttributeUpdater: assembly [", redirect->first,
+                                          "] version=", AssemblyVersionStr(existing_version),
+                                          " is higher than an earlier applied redirection to version=",
+                                          redirect->second.VersionStr());
+                        }
+                    }
+
+                    return false;
+                }
+
+                const auto target_version = VersionString(redirect->second);
+                rewritten_type_name = type_name.substr(0, value_begin) + target_version + type_name.substr(value_end);
+                redirected_assembly_name = redirect->first;
+                return true;
+            }
+        }
+
+        qualifier = qualifier_end;
+    }
+
+    // A versionless request can bind to the runtime's lower trusted platform assembly (TPA) copy without invoking the
+    // managed resolver. Adding an explicit higher version lets the resolver supply the instrumentation copy.
+    const auto target_version = VersionString(redirect->second);
+    rewritten_type_name =
+        type_name.substr(0, assembly_name_end) + ", Version=" + target_version + type_name.substr(assembly_name_end);
+    redirected_assembly_name = redirect->first;
+    return true;
+}
+
+bool TryRewriteUnsafeAccessorTypeAttributeBlob(
+    const BYTE*                                              blob,
+    ULONG                                                    blob_size,
+    std::unordered_map<WSTRING, AssemblyVersionRedirection>& assembly_redirects,
+    std::vector<BYTE>&                                       rewritten_blob,
+    WSTRING&                                                 redirected_assembly_name)
+{
+    constexpr size_t custom_attribute_prolog_size = 2;
+    constexpr size_t named_argument_count_size    = 2;
+    // The expected blob is: 01 00 prolog, one SerString constructor argument,
+    // then at least the two-byte named-argument count.
+    // A null SerString (FF) is not a type name and cannot be redirected.
+    if (blob == nullptr || blob_size < custom_attribute_prolog_size + 1 + named_argument_count_size ||
+        blob[0] != 0x01 || blob[1] != 0x00 || blob[custom_attribute_prolog_size] == 0xFF)
+    {
+        return false;
+    }
+
+    ULONG      string_length  = 0;
+    size_t     length_bytes   = 0;
+    const auto remaining_size = static_cast<size_t>(blob_size) - custom_attribute_prolog_size;
+    if (!TryReadPackedLength(blob + custom_attribute_prolog_size, remaining_size, string_length, length_bytes))
+    {
+        return false;
+    }
+
+    // Validate the declared string range with subtraction (which cannot overflow) and require the trailing two-byte
+    // named-argument count before constructing a string or advancing any pointers.
+    const auto string_begin = custom_attribute_prolog_size + length_bytes;
+    if (string_length > static_cast<size_t>(blob_size) - string_begin ||
+        static_cast<size_t>(blob_size) - string_begin - string_length < named_argument_count_size)
+    {
+        return false;
+    }
+
+    const std::string type_name(reinterpret_cast<const char*>(blob + string_begin), string_length);
+    std::string       rewritten_type_name;
+    if (!TryRewriteUnsafeAccessorTypeName(type_name, assembly_redirects, rewritten_type_name, redirected_assembly_name))
+    {
+        return false;
+    }
+
+    // Rebuild rather than overwrite in place because the new version can cross a 1/2/4-byte length boundary. Preserve
+    // every byte after the string instead of assuming it is only an empty named-argument count.
+    const auto trailing_size = static_cast<size_t>(blob_size) - string_begin - string_length;
+    rewritten_blob.clear();
+    rewritten_blob.insert(rewritten_blob.end(), blob, blob + custom_attribute_prolog_size);
+    if (!WritePackedLength(rewritten_blob, rewritten_type_name.size()))
+    {
+        rewritten_blob.clear();
+        return false;
+    }
+
+    constexpr auto max_blob_size = static_cast<size_t>((std::numeric_limits<ULONG>::max)());
+    if (trailing_size > max_blob_size - rewritten_blob.size())
+    {
+        rewritten_blob.clear();
+        return false;
+    }
+
+    const auto fixed_size = rewritten_blob.size() + trailing_size;
+    if (rewritten_type_name.size() > max_blob_size - fixed_size)
+    {
+        rewritten_blob.clear();
+        return false;
+    }
+
+    rewritten_blob.reserve(fixed_size + rewritten_type_name.size());
+    rewritten_blob.insert(rewritten_blob.end(), rewritten_type_name.begin(), rewritten_type_name.end());
+    rewritten_blob.insert(rewritten_blob.end(), blob + string_begin + string_length, blob + blob_size);
+    return true;
+}
+
+void UpdateUnsafeAccessorTypeAttributes(const ModuleMetadata&                                    module_metadata,
+                                        std::unordered_map<WSTRING, AssemblyVersionRedirection>& assembly_redirects)
+{
+    const auto&       metadata_import = module_metadata.metadata_import;
+    const auto&       metadata_emit   = module_metadata.metadata_emit;
+    HCORENUM          attribute_enum  = nullptr;
+    mdCustomAttribute attributes[32];
+    ULONG             applicable_count = 0;
+    ULONG             updated_count    = 0;
+    HRESULT           hr               = S_OK;
+
+    while (hr == S_OK)
+    {
+        ULONG attribute_count = 0;
+        hr = metadata_import->EnumCustomAttributes(&attribute_enum, mdTokenNil, mdTokenNil, attributes, 32,
+                                                   &attribute_count);
+        if (FAILED(hr))
+        {
+            Logger::Warn("UnsafeAccessorTypeAttributeUpdater: failed to enumerate custom attributes in ",
+                         module_metadata.assemblyName, ", HRESULT=", HResultStr(hr));
+            break;
+        }
+
+        for (ULONG i = 0; i < attribute_count; i++)
+        {
+            mdToken     owner       = mdTokenNil;
+            mdToken     constructor = mdTokenNil;
+            const void* blob_data   = nullptr;
+            ULONG       blob_size   = 0;
+            const auto  attribute_hr =
+                metadata_import->GetCustomAttributeProps(attributes[i], &owner, &constructor, &blob_data, &blob_size);
+            if (FAILED(attribute_hr))
+            {
+                Logger::Warn("UnsafeAccessorTypeAttributeUpdater: failed to read custom attribute in ",
+                             module_metadata.assemblyName, ", HRESULT=", HResultStr(attribute_hr));
+                continue;
+            }
+
+            const auto* blob = static_cast<const BYTE*>(blob_data);
+
+            // UnsafeAccessorType is valid only on parameters and return values;
+            // both are represented by ParamDef tokens (the return value has sequence zero).
+            if (TypeFromToken(owner) != mdtParamDef)
+            {
+                continue;
+            }
+
+            if (!IsUnsafeAccessorTypeAttribute(metadata_import, constructor))
+            {
+                continue;
+            }
+
+            mdMethodDef method   = mdMethodDefNil;
+            const auto  owner_hr = metadata_import->GetParamProps(owner, &method, nullptr, nullptr, 0, nullptr, nullptr,
+                                                                  nullptr, nullptr, nullptr);
+            if (FAILED(owner_hr))
+            {
+                // A ParamDef should always identify its declaring method; failure indicates invalid or unreadable
+                // metadata, so skip this attribute without jeopardizing module loading.
+                Logger::Warn("UnsafeAccessorTypeAttributeUpdater: failed to get the declaring method in ",
+                             module_metadata.assemblyName, ", HRESULT=", HResultStr(owner_hr));
+                continue;
+            }
+
+            const void* unsafe_accessor_blob      = nullptr;
+            ULONG       unsafe_accessor_blob_size = 0;
+            if (metadata_import->GetCustomAttributeByName(method, unsafe_accessor_attribute_name.c_str(),
+                                                          &unsafe_accessor_blob, &unsafe_accessor_blob_size) != S_OK)
+            {
+                continue;
+            }
+
+            applicable_count++;
+
+            std::vector<BYTE> rewritten_blob;
+            WSTRING           redirected_assembly_name;
+            if (!TryRewriteUnsafeAccessorTypeAttributeBlob(blob, blob_size, assembly_redirects, rewritten_blob,
+                                                           redirected_assembly_name))
+            {
+                continue;
+            }
+
+            const auto update_hr = metadata_emit->SetCustomAttributeValue(attributes[i], rewritten_blob.data(),
+                                                                          static_cast<ULONG>(rewritten_blob.size()));
+            if (FAILED(update_hr))
+            {
+                Logger::Warn("UnsafeAccessorTypeAttributeUpdater: failed to update an attribute in ",
+                             module_metadata.assemblyName, ", HRESULT=", HResultStr(update_hr));
+                continue;
+            }
+
+            const auto redirect = assembly_redirects.find(redirected_assembly_name);
+            if (redirect != assembly_redirects.end())
+            {
+                // Commit state only after metadata mutation succeeds; later higher requests must know a previous
+                // reference has already been rewritten.
+                redirect->second.ulRedirectionCount++;
+            }
+            updated_count++;
+        }
+    }
+
+    metadata_import->CloseEnum(attribute_enum);
+    if (applicable_count > 0)
+    {
+        // This debug summary also makes the separate CoreLib scan visible when none of its attributes target an
+        // assembly in the current redirection map.
+        Logger::Debug("UnsafeAccessorTypeAttributeUpdater: found ", applicable_count,
+                      " applicable attribute(s), updated ", updated_count, " in ", module_metadata.assemblyName);
+    }
+    if (updated_count > 0)
+    {
+        Logger::Info("UnsafeAccessorTypeAttributeUpdater: updated ", updated_count, " attribute(s) in ",
+                     module_metadata.assemblyName);
+    }
+}
+
+} // namespace trace

--- a/src/OpenTelemetry.AutoInstrumentation.Native/unsafe_accessor_type_attribute_updater.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/unsafe_accessor_type_attribute_updater.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef OTEL_CLR_PROFILER_UNSAFE_ACCESSOR_TYPE_ATTRIBUTE_UPDATER_H_
+#define OTEL_CLR_PROFILER_UNSAFE_ACCESSOR_TYPE_ATTRIBUTE_UPDATER_H_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "clr_helpers.h"
+
+namespace trace
+{
+
+class ModuleMetadata;
+
+// Returns whether this metadata scope defines UnsafeAccessorTypeAttribute as a TypeDef. Called for CoreLib as a
+// runtime capability check; it does not search for usages.
+bool HasUnsafeAccessorTypeAttribute(const ComPtr<IMetaDataImport2>& metadata_import);
+
+// Rewrites only the outer assembly qualifier: adds Version when absent or replaces a lower version. An explicit higher
+// version is preserved and can raise the shared target until a redirect is committed. True means rewritten output was
+// produced; false can still mean that a preserved higher version updated the shared redirection state.
+bool TryRewriteUnsafeAccessorTypeName(const std::string&                                       type_name,
+                                      std::unordered_map<WSTRING, AssemblyVersionRedirection>& assembly_redirects,
+                                      std::string&                                             rewritten_type_name,
+                                      WSTRING& redirected_assembly_name);
+
+// Parses the attribute's string argument and rebuilds the blob because the encoded length can grow or shrink. All
+// trailing metadata bytes are preserved. Outputs are valid only when this function returns true.
+bool TryRewriteUnsafeAccessorTypeAttributeBlob(
+    const BYTE*                                              blob,
+    ULONG                                                    blob_size,
+    std::unordered_map<WSTRING, AssemblyVersionRedirection>& assembly_redirects,
+    std::vector<BYTE>&                                       rewritten_blob,
+    WSTRING&                                                 redirected_assembly_name);
+
+// Scans one module for UnsafeAccessorType attributes on UnsafeAccessor return values and parameters. Redirect state is
+// committed only after a successful metadata write.
+void UpdateUnsafeAccessorTypeAttributes(const ModuleMetadata&                                    module_metadata,
+                                        std::unordered_map<WSTRING, AssemblyVersionRedirection>& assembly_redirects);
+
+} // namespace trace
+
+#endif // OTEL_CLR_PROFILER_UNSAFE_ACCESSOR_TYPE_ATTRIBUTE_UPDATER_H_

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -493,6 +493,35 @@ public static partial class LibraryVersion
             return theoryData;
         }
     }
+    public static TheoryData<string> UnsafeAccessorTypeRedirection
+    {
+        get
+        {
+            TheoryData<string> theoryData =
+            [
+#if DEFAULT_TEST_PACKAGE_VERSIONS
+                string.Empty,
+#else
+#if NET10_0
+                "null",
+#endif
+#if NET10_0
+                "9.0.0.0",
+#endif
+#if NET10_0
+                "10.0.0.0",
+#endif
+#if NET10_0
+                "11.0.0.0",
+#endif
+#if NET10_0
+                "1.0.0.0-incomplete",
+#endif
+#endif
+            ];
+            return theoryData;
+        }
+    }
     public static TheoryData<string> WCFCoreServer
     {
         get
@@ -540,6 +569,7 @@ public static partial class LibraryVersion
        { "WCFCoreClient", WCFCoreClient },
        { "Kafka", Kafka },
        { "AssemblyRedirection", AssemblyRedirection },
+       { "UnsafeAccessorTypeRedirection", UnsafeAccessorTypeRedirection },
        { "WCFCoreServer", WCFCoreServer },
     };
 }

--- a/test/IntegrationTests/UnsafeAccessorTypeRedirectionTests.cs
+++ b/test/IntegrationTests/UnsafeAccessorTypeRedirectionTests.cs
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// UnsafeAccessorTypeAttribute overrides should work starting from net10.0
+#if NET10_0_OR_GREATER
+
+using IntegrationTests.Helpers;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// Verifies that the native profiler rewrites assembly versions in UnsafeAccessorTypeAttribute metadata without
+/// resolving or loading the assembly named by the attribute. It also verifies that incomplete unsafe-accessor
+/// declarations are ignored.
+/// </summary>
+public class UnsafeAccessorTypeRedirectionTests(ITestOutputHelper output)
+    : TestHelper("UnsafeAccessorTypeRedirection", output)
+{
+    /// <summary>
+    /// Verifies that the native profiler adds a missing version, promotes a lower version, and preserves equal or
+    /// higher versions in complete unsafe-accessor declarations.
+    /// </summary>
+    /// <param name="assemblyName">The assembly name embedded in the attribute.</param>
+    /// <param name="compiledVersion">The assembly version embedded at build time, or <see langword="null"/> to omit it.</param>
+    /// <param name="expectedVersion">The assembly version expected after the profiler processes the module.</param>
+    [Theory]
+    [Trait("Category", "EndToEnd")]
+#if NET10_0
+    [InlineData("Microsoft.Extensions.DependencyInjection.Abstractions", null, "10.0.0.0")]
+    [InlineData("Microsoft.Extensions.DependencyInjection.Abstractions", "9.0.0.0", "10.0.0.0")]
+    [InlineData("Microsoft.Extensions.DependencyInjection.Abstractions", "10.0.0.0", "10.0.0.0")]
+    [InlineData("Microsoft.Extensions.DependencyInjection.Abstractions", "11.0.0.0", "11.0.0.0")]
+#endif
+    public void NativeRewriteAttributeMetadata(string assemblyName, string? compiledVersion, string expectedVersion)
+    {
+        EnableBytecodeInstrumentation();
+
+        var packageVersion = compiledVersion ?? "null";
+        var arguments = $"--assembly-name {assemblyName} --expected-version {expectedVersion}";
+
+        RunTestApplication(new TestSettings { PackageVersion = packageVersion, Arguments = arguments });
+    }
+
+    /// <summary>
+    /// Verifies that UnsafeAccessorTypeAttribute metadata is not rewritten when the declaring method does not also
+    /// have UnsafeAccessorAttribute.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "EndToEnd")]
+    public void NoNativeRewriteOnIncompleteAttribute()
+    {
+        EnableBytecodeInstrumentation();
+
+        var packageVersion = "1.0.0.0-incomplete";
+        var arguments = $"--assembly-name Microsoft.Extensions.DependencyInjection.Abstractions --expected-version 1.0.0.0";
+
+        RunTestApplication(new TestSettings { PackageVersion = packageVersion, Arguments = arguments });
+    }
+}
+#endif

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="startup_hook_test.cpp" />
     <ClCompile Include="string_utils_test.cpp" />
     <ClCompile Include="thread_span_context_test.cpp" />
+    <ClCompile Include="unsafe_accessor_type_attribute_updater_test.cpp" />
     <ClCompile Include="util_test.cpp" />
     <ClCompile Include="version_struct_test.cpp" />
   </ItemGroup>

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/unsafe_accessor_type_attribute_updater_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/unsafe_accessor_type_attribute_updater_test.cpp
@@ -1,0 +1,301 @@
+#include "pch.h"
+
+#include <stdexcept>
+
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/unsafe_accessor_type_attribute_updater.h"
+
+using namespace trace;
+
+namespace
+{
+
+constexpr size_t one_byte_length_max = 0x7F;
+constexpr size_t two_byte_length_max = 0x3FFF;
+
+// This creates the complete UnsafeAccessorTypeAttribute value blob:
+// 1) custom-attribute prolog,
+// 2) one string constructor argument,
+// 3) zero named-argument count.
+// This test encoder remains independent from production.
+std::vector<BYTE> CreateUnsafeAccessorTypeAttributeBlob(const std::string& type_name)
+{
+    std::vector<BYTE> blob;
+    // 1) custom-attribute prolog as fixed 0x0001 in little-endian order.
+    blob.push_back(0x01);
+    blob.push_back(0x00);
+
+    // 2) one string constructor argument - a type name as an ECMA-335 SerString: a compressed UTF-8 byte length
+    // followed by the UTF-8 bytes. Encoding the length here keeps the expected test blobs independent from the
+    // production CLR codec.
+    const auto type_name_length = type_name.size();
+    if (type_name_length <= one_byte_length_max)
+    {
+        blob.push_back(static_cast<BYTE>(type_name_length));
+    }
+    else if (type_name_length <= two_byte_length_max)
+    {
+        blob.push_back(static_cast<BYTE>((type_name_length >> 8) | 0x80));
+        blob.push_back(static_cast<BYTE>(type_name_length));
+    }
+    else if (type_name_length <= 0x1FFFFFFF)
+    {
+        blob.push_back(static_cast<BYTE>((type_name_length >> 24) | 0xC0));
+        blob.push_back(static_cast<BYTE>(type_name_length >> 16));
+        blob.push_back(static_cast<BYTE>(type_name_length >> 8));
+        blob.push_back(static_cast<BYTE>(type_name_length));
+    }
+    else
+    {
+        throw std::invalid_argument("Serialized string is too long for an ECMA-335 compressed length.");
+    }
+
+    blob.insert(blob.end(), type_name.begin(), type_name.end());
+
+    // 3) zero named-argument count as a 16-bit little-endian value.
+    blob.push_back(0x00);
+    blob.push_back(0x00);
+    return blob;
+}
+
+} // namespace
+
+TEST(UnsafeAccessorTypeNameRewriterTest, AddsMissingVersion)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeName("Test.Type, Test.Redirected.Assembly", redirects, rewritten_type_name,
+                                                 rewritten_assembly_name));
+    EXPECT_EQ(rewritten_type_name, "Test.Type, Test.Redirected.Assembly, Version=11.0.0.0");
+    EXPECT_EQ(rewritten_assembly_name, WStr("Test.Redirected.Assembly"));
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, MatchesAssemblyNameCaseInsensitively)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeName("Test.Type, test.redirected.assembly", redirects, rewritten_type_name,
+                                                 rewritten_assembly_name));
+    EXPECT_EQ(rewritten_type_name, "Test.Type, test.redirected.assembly, Version=11.0.0.0");
+    EXPECT_EQ(rewritten_assembly_name, WStr("Test.Redirected.Assembly"));
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, ReplacesLowerVersionAndPreservesQualifiers)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeName(
+        "Test.Type, Test.Redirected.Assembly, Culture=neutral, Version=1.12345.12345.12345, "
+        "PublicKeyToken=0123456789abcdef",
+        redirects, rewritten_type_name, rewritten_assembly_name));
+    EXPECT_EQ(rewritten_type_name, "Test.Type, Test.Redirected.Assembly, Culture=neutral, Version=11.0.0.0, "
+                                   "PublicKeyToken=0123456789abcdef");
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, PreservesEqualVersion)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    EXPECT_FALSE(TryRewriteUnsafeAccessorTypeName("Test.Type, Test.Redirected.Assembly, Version=11.0.0.0", redirects,
+                                                  rewritten_type_name, rewritten_assembly_name));
+    auto& redirect = redirects.at(WStr("Test.Redirected.Assembly"));
+    EXPECT_EQ(redirect.VersionStr(), WStr("11.0.0.0"));
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, FindsOuterAssemblyAfterGenericArguments)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeName(
+        "Test.GenericType`1[[Test.OtherType, Test.Other.Assembly]], Test.Redirected.Assembly", redirects,
+        rewritten_type_name, rewritten_assembly_name));
+    EXPECT_EQ(rewritten_type_name,
+              "Test.GenericType`1[[Test.OtherType, Test.Other.Assembly]], Test.Redirected.Assembly, "
+              "Version=11.0.0.0");
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, DoesNotRewriteAssemblyNestedInsideGenericArguments)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    EXPECT_FALSE(TryRewriteUnsafeAccessorTypeName(
+        "Test.GenericType`1[[Test.OtherType, Test.Redirected.Assembly, Version=1.0.0.0]], Test.Other.Assembly",
+        redirects, rewritten_type_name, rewritten_assembly_name));
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, DoesNotRewriteUnmappedAssembly)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    EXPECT_FALSE(TryRewriteUnsafeAccessorTypeName("Test.Type, Test.Other.Assembly", redirects, rewritten_type_name,
+                                                  rewritten_assembly_name));
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, DoesNotRewriteUnqualifiedType)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    EXPECT_FALSE(
+        TryRewriteUnsafeAccessorTypeName("Test.Type", redirects, rewritten_type_name, rewritten_assembly_name));
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, DoesNotRewriteMalformedVersion)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    EXPECT_FALSE(TryRewriteUnsafeAccessorTypeName("Test.Type, Test.Redirected.Assembly, Version=11.0.invalid.0",
+                                                  redirects, rewritten_type_name, rewritten_assembly_name));
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, PromotesMapForHigherVersionBeforeFirstRedirection)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    EXPECT_FALSE(TryRewriteUnsafeAccessorTypeName("Test.Type, Test.Redirected.Assembly, Version=12.0.0.0", redirects,
+                                                  rewritten_type_name, rewritten_assembly_name));
+    auto& redirect = redirects.at(WStr("Test.Redirected.Assembly"));
+    EXPECT_EQ(redirect.VersionStr(), WStr("12.0.0.0"));
+    EXPECT_EQ(redirect.ulRedirectionCount, 1);
+}
+
+TEST(UnsafeAccessorTypeNameRewriterTest, DoesNotPromoteMapAfterRedirectionWasApplied)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    redirects.at(WStr("Test.Redirected.Assembly")).ulRedirectionCount = 1;
+    std::string rewritten_type_name;
+    WSTRING     rewritten_assembly_name;
+
+    EXPECT_FALSE(TryRewriteUnsafeAccessorTypeName("Test.Type, Test.Redirected.Assembly, Version=12.0.0.0", redirects,
+                                                  rewritten_type_name, rewritten_assembly_name));
+    auto& redirect = redirects.at(WStr("Test.Redirected.Assembly"));
+    EXPECT_EQ(redirect.VersionStr(), WStr("11.0.0.0"));
+    EXPECT_EQ(redirect.ulRedirectionCount, 1);
+}
+
+TEST(UnsafeAccessorTypeAttributeBlobRewriterTest, RewritesWithoutLeavingBytesFromLongerValue)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    const auto original_suffix = std::string(", Test.Redirected.Assembly, Version=1.12345.12345.12345");
+    const auto expected_suffix = std::string(", Test.Redirected.Assembly, Version=11.0.0.0");
+    const auto type_prefix     = std::string(one_byte_length_max - expected_suffix.size(), 'N');
+    const auto original_name   = type_prefix + original_suffix;
+    const auto expected_name   = type_prefix + expected_suffix;
+    ASSERT_GT(original_name.size(), one_byte_length_max);
+    ASSERT_EQ(expected_name.size(), one_byte_length_max);
+    const auto        original_blob = CreateUnsafeAccessorTypeAttributeBlob(original_name);
+    const auto        expected_blob = CreateUnsafeAccessorTypeAttributeBlob(expected_name);
+    std::vector<BYTE> rewritten_blob;
+    WSTRING           rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeAttributeBlob(original_blob.data(),
+                                                          static_cast<ULONG>(original_blob.size()), redirects,
+                                                          rewritten_blob, rewritten_assembly_name));
+    EXPECT_EQ(rewritten_blob, expected_blob);
+}
+
+TEST(UnsafeAccessorTypeAttributeBlobRewriterTest, RewritesWhenValueNeedsTwoByteLength)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    const auto assembly_suffix = std::string(", Test.Redirected.Assembly");
+    const auto type_prefix     = std::string(one_byte_length_max - assembly_suffix.size(), 'N');
+    const auto original_name   = type_prefix + assembly_suffix;
+    const auto expected_name   = original_name + ", Version=11.0.0.0";
+    ASSERT_EQ(original_name.size(), one_byte_length_max);
+    ASSERT_GT(expected_name.size(), one_byte_length_max);
+    const auto        original_blob = CreateUnsafeAccessorTypeAttributeBlob(original_name);
+    const auto        expected_blob = CreateUnsafeAccessorTypeAttributeBlob(expected_name);
+    std::vector<BYTE> rewritten_blob;
+    WSTRING           rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeAttributeBlob(original_blob.data(),
+                                                          static_cast<ULONG>(original_blob.size()), redirects,
+                                                          rewritten_blob, rewritten_assembly_name));
+    EXPECT_EQ(rewritten_blob, expected_blob);
+}
+
+TEST(UnsafeAccessorTypeAttributeBlobRewriterTest, RewritesWhenValueNeedsFourByteLength)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    const auto assembly_suffix = std::string(", Test.Redirected.Assembly");
+    const auto type_prefix     = std::string(two_byte_length_max - assembly_suffix.size(), 'N');
+    const auto original_name   = type_prefix + assembly_suffix;
+    const auto expected_name   = original_name + ", Version=11.0.0.0";
+    ASSERT_EQ(original_name.size(), two_byte_length_max);
+    ASSERT_GT(expected_name.size(), two_byte_length_max);
+    const auto        original_blob = CreateUnsafeAccessorTypeAttributeBlob(original_name);
+    const auto        expected_blob = CreateUnsafeAccessorTypeAttributeBlob(expected_name);
+    std::vector<BYTE> rewritten_blob;
+    WSTRING           rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeAttributeBlob(original_blob.data(),
+                                                          static_cast<ULONG>(original_blob.size()), redirects,
+                                                          rewritten_blob, rewritten_assembly_name));
+    EXPECT_EQ(rewritten_blob, expected_blob);
+}
+
+TEST(UnsafeAccessorTypeAttributeBlobRewriterTest, PreservesTrailingBlobBytes)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    const auto original_name = std::string("Test.Type, Test.Redirected.Assembly, Version=1.0.0.0");
+    const auto expected_name = std::string("Test.Type, Test.Redirected.Assembly, Version=11.0.0.0");
+    auto       original_blob = CreateUnsafeAccessorTypeAttributeBlob(original_name);
+    auto       expected_blob = CreateUnsafeAccessorTypeAttributeBlob(expected_name);
+    // Opaque marker bytes make this distinguish preservation from rebuilding a hardcoded 00 00 suffix.
+    const std::vector<BYTE> trailing_marker = {0xAA, 0xBB, 0xCC};
+    original_blob.insert(original_blob.end(), trailing_marker.begin(), trailing_marker.end());
+    expected_blob.insert(expected_blob.end(), trailing_marker.begin(), trailing_marker.end());
+    std::vector<BYTE> rewritten_blob;
+    WSTRING           rewritten_assembly_name;
+
+    ASSERT_TRUE(TryRewriteUnsafeAccessorTypeAttributeBlob(original_blob.data(),
+                                                          static_cast<ULONG>(original_blob.size()), redirects,
+                                                          rewritten_blob, rewritten_assembly_name));
+    EXPECT_EQ(rewritten_blob, expected_blob);
+}
+
+TEST(UnsafeAccessorTypeAttributeBlobRewriterTest, RejectsTruncatedPackedLength)
+{
+    std::unordered_map<WSTRING, AssemblyVersionRedirection> redirects = {
+        {WStr("Test.Redirected.Assembly"), {11, 0, 0, 0}}};
+    const std::vector<BYTE> truncated_blob = {0x01, 0x00, 0xC0, 0x00, 0x00};
+    std::vector<BYTE>       rewritten_blob;
+    WSTRING                 rewritten_assembly_name;
+
+    EXPECT_FALSE(TryRewriteUnsafeAccessorTypeAttributeBlob(truncated_blob.data(),
+                                                           static_cast<ULONG>(truncated_blob.size()), redirects,
+                                                           rewritten_blob, rewritten_assembly_name));
+}

--- a/test/test-applications/integrations/TestApplication.UnsafeAccessorTypeRedirection/Program.cs
+++ b/test/test-applications/integrations/TestApplication.UnsafeAccessorTypeRedirection/Program.cs
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using TestApplication.Shared;
+
+var expectedAssemblyName = ArgumentHelper.GetRequiredArgument(args, "--assembly-name");
+var expectedVersion = ArgumentHelper.GetArgument(args, "--expected-version", string.Empty);
+var expectedTypeName = $"Some.Type, {expectedAssemblyName}";
+if (!string.IsNullOrEmpty(expectedVersion))
+{
+    expectedTypeName += $", Version={expectedVersion}";
+}
+
+var method = typeof(UnsafeAccessorTarget).GetMethod(
+    nameof(UnsafeAccessorTarget.Unused),
+    BindingFlags.NonPublic | BindingFlags.Static) ??
+    throw new MissingMethodException(typeof(UnsafeAccessorTarget).FullName, nameof(UnsafeAccessorTarget.Unused));
+
+var returnTypeName = method.ReturnParameter.GetCustomAttribute<UnsafeAccessorTypeAttribute>()?.TypeName ??
+    throw new InvalidOperationException(
+        $"UnsafeAccessorTypeAttribute is missing from the return value of {nameof(UnsafeAccessorTarget.Unused)}.");
+var parameterTypeName = method.GetParameters().Single().GetCustomAttribute<UnsafeAccessorTypeAttribute>()?.TypeName ??
+    throw new InvalidOperationException(
+        $"UnsafeAccessorTypeAttribute is missing from the parameter of {nameof(UnsafeAccessorTarget.Unused)}.");
+
+if (returnTypeName != expectedTypeName || parameterTypeName != expectedTypeName)
+{
+    throw new InvalidOperationException(
+        $"Expected UnsafeAccessorType metadata '{expectedTypeName}', " +
+        $"but found return '{returnTypeName}' and parameter '{parameterTypeName}'.");
+}
+
+return 0;

--- a/test/test-applications/integrations/TestApplication.UnsafeAccessorTypeRedirection/TestApplication.UnsafeAccessorTypeRedirection.csproj
+++ b/test/test-applications/integrations/TestApplication.UnsafeAccessorTypeRedirection/TestApplication.UnsafeAccessorTypeRedirection.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <UnsafeAccessorAssemblyName Condition="'$(UnsafeAccessorAssemblyName)' == ''">Some.Assembly.Name</UnsafeAccessorAssemblyName>
+    <UnsafeAccessorComplete Condition="'$(UnsafeAccessorComplete)' == ''">true</UnsafeAccessorComplete>
+    <DefineConstants Condition="'$(UnsafeAccessorComplete)' == 'true'">$(DefineConstants);COMPLETE_UNSAFE_ACCESSOR</DefineConstants>
+    <!-- The incomplete variant intentionally declares an extern method without an implementation attribute. -->
+    <NoWarn Condition="'$(UnsafeAccessorComplete)' != 'true'">$(NoWarn);CS0626</NoWarn>
+  </PropertyGroup>
+
+  <Target Name="GenerateUnsafeAccessorBuildSettings" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_UnsafeAccessorVersionSuffix Condition="'$(UnsafeAccessorAssemblyVersion)' != ''">, Version=$(UnsafeAccessorAssemblyVersion)</_UnsafeAccessorVersionSuffix>
+      <_UnsafeAccessorBuildSettingsFile>$(IntermediateOutputPath)UnsafeAccessorBuildSettings.g.cs</_UnsafeAccessorBuildSettingsFile>
+    </PropertyGroup>
+    <!-- Generate the compile-time constant required by UnsafeAccessorTypeAttribute from the test build properties. -->
+    <ItemGroup>
+      <_UnsafeAccessorBuildSettingsLine Include="// &lt;auto-generated /&gt;" />
+      <_UnsafeAccessorBuildSettingsLine Include="internal static class UnsafeAccessorBuildSettings" />
+      <_UnsafeAccessorBuildSettingsLine Include="{" />
+      <_UnsafeAccessorBuildSettingsLine Include="    internal const string TypeName = &quot;Some.Type, $(UnsafeAccessorAssemblyName)$(_UnsafeAccessorVersionSuffix)&quot;%3B" />
+      <_UnsafeAccessorBuildSettingsLine Include="}" />
+      <Compile Include="$(_UnsafeAccessorBuildSettingsFile)" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(_UnsafeAccessorBuildSettingsFile)" Lines="@(_UnsafeAccessorBuildSettingsLine)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
+</Project>

--- a/test/test-applications/integrations/TestApplication.UnsafeAccessorTypeRedirection/UnsafeAccessorTarget.cs
+++ b/test/test-applications/integrations/TestApplication.UnsafeAccessorTypeRedirection/UnsafeAccessorTarget.cs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+
+internal static class UnsafeAccessorTarget
+{
+#if COMPLETE_UNSAFE_ACCESSOR
+    [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "Unused")]
+#endif
+    [return: UnsafeAccessorType(UnsafeAccessorBuildSettings.TypeName)]
+    internal static extern object Unused(
+        [UnsafeAccessorType(UnsafeAccessorBuildSettings.TypeName)] object value);
+}

--- a/tools/LibraryVersionsGenerator/BuildFileBuilder.cs
+++ b/tools/LibraryVersionsGenerator/BuildFileBuilder.cs
@@ -46,11 +46,11 @@ internal sealed class BuildFileBuilder : CSharpFileBuilder
         return this;
     }
 
-    public override CSharpFileBuilder AddVersionWithDependencies(string version, Dictionary<string, string> dependencies, string[] supportedFrameworks, string[] supportedPlatforms)
+    public override CSharpFileBuilder AddVersionWithMetadata(string version, Dictionary<string, string> metadata, string[] supportedFrameworks, string[] supportedPlatforms)
     {
         AddVersion(version, supportedFrameworks, supportedPlatforms, appendEnd: false);
 
-        Builder.AppendLine(CultureInfo.InvariantCulture, $", additionalMetaData: {SerializeDictionary(dependencies)}),");
+        Builder.AppendLine(CultureInfo.InvariantCulture, $", additionalMetaData: {SerializeDictionary(metadata)}),");
         return this;
     }
 

--- a/tools/LibraryVersionsGenerator/CSharpFileBuilder.cs
+++ b/tools/LibraryVersionsGenerator/CSharpFileBuilder.cs
@@ -67,7 +67,7 @@ internal abstract class CSharpFileBuilder
 
     public abstract CSharpFileBuilder AddVersion(string version, string[] supportedFrameworks, string[] supportedPlatforms);
 
-    public abstract CSharpFileBuilder AddVersionWithDependencies(string version, Dictionary<string, string> dependencies, string[] supportedFrameworks, string[] supportedPlatforms);
+    public abstract CSharpFileBuilder AddVersionWithMetadata(string version, Dictionary<string, string> metadata, string[] supportedFrameworks, string[] supportedPlatforms);
 
     public abstract CSharpFileBuilder EndTestPackage();
 

--- a/tools/LibraryVersionsGenerator/Models/PackageVersion.cs
+++ b/tools/LibraryVersionsGenerator/Models/PackageVersion.cs
@@ -5,12 +5,18 @@ namespace LibraryVersionsGenerator.Models;
 
 internal class PackageVersion
 {
-    public PackageVersion(string version, string[]? supportedTargetFrameworks = null, string[]? supportedExecutionFrameworks = null, string[]? supportedPlatforms = null)
+    public PackageVersion(
+        string version,
+        string[]? supportedTargetFrameworks = null,
+        string[]? supportedExecutionFrameworks = null,
+        string[]? supportedPlatforms = null,
+        IReadOnlyDictionary<string, string>? buildProperties = null)
     {
         Version = version;
         SupportedTargetFrameworks = supportedTargetFrameworks ?? Array.Empty<string>();
         SupportedExecutionFrameworks = supportedExecutionFrameworks ?? Array.Empty<string>();
         SupportedPlatforms = supportedPlatforms ?? Array.Empty<string>();
+        BuildProperties = buildProperties ?? new Dictionary<string, string>();
     }
 
     public string Version { get; init; }
@@ -20,4 +26,6 @@ internal class PackageVersion
     public string[] SupportedExecutionFrameworks { get; init; }
 
     public string[] SupportedPlatforms { get; init; }
+
+    public IReadOnlyDictionary<string, string> BuildProperties { get; init; }
 }

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -358,6 +358,66 @@ internal static class PackageVersionDefinitions
         },
         new()
         {
+            IntegrationName = "UnsafeAccessorTypeRedirection",
+            // The existing generator contract requires it, but explicit build variants never read it.
+            // Use an obvious sentinel
+            NugetPackageName = "NotUsed",
+            TestApplicationName = "TestApplication.UnsafeAccessorTypeRedirection",
+            Versions =
+            [
+                new(
+                    "null",
+                    supportedTargetFrameworks: ["net10.0"],
+                    supportedExecutionFrameworks: ["net10.0"],
+                    buildProperties: new Dictionary<string, string>
+                    {
+                        ["UnsafeAccessorAssemblyName"] = "Microsoft.Extensions.DependencyInjection.Abstractions",
+                        ["UnsafeAccessorComplete"] = "true"
+                    }),
+                new(
+                    "9.0.0.0",
+                    supportedTargetFrameworks: ["net10.0"],
+                    supportedExecutionFrameworks: ["net10.0"],
+                    buildProperties: new Dictionary<string, string>
+                    {
+                        ["UnsafeAccessorAssemblyName"] = "Microsoft.Extensions.DependencyInjection.Abstractions",
+                        ["UnsafeAccessorAssemblyVersion"] = "9.0.0.0",
+                        ["UnsafeAccessorComplete"] = "true"
+                    }),
+                new(
+                    "10.0.0.0",
+                    supportedTargetFrameworks: ["net10.0"],
+                    supportedExecutionFrameworks: ["net10.0"],
+                    buildProperties: new Dictionary<string, string>
+                    {
+                        ["UnsafeAccessorAssemblyName"] = "Microsoft.Extensions.DependencyInjection.Abstractions",
+                        ["UnsafeAccessorAssemblyVersion"] = "10.0.0.0",
+                        ["UnsafeAccessorComplete"] = "true"
+                    }),
+                new(
+                    "11.0.0.0",
+                    supportedTargetFrameworks: ["net10.0"],
+                    supportedExecutionFrameworks: ["net10.0"],
+                    buildProperties: new Dictionary<string, string>
+                    {
+                        ["UnsafeAccessorAssemblyName"] = "Microsoft.Extensions.DependencyInjection.Abstractions",
+                        ["UnsafeAccessorAssemblyVersion"] = "11.0.0.0",
+                        ["UnsafeAccessorComplete"] = "true"
+                    }),
+                new(
+                    "1.0.0.0-incomplete",
+                    supportedTargetFrameworks: ["net10.0"],
+                    supportedExecutionFrameworks: ["net10.0"],
+                    buildProperties: new Dictionary<string, string>
+                    {
+                        ["UnsafeAccessorAssemblyName"] = "Microsoft.Extensions.DependencyInjection.Abstractions",
+                        ["UnsafeAccessorAssemblyVersion"] = "1.0.0.0",
+                        ["UnsafeAccessorComplete"] = "false"
+                    })
+            ]
+        },
+        new()
+        {
             IntegrationName = "WCFCoreServer",
             NugetPackageName = "CoreWCF.Primitives",
             TestApplicationName = "TestApplication.Wcf.Core",

--- a/tools/LibraryVersionsGenerator/Program.cs
+++ b/tools/LibraryVersionsGenerator/Program.cs
@@ -43,6 +43,7 @@ internal static class Program
             foreach (var version in packageVersionDefinition.Versions)
             {
                 var calculatedVersion = EvaluateVersion(packageVersionDefinition.NugetPackageName, version.Version);
+                var buildProperties = GetDependencies(version).Concat(version.BuildProperties).ToDictionary();
 
                 if (uniqueVersions.Add(calculatedVersion))
                 {
@@ -65,7 +66,7 @@ internal static class Program
                         }
                     }
 
-                    if (version.GetType() == typeof(PackageVersion))
+                    if (buildProperties.Count == 0)
                     {
                         // Filter platform specific version
                         if (!isPlatformSpecific)
@@ -80,10 +81,10 @@ internal static class Program
                         // Filter platform specific version
                         if (!isPlatformSpecific)
                         {
-                            xUnitFileStringBuilder.AddVersionWithDependencies(calculatedVersion, GetDependencies(version), version.SupportedExecutionFrameworks, version.SupportedPlatforms);
+                            xUnitFileStringBuilder.AddVersionWithMetadata(calculatedVersion, buildProperties, version.SupportedExecutionFrameworks, version.SupportedPlatforms);
                         }
 
-                        buildFileStringBuilder.AddVersionWithDependencies(calculatedVersion, GetDependencies(version), version.SupportedTargetFrameworks, version.SupportedPlatforms);
+                        buildFileStringBuilder.AddVersionWithMetadata(calculatedVersion, buildProperties, version.SupportedTargetFrameworks, version.SupportedPlatforms);
                     }
                 }
             }

--- a/tools/LibraryVersionsGenerator/XUnitFileBuilder.cs
+++ b/tools/LibraryVersionsGenerator/XUnitFileBuilder.cs
@@ -47,9 +47,9 @@ internal sealed class XUnitFileBuilder : CSharpFileBuilder
         return this;
     }
 
-    public override CSharpFileBuilder AddVersionWithDependencies(string version, Dictionary<string, string> dependencies, string[] supportedFrameworks, string[] supportedPlatforms)
+    public override CSharpFileBuilder AddVersionWithMetadata(string version, Dictionary<string, string> metadata, string[] supportedFrameworks, string[] supportedPlatforms)
     {
-        // Dependencies info is currently not usable here. Build is located based on main package version string.
+        // Build metadata is not needed here. The application build is located by its main version string.
         return AddVersion(version, supportedFrameworks, supportedPlatforms);
     }
 


### PR DESCRIPTION
## Why

**Fixes #4923**

On .NET 10+, assembly-qualified type names stored in `UnsafeAccessorTypeAttribute` metadata are resolved independently of normal `AssemblyRef` metadata. Consequently, rewriting only `AssemblyRef` entries leaves a path that can load an older redirected dependency into the wrong `AssemblyLoadContext`.

This change closes that gap for native-profiler deployments before dependencies such as `System.Diagnostics.DiagnosticSource` require a higher redirected version.

## What

- Detect whether the runtime provides `UnsafeAccessorTypeAttribute` before searching modules for metadata to rewrite. This limits the additional processing to supported .NET runtimes.
- Find complete unsafe-accessor declarations: methods using `UnsafeAccessorAttribute` together with `UnsafeAccessorTypeAttribute` on a return value or parameter.
- Rewrite assembly versions in `UnsafeAccessorTypeAttribute` values using the existing framework-specific assembly redirection map:
  - add a missing version;
  - replace a lower version with the mapped version;
  - preserve equal or higher versions;
  - participate in the existing highest-version selection behavior - symmetrical to AssemblyRef redirection.
- Re-encode modified custom-attribute blobs safely, including compressed string-length transitions and trailing metadata.
- Extend test-build automation to pass arbitrary MSBuild properties to generated application variants.
- Add focused native unit tests and a .NET 10 end-to-end test application.
- Document how `UnsafeAccessorTypeAttribute` redirection participates in assembly conflict resolution.

**NOTE:** This applies only to native-profiler deployments. StartupHook-only isolation remains subject to the limitation tracked by #4924.

The implementation redirects the outer assembly qualification of the unsafe-accessor type. Assembly identities nested inside generic type arguments are intentionally left unchanged.

## Tests

- Focused native unit-test suites:
  - `UnsafeAccessorTypeNameRewriterTest`
  - `UnsafeAccessorTypeAttributeBlobRewriterTest`
- Focused integration tests for .NET 10+ runtimes covering:
  - a versionless assembly name redirection;
  - a lower version redirection;
  - an equal version preservation;
  - a higher version preservation;
  - no redirection on an incomplete declaration without `UnsafeAccessorAttribute`.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.