### PR TITLE
Bump vendored YamlDotNet to 17.1.0 (from 17.0.0)

### DIFF
--- a/docs/internal/vendored-code.md
+++ b/docs/internal/vendored-code.md
@@ -21,6 +21,6 @@ To make vendored code fully internal, apply the following changes:
 `YamlDotNet` is needed for file-based configuration.
 
 * Source: <https://github.com/aaubry/YamlDotNet>
-* Version: `17.0.0`
+* Version: `17.1.0`
 * Content: Only the `YamlDotNet` folder is added to
   `src\OpenTelemetry.AutoInstrumentation\Vendors\YamlDotNet`.

--- a/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/AnchorName.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/AnchorName.cs
@@ -50,7 +50,7 @@ namespace Vendors.YamlDotNet.Core
                                             $"disallowed characters: []{{}},\nThe value was '{value}'.", nameof(value));
             }
 
-            this.value = string.Intern(value);
+            this.value = string.IsInterned(value) ?? value;
         }
 
         public override string ToString() => value ?? "[empty]";

--- a/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/Events/Scalar.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/Events/Scalar.cs
@@ -79,11 +79,8 @@ namespace Vendors.YamlDotNet.Core.Events
         public Scalar(AnchorName anchor, TagName tag, string value, ScalarStyle style, bool isPlainImplicit, bool isQuotedImplicit, Mark start, Mark end, bool isKey = false)
             : base(anchor, tag, start, end)
         {
-            // In a real client program, keys are likely to be
-            // interned already. Thus, IsInterned might work
-            // much better, but you can't really benchmark that.
             this.Value = isKey ?
-                    string.Intern(value) :
+                    string.IsInterned(value) ?? value :
                     value;
             this.Style = style;
             this.IsPlainImplicit = isPlainImplicit;

--- a/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/MergingParser.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/MergingParser.cs
@@ -36,13 +36,25 @@ namespace Vendors.YamlDotNet.Core
         private readonly IParser innerParser;
         private IEnumerator<LinkedListNode<ParsingEvent>> iterator;
         private bool merged;
+        private readonly int maxParsingEvents;
 
         public MergingParser(IParser innerParser)
+          : this(innerParser, 100_000)
         {
+        }
+
+        public MergingParser(IParser innerParser, int maxParsingEvents = 100_000)
+        {
+            if (maxParsingEvents <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxParsingEvents), "Max parsing events must be a positive integer.");
+            }
+
             events = new ParsingEventCollection();
             merged = false;
             iterator = events.GetEnumerator();
             this.innerParser = innerParser;
+            this.maxParsingEvents = maxParsingEvents;
         }
 
         public ParsingEvent? Current => iterator.Current?.Value;
@@ -64,7 +76,9 @@ namespace Vendors.YamlDotNet.Core
         {
             while (innerParser.MoveNext())
             {
-                events.Add(innerParser.Current!);
+                var parsingEvent = innerParser.Current!;
+                events.Add(parsingEvent);
+                EnsureMaxParsingEventsNotExceeded(parsingEvent);
             }
 
             foreach (var node in events)
@@ -126,7 +140,7 @@ namespace Vendors.YamlDotNet.Core
         {
             var mergedEvents = GetMappingEvents(anchorAlias.Value);
 
-            events.AddAfter(node, mergedEvents);
+            events.AddAfter(node, mergedEvents, EnsureMaxParsingEventsNotExceeded);
             events.MarkDeleted(anchorNode);
 
             return true;
@@ -165,6 +179,14 @@ namespace Vendors.YamlDotNet.Core
                 .Select(cloner.Clone);
         }
 
+        private void EnsureMaxParsingEventsNotExceeded(ParsingEvent parsingEvent)
+        {
+            if (events.Count > maxParsingEvents)
+            {
+                throw new YamlException(parsingEvent.Start, parsingEvent.End, $"Too many parsing events. The configured limit of {maxParsingEvents} was exceeded to prevent excessive memory usage.");
+            }
+        }
+
         private sealed class ParsingEventCollection : IEnumerable<LinkedListNode<ParsingEvent>>
         {
             private readonly LinkedList<ParsingEvent> events;
@@ -178,11 +200,14 @@ namespace Vendors.YamlDotNet.Core
                 references = [];
             }
 
-            public void AddAfter(LinkedListNode<ParsingEvent> node, IEnumerable<ParsingEvent> items)
+            public int Count => events.Count;
+
+            public void AddAfter(LinkedListNode<ParsingEvent> node, IEnumerable<ParsingEvent> items, Action<ParsingEvent> onItemAdded)
             {
                 foreach (var item in items)
                 {
                     node = events.AddAfter(node, item);
+                    onItemAdded(item);
                 }
             }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/TagName.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Vendors/YamlDotNet/Core/TagName.cs
@@ -49,7 +49,7 @@ namespace Vendors.YamlDotNet.Core
                 throw new ArgumentException("Tag value must not be empty.", nameof(value));
             }
 
-            this.value = string.Intern(value);
+            this.value = string.IsInterned(value) ?? value;
 
             if (IsGlobal && !Uri.IsWellFormedUriString(value, UriKind.RelativeOrAbsolute))
             {


### PR DESCRIPTION
## Why

https://github.com/aaubry/YamlDotNet/releases/tag/v17.1.0

## What

Bump vendored YamlDotNet to 17.1.0 (from 17.0.0)

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.
