### PR TITLE
Test - execute log4net with 3.3.0+ only

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -66,7 +66,6 @@ public static partial class LibraryVersion
         {
             "TestApplication.Log4NetBridge",
             [
-                new("2.0.13"),
                 new("3.3.0"),
             ]
         },

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -128,7 +128,6 @@ public static partial class LibraryVersion
 #if DEFAULT_TEST_PACKAGE_VERSIONS
                 string.Empty,
 #else
-                "2.0.13",
                 "3.3.0",
 #endif
             ];

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -98,7 +98,8 @@ internal static class PackageVersionDefinitions
             [
                 // versions below 2.0.10 have critical vulnerabilities
                 // versions below 2.0.13 have known bugs e.g. https://issues.apache.org/jira/browse/LOG4NET-652
-                new("2.0.13"),
+                // versions below 3.3.0 have known security vulnerabilities https://github.com/advisories/GHSA-4f7c-pmjv-c25w
+                new("3.3.0"),
                 new("*")
             ]
         },


### PR DESCRIPTION
## Why

all old versions are affected by https://github.com/advisories/GHSA-4f7c-pmjv-c25w

## What

Test - execute log4net with 3.3.0+ only

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
