### PR TITLE
Release process - split attestation to smaller chunks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,9 @@ jobs:
           echo "Verifying checksums"
           sha256sum "./checksums.txt" --check || exit 1
 
-      - name: Attest artifacts
+      # actions/attest has a hard limit of 1024 subjects per step (no override).
+      # Keep attestations split into small batches to stay under this cap.
+      - name: Attest release files
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: |
@@ -115,13 +117,41 @@ jobs:
             ./otel-dotnet-auto-install.sh
             ./OpenTelemetry.DotNet.Auto.psm1
             ./checksums.txt
-            ./bin-alpine-x64/**/*
-            ./bin-alpine-arm64/**/*
-            ./bin-ubuntu-22.04/**/*
-            ./bin-ubuntu-22.04-arm/**/*
-            ./bin-windows-2022/**/*
-            ./bin-macos-14/**/*
-            ./bin-nuget-packages/**/*
+
+      - name: Attest bin-alpine-x64
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ./bin-alpine-x64/**/*
+
+      - name: Attest bin-alpine-arm64
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ./bin-alpine-arm64/**/*
+
+      - name: Attest bin-ubuntu-22.04
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ./bin-ubuntu-22.04/**/*
+
+      - name: Attest bin-ubuntu-22.04-arm
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ./bin-ubuntu-22.04-arm/**/*
+
+      - name: Attest bin-windows-2022
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ./bin-windows-2022/**/*
+
+      - name: Attest bin-macos-14
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ./bin-macos-14/**/*
+
+      - name: Attest bin-nuget-packages
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: ./bin-nuget-packages/**/*
 
       - name: Create Release
         env:


### PR DESCRIPTION
## Why

there is a hard limit to 1024 elements

Fixes #4926

## What

Release process - split attestation to smaller chunks

## Tests

Release process.

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
