### PR TITLE
fix: remove dead nuget-version-suffix references from build-nuget-packages workflow

### DIFF
--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -2,11 +2,6 @@ name: Build NuGet Packages
 
 on:
   workflow_call:
-    outputs:
-      # Output the NuGet version suffix so that the caller workflow can have the correct package version.
-      nuget-version-suffix:
-        description: "The NuGet version suffix to build the packages"
-        value: ${{ jobs.build-nuget-packages.outputs.nuget-version-suffix }}
 
 permissions:
   contents: read
@@ -19,8 +14,6 @@ jobs:
   build-nuget-packages:
     # In principle this job needs the build outputs, however that would cause the upstream reusable workflow
     # to run twice. Instead, we let the caller workflow handle the dependencies.
-    outputs:
-      nuget-version-suffix: ${{ steps.set-nuget-version-suffix.outputs.suffix }}
     runs-on: windows-2022
     steps:
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -83,7 +83,7 @@ jobs:
           set -e
           mkdir testapp
           cd testapp
-          echo '<Project />' > Directory.Build.props
+          echo "<Project />" > Directory.Build.props
           dotnet new console
           dotnet publish -f net10.0 -c Release
           curl -sSfL https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/otel-dotnet-auto-install.sh -O


### PR DESCRIPTION
Fixes #5001

The `set-nuget-version-suffix` step was removed in #2772 but two dead 
references remained:

- `workflow_call.outputs.nuget-version-suffix` referencing 
  `jobs.build-nuget-packages.outputs.nuget-version-suffix`
- `jobs.build-nuget-packages.outputs.nuget-version-suffix` referencing 
  `steps.set-nuget-version-suffix.outputs.suffix`

Both have been removed.