### PR TITLE
Readme - fix terminology for opentelemetry.io page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -207,17 +207,17 @@ OTEL_SERVICE_NAME=myapp OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=sta
 ```
 
 NOTE: for air-gapped environments you can provide either the installation
-archive directly with:
+file directly with:
 
 ```sh
-LOCAL_PATH=<PATH_TO_ARCHIVE> sh ./otel-dotnet-auto-install.sh
+LOCAL_PATH=<PATH_TO_INSTALLER> sh ./otel-dotnet-auto-install.sh
 ```
 
-or the folder with the archives, this has the added benefit that the install
-script will determine the correct archive to choose.
+or the folder with the files, this has the added benefit that the install
+script will determine the correct file to choose.
 
 ```sh
-DOWNLOAD_DIR=<PATH_TO_FOLDER_WITH_ARCHIVES> sh ./otel-dotnet-auto-install.sh
+DOWNLOAD_DIR=<PATH_TO_FOLDER_WITH_FILES> sh ./otel-dotnet-auto-install.sh
 ```
 
 `otel-dotnet-auto-install.sh` script


### PR DESCRIPTION
## Why

Fix terminology: s/archive/file to align with docs.
