### PR TITLE
[infra] harden dotnet-install updater

### DIFF
--- a/.github/workflows/update-dotnet-install-script.yml
+++ b/.github/workflows/update-dotnet-install-script.yml
@@ -16,6 +16,7 @@ jobs:
       DOTNET_INSTALL_SCRIPT_URL: 'https://dot.net/v1/dotnet-install.sh'
       DOTNET_INSTALL_SCRIPT_GPG_KEY_URL: 'https://dot.net/v1/dotnet-install.asc'
       DOTNET_INSTALL_SCRIPT_SIGNATURE_URL: 'https://dot.net/v1/dotnet-install.sig'
+      DOTNET_INSTALL_SCRIPT_GPG_KEY_FINGERPRINT: '2B930AB1228D11D5D7F6B6ACB9CF1A51FC7D3ACF'
       GIT_COMMIT_USER_EMAIL: '197425009+otelbot[bot]@users.noreply.github.com'
       GIT_COMMIT_USER_NAME: 'otelbot[bot]'
       UPDATE_BRANCH_NAME: 'update-dotnet-install-script'
@@ -65,6 +66,16 @@ jobs:
 
         Invoke-WebRequest -Uri ${env:DOTNET_INSTALL_SCRIPT_GPG_KEY_URL} -MaximumRetryCount 5 -OutFile $KeyFileName | Out-Null
         Invoke-WebRequest -Uri ${env:DOTNET_INSTALL_SCRIPT_SIGNATURE_URL} -MaximumRetryCount 5 -OutFile $SignatureFileName | Out-Null
+
+        $ExpectedKeyFingerprint = ${env:DOTNET_INSTALL_SCRIPT_GPG_KEY_FINGERPRINT}.ToUpperInvariant()
+        $KeyFingerprints = @(gpg --show-keys --with-colons $KeyFileName |
+          Where-Object { $_.StartsWith("fpr:") } |
+          ForEach-Object { ($_ -split ":")[9].ToUpperInvariant() } |
+          Select-Object -Unique)
+
+        if ($KeyFingerprints.Count -ne 1 -or $KeyFingerprints[0] -ne $ExpectedKeyFingerprint) {
+          throw "Unexpected GPG key fingerprint in ${KeyFileName}. Expected ${ExpectedKeyFingerprint}, found $($KeyFingerprints -join ', ')."
+        }
 
         gpg --import $KeyFileName || throw "Failed to import GPG key."
         gpg --verify $SignatureFileName $InstallScriptFileName || throw "Failed to verify GPG signature."


### PR DESCRIPTION
## Why

Codex scans with security plugin.

## What

Pin the expected .NET install signing key fingerprint in the update workflow.
Before importing the downloaded key, the workflow now validates that its fingerprint matches the known trusted value, then verifies the script signature. This prevents accepting attacker-supplied key/signature pairs from the same endpoint and hardens the auto-update supply chain path.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
