### PR TITLE
Do not reference OpenTelemetry.Instrumentation.AspNetCore for NuGet

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
+++ b/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
@@ -8,6 +8,12 @@
         TargetNuGetPackageVersionRange="[2.6.122, 3.0.0)"
         InstrumentationNuGetPackageId="OpenTelemetry.Instrumentation.StackExchangeRedis"
         InstrumentationNuGetPackageVersion="1.15.1-beta.1" />
+      <InstrumentationTarget
+        Include="Microsoft.AspNetCore.App"
+        Condition="!$(SkippedInstrumentations.Contains('Microsoft.AspNetCore.App'))"
+        TargetNuGetPackageVersionRange="*"
+        InstrumentationNuGetPackageId="OpenTelemetry.Instrumentation.AspNetCore"
+        InstrumentationNuGetPackageVersion="1.15.2" />
 
     </ItemGroup>
 
@@ -19,9 +25,16 @@
     Name="CheckForInstrumentationPackagesTarget"
     AfterTargets="ResolvePackageAssets">
 
+    <ItemGroup>
+      <OtelValidatePackages Include="@(RuntimeCopyLocalItems)" />
+      <OtelValidatePackages Include="@(RuntimeFramework)"
+                            NuGetPackageId="%(FrameworkName)"
+                            NuGetPackageVersion="%(Version)" />
+    </ItemGroup>
+
     <CheckForInstrumentationPackages
       InstrumentationTargetItems="@(InstrumentationTarget)"
-      RuntimeCopyLocalItems="@(RuntimeCopyLocalItems)"
+      RuntimeCopyLocalItems="@(OtelValidatePackages)"
       UseVerboseLog="$(UseVerboseLog)" />
   </Target>
 

--- a/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
+++ b/src/OpenTelemetry.AutoInstrumentation.BuildTasks/OpenTelemetry.AutoInstrumentation.BuildTasks.targets
@@ -28,8 +28,8 @@
     <ItemGroup>
       <OtelValidatePackages Include="@(RuntimeCopyLocalItems)" />
       <OtelValidatePackages Include="@(RuntimeFramework)"
-                            NuGetPackageId="%(FrameworkName)"
-                            NuGetPackageVersion="%(Version)" />
+                            NuGetPackageId="%(RuntimeFramework.FrameworkName)"
+                            NuGetPackageVersion="%(RuntimeFramework.Version)" />
     </ItemGroup>
 
     <CheckForInstrumentationPackages

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -55,8 +55,14 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+  <ItemGroup Condition="$(_IsPacking) != true And '$(TargetFramework)' == 'net8.0' ">
+    <!-- Dependencies below are shipped in the distribution folder, but not included in the NuGet package. -->
+    <!-- If necessary these packages are flagged by custom build tasks and manually added to the targeted  -->
+    <!-- projects that are using the NuGet package. -->
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
     <PackageReference Include="OpenTelemetry.Resources.Container" />
   </ItemGroup>

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(_IsPacking) != true">
+  <ItemGroup Condition="$(_IsPacking) == true">
     <!-- Dependencies below are shipped in the distribution folder, but not included in the NuGet package. -->
     <!-- If necessary these packages are flagged by custom build tasks and manually added to the targeted  -->
     <!-- projects that are using the NuGet package. -->
@@ -62,7 +62,7 @@
     <PackageReference Include="OpenTelemetry.Resources.Container" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(_IsPacking) != true And '$(TargetFramework)' == 'net8.0' ">
+  <ItemGroup Condition=" $(_IsPacking) == true And '$(TargetFramework)' == 'net8.0' ">
     <!-- Dependencies below are shipped in the distribution folder, but not included in the NuGet package. -->
     <!-- If necessary these packages are flagged by custom build tasks and manually added to the targeted  -->
     <!-- projects that are using the NuGet package. -->

--- a/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
+++ b/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj
@@ -17,14 +17,6 @@
     <Compile Remove="$(GeneratedFolder)/*/**/*.cs" />
   </ItemGroup>
 
-  <!-- Separate dependencies are to be shipped in the distribution but not in the NuGet package -->
-  <ItemGroup Condition="$(_IsPacking) != true">
-    <!-- Dependencies below are shipped in the distribution folder, but not included in the NuGet package. -->
-    <!-- If necessary these packages are flagged by custom build tasks and manually added to the targeted  -->
-    <!-- projects that are using the NuGet package. -->
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Api" />
@@ -38,6 +30,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" />
     <PackageReference Include="OpenTelemetry.Resources.Azure" />
     <PackageReference Include="OpenTelemetry.Resources.Host" />
@@ -48,6 +41,13 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" />
   </ItemGroup>
 
+  <ItemGroup Condition="$(_IsPacking) != true">
+    <!-- Dependencies below are shipped in the distribution folder, but not included in the NuGet package. -->
+    <!-- If necessary these packages are flagged by custom build tasks and manually added to the targeted  -->
+    <!-- projects that are using the NuGet package. -->
+    <PackageReference Update="OpenTelemetry.Instrumentation.StackExchangeRedis" PrivateAssets="all"/>
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System.ServiceModel" ExcludeAssets="all" />
     <Reference Include="System.Configuration" />
@@ -55,16 +55,18 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(_IsPacking) != true And '$(TargetFramework)' == 'net8.0' ">
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
+    <PackageReference Include="OpenTelemetry.Resources.Container" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(_IsPacking) != true And '$(TargetFramework)' == 'net8.0' ">
     <!-- Dependencies below are shipped in the distribution folder, but not included in the NuGet package. -->
     <!-- If necessary these packages are flagged by custom build tasks and manually added to the targeted  -->
     <!-- projects that are using the NuGet package. -->
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
-    <PackageReference Include="OpenTelemetry.Resources.Container" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" PrivateAssets="all"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
That PR opened to start discussion. It will be breaking change for all ASP.NET Core customer using our NuGet package - they will need to add OpenTelemetry.Instrumentation.AspNetCore package, which is controlled by our build task - which produce error if it is not done.
To make it usable, we probably should allow version range test for referenced package, to allow user reference newer package than expected version at release time.
Additional question - what is our policy for version controlling? Should we test for future versions - or should it be limited to known supported versions?
It is continuation of work started in #2554 and part of #2556.

## Why

Fixes #3911

## What

Do not reference OpenTelemetry.Instrumentation.AspNetCore in NuGet package automatically - instead validate it same way, as we do for reddis

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
