### PR TITLE
[infra] harden Nuke build scripts to usilize local copy of dotnet-install

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -17,6 +17,7 @@ $BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
 $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetInstallFileDefault = "$PSScriptRoot\scripts\dotnet-install.ps1"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
 $DotNetChannel = "STS"
 
@@ -38,11 +39,11 @@ if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
     $env:DOTNET_EXE = (Get-Command "dotnet").Path
 }
 else {
-    # Download install script
-    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
-    New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
+    # Use local install script (preferred) or explicit override
+    $DotNetInstallFile = if (Test-Path env:DOTNET_INSTALL_FILE) { $env:DOTNET_INSTALL_FILE } else { $DotNetInstallFileDefault }
+    if (!(Test-Path $DotNetInstallFile)) {
+        throw "dotnet installer script not found: $DotNetInstallFile`nPlace a trusted copy at scripts/dotnet-install.ps1 (or set DOTNET_INSTALL_FILE).`nReference URL for obtaining the script: $DotNetInstallUrl"
+    }
 
     # If global.json exists, load expected version
     if (Test-Path $DotNetGlobalFile) {

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
 TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_INSTALL_FILE_DEFAULT="$SCRIPT_DIR/scripts/dotnet-install.sh"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="STS"
 
@@ -32,10 +33,14 @@ if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
     DOTNET_EXE="$(command -v dotnet)"
     export DOTNET_EXE
 else
-    # Download install script
-    DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
-    mkdir -p "$TEMP_DIRECTORY"
-    curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+    # Use local install script (preferred) or explicit override
+    DOTNET_INSTALL_FILE="${DOTNET_INSTALL_FILE:-$DOTNET_INSTALL_FILE_DEFAULT}"
+    if [[ ! -f "$DOTNET_INSTALL_FILE" ]]; then
+        echo "dotnet installer script not found: $DOTNET_INSTALL_FILE" >&2
+        echo "Place a trusted copy at scripts/dotnet-install.sh (or set DOTNET_INSTALL_FILE)." >&2
+        echo "Reference URL for obtaining the script: $DOTNET_INSTALL_URL" >&2
+        exit 1
+    fi
     chmod +x "$DOTNET_INSTALL_FILE"
 
     # If global.json exists, load expected version


### PR DESCRIPTION
## Why

Codex with security plugins scans on this repository

## What

harden Nuke build scripts to usilize local copy of dotnet-install
It changes default scripts from the nuke, but we are using the local dotnet-install version in all other parts

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
