### PR TITLE
[infra] Fix cmake installation on Ubuntu16.04

### DIFF
--- a/docker/ubuntu1604.dockerfile
+++ b/docker/ubuntu1604.dockerfile
@@ -26,11 +26,11 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
     apt-get install -y g++-9 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 
-# Install newer cmake, based on https://apt.kitware.com/
-RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg && \
-    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ xenial main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
-    apt-get update && \
-    apt-get install -y cmake
+# Install cmake 3.20.5 directly from GitHub releases (Kitware Xenial apt repo no longer serves cmake)
+RUN curl -fsSL -o cmake.sh https://github.com/Kitware/CMake/releases/download/v3.20.5/cmake-3.20.5-linux-x86_64.sh && \
+    echo "f582e02696ceee81818dc3378531804b2213ed41c2a8bc566253d16d894cefab  cmake.sh" | sha256sum -c - && \
+    sh cmake.sh --skip-license --prefix=/usr/local && \
+    rm cmake.sh
 
 COPY ./scripts/dotnet-install.sh ./dotnet-install.sh
 


### PR DESCRIPTION
## Why

The Kitware apt repository for Ubuntu 16.04 (Xenial) stopped serving cmake packages around April 28, 2026. When apt-get install cmake ran, it fell back to the Ubuntu archive's cmake 3.5.1, which is below the cmake_minimum_required(3.10) requirement in CMakeLists.txt.

## What

Replace the Kitware apt repository install with a direct binary download from GitHub Releases, pinning to the same version (3.20.5) that was previously installed from the Kitware repo. A SHA-256 checksum is verified before executing the installer.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
