### PR TITLE
Release 1.15.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Add support for `OTEL_CONFIG_FILE` environment variable for file-based configuration.
   This variable takes precedence over the deprecated
   `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable.
-- Configuration based instrumentation support dynamic evaluation for
+- Configuration based instrumentation supports dynamic evaluation for
   - span names,
   - attribute values,
   - statuses.
@@ -47,7 +47,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - Added the `db.response.status_code` and `error.type` attributes to error spans,
   - Removed the `network.peer.address` and `network.peer.port` attributes.
 - Plugins limited to one instance per type.
-- Improves allocation sampling behavior at startup for
+- Improve allocation sampling behavior at startup for
   a more even distribution of samples.
 
 #### Dependency updates
@@ -66,10 +66,10 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
-- Fixed configuration based instrumentation for some .NET Framework methods.
-- Fixed .NET Framework assembly redirection startup by registering the loader
+- Fix configuration based instrumentation for some .NET Framework methods.
+- Fix .NET Framework assembly redirection startup by registering the loader
   before the application's entry point executes.
-- Fixed various assembly resolution conflicts.
+- Fix various assembly resolution conflicts.
 - When both `ENTITYFRAMEWORKCORE` and `NPGSQL` traces instrumentations are enabled,
   Entity Framework Core instrumentation now skips the
   `Npgsql.EntityFrameworkCore.PostgreSQL` provider so both instrumentations can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this component are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v1.14.1..HEAD)
+## [Unreleased](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/compare/v1.15.0-beta.1..HEAD)
+
+### Added
+
+### Changed
+
+#### Dependency updates
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [v1.15.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.15.0-beta.1)
 
 ### Added
 
@@ -50,13 +64,12 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable for file-based
   configuration is deprecated. Use `OTEL_CONFIG_FILE` instead.
 
-### Removed
-
 ### Fixed
 
 - Fixed configuration based instrumentation for some .NET Framework methods.
 - Fixed .NET Framework assembly redirection startup by registering the loader
   before the application's entry point executes.
+- Fixed various assembly resolution conflicts.
 - When both `ENTITYFRAMEWORKCORE` and `NPGSQL` traces instrumentations are enabled,
   Entity Framework Core instrumentation now skips the
   `Npgsql.EntityFrameworkCore.PostgreSQL` provider so both instrumentations can

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ to .NET applications without having to modify their source code.
 > [!WARNING]
 > The following documentation refers to the in-development version
 of OpenTelemetry .NET Automatic Instrumentation. Docs for the latest version
-([1.14.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
+([1.15.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest))
 can be found in [opentelemetry.io](https://opentelemetry.io/docs/zero-code/dotnet/)
-or [versioned README](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.14.1/docs/README.md).
+or [versioned README](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.15.0-beta.1/docs/README.md).
 
 ---
 
@@ -231,7 +231,7 @@ uses environment variables as parameters:
 | `TMPDIR`                | (deprecated) prefer `DOWNLOAD_DIR`                                              | No       | `$(mktemp -d)`              |
 | `DOWNLOAD_DIR`          | Folder to download the archive to. Will use local archive if it already exists  | No       | `$TMPDIR` or `$(mktemp -d)` |
 | `LOCAL_PATH`            | Full path the archive to use for installation. (ideal for air-gapped scenarios) | No       | *Calculated*                |
-| `VERSION`               | Version to download                                                             | No       | `1.14.1`                    |
+| `VERSION`               | Version to download                                                             | No       | `1.15.0-beta.1`             |
 
 [instrument.sh](../instrument.sh) script
 uses environment variables as parameters:
@@ -259,7 +259,7 @@ Example usage (run as administrator):
 #Requires -PSEdition Desktop
 
 # Download the module
-$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.14.1/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v1.15.0-beta.1/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
 


### PR DESCRIPTION
## [v1.15.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.15.0-beta.1)

### Added

- Support for [MongoDB.Driver](https://www.nuget.org/packages/MongoDB.Driver/)
  traces instrumentation for versions `3.7.0`+.
- Support for generic ADO.NET traces instrumentation.
- Support for [Microsoft.Data.Sqlite](https://www.nuget.org/packages/Microsoft.Data.Sqlite)
  `8.0.0+` traces instrumentation.
- Add support for file-based configuration file format version `1.0`.
- Add support for `OTEL_CONFIG_FILE` environment variable for file-based configuration.
  This variable takes precedence over the deprecated
  `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable.
- Configuration based instrumentation support dynamic evaluation for
  - span names,
  - attribute values,
  - statuses.
- Add file existence validation for file-based configuration.

### Changed

- MongoDB instrumentation for versions `3.7.0` is updated to comply with v1.39.0
  Semantic Convention
  - Renamed the `db.system` attribute to `db.system.name`,
  - Added `db.operation.batch.size` attribute,
  - Added the `db.response.status_code` and `error.type` attributes to error spans,
  - Removed the `network.peer.address` and `network.peer.port` attributes.
- Plugins limited to one instance per type.
- Improves allocation sampling behavior at startup for
  a more even distribution of samples.

#### Dependency updates

- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
  [`1.15.2`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.15.2).
- Following packages updated
  - `OpenTelemetry.Instrumentation.SqlClient` from `1.15.0` to `1.15.1`.
- .NET only, following packages updated
  - `OpenTelemetry.Instrumentation.AspNetCore` from `1.15.0` to `1.15.1`.

### Deprecated

- `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable for file-based
  configuration is deprecated. Use `OTEL_CONFIG_FILE` instead.

### Fixed

- Fixed configuration based instrumentation for some .NET Framework methods.
- Fixed .NET Framework assembly redirection startup by registering the loader
  before the application's entry point executes.
- Fixed various assembly resolution conflicts.
- When both `ENTITYFRAMEWORKCORE` and `NPGSQL` traces instrumentations are enabled,
  Entity Framework Core instrumentation now skips the
  `Npgsql.EntityFrameworkCore.PostgreSQL` provider so both instrumentations can
  stay enabled without conflicting spans.

## Tests

- [x] CI
- [x] MacOS with Linux Containers - passed with downgraded `Microsoft.CodeAnalysis.CSharp` to `5.0.0` (from `5.3.0`). I think that is local issue on my testing env, as it is working fine on CI
- [x] Windows with Linux Containers (with rerun, but it seems to be related to my fresh machine)

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.
