### PR TITLE
Bump .NET SDK to 10.0.300/9.0.314/8.0.412

### DIFF
--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -8,6 +8,6 @@ runs:
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # tag: v5.2.0
       with:
         dotnet-version: |
-          8.0.420
-          9.0.313
-          10.0.203
+          8.0.421
+          9.0.314
+          10.0.300

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23@sha256:0191ff386e93923edf795d363ea0ae0669ce467ada4010b370644b670fa495c1
+FROM mcr.microsoft.com/dotnet/sdk:10.0.300-alpine3.23@sha256:5c559aa5d99337e400d39ab4fa1f6979d126c29b20939d53658ed38300571e74
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache --update \
@@ -20,8 +20,8 @@ COPY ./scripts/dotnet-install.sh ./dotnet-install.sh
 
 # Install older SDKs using the install script
 RUN chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 9.0.313 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh -v 8.0.420 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 9.0.314 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 8.0.421 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 WORKDIR /project

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9@sha256:d5b319ece56684157ce9a09a857ad7002794159f572c890005cddeb2c5043b1f
+FROM quay.io/centos/centos:stream9@sha256:dbd9d8293d90c33829dab178cb2713218855c11d30353ea1b2e06fb168a7ceba
 
 # Install dotnet sdk
 RUN dnf install -y \

--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -7,9 +7,9 @@ RUN dnf install -y \
 COPY ./scripts/dotnet-install.sh ./dotnet-install.sh
 
 RUN chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 10.0.203 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh -v 9.0.313 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh -v 8.0.420 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 10.0.300 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 9.0.314 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 8.0.421 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 ENV PATH="$PATH:/usr/share/dotnet"

--- a/docker/debian-arm64.dockerfile
+++ b/docker/debian-arm64.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.313-bookworm-slim@sha256:f9ddb8a31ae90f4b38d18355d82f03d76dcdd2a57d7235a2ffdf008fab11a862
+FROM mcr.microsoft.com/dotnet/sdk:9.0.314-bookworm-slim@sha256:087fc98e5c6ffcea6c3e276c135c4a6717c589d9509a09cc22e7c634830a4db8
 # There is no official base image for .NET SDK 10+ on Debian, so install .NET10 via dotnet-install
 
 RUN apt-get update && \
@@ -11,8 +11,8 @@ COPY ./scripts/dotnet-install.sh ./dotnet-install.sh
 
 # Install older SDKs using the install script as there are no arm64 SDK packages.
 RUN chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 10.0.203 --install-dir /usr/share/dotnet --no-path \
-    && ./dotnet-install.sh -v 8.0.420 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 10.0.300 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 8.0.421 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 WORKDIR /project

--- a/docker/debian.dockerfile
+++ b/docker/debian.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.313-bookworm-slim@sha256:f9ddb8a31ae90f4b38d18355d82f03d76dcdd2a57d7235a2ffdf008fab11a862
+FROM mcr.microsoft.com/dotnet/sdk:9.0.314-bookworm-slim@sha256:087fc98e5c6ffcea6c3e276c135c4a6717c589d9509a09cc22e7c634830a4db8
 # There is no official base image for .NET SDK 10+ on Debian, so install .NET10 via apt-get
 
 RUN wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \

--- a/docker/ubuntu1604.dockerfile
+++ b/docker/ubuntu1604.dockerfile
@@ -35,7 +35,7 @@ RUN curl -fsSL -o cmake.sh https://github.com/Kitware/CMake/releases/download/v3
 COPY ./scripts/dotnet-install.sh ./dotnet-install.sh
 
 RUN chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh -v 9.0.313 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh -v 9.0.314 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 ENV IsLegacyUbuntu=true

--- a/examples/demo/Dockerfile
+++ b/examples/demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.203-noble@sha256:adc02be8b87957d07208a4a3e51775935b33bad3317de8c45b1e67357b4c073b
+FROM mcr.microsoft.com/dotnet/sdk:10.0.300-noble@sha256:dc8430e6024d454edadad1e160e1973be3cabbb7125998ef190d9e5c6adf7dbb
 
 # install OpenTelemetry .NET Automatic Instrumentation
 ARG OTEL_VERSION=1.15.0

--- a/src/OpenTelemetry.AutoInstrumentation/Generated/net8.0/System.Text.RegularExpressions.Generator/System.Text.RegularExpressions.Generator.RegexGenerator/RegexGenerator.g.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Generated/net8.0/System.Text.RegularExpressions.Generator/System.Text.RegularExpressions.Generator.RegexGenerator/RegexGenerator.g.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguratio
         /// ○ Match '}'.<br/>
         /// </code>
         /// </remarks>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.16921")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.22922")]
         private static partial global::System.Text.RegularExpressions.Regex GetEnvVarRegex() => global::System.Text.RegularExpressions.Generated.GetEnvVarRegex_0.Instance;
     }
 }
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Instrumentation
         /// ○ Match if at the end of the string or if before an ending newline.<br/>
         /// </code>
         /// </remarks>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.16921")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.22922")]
         private static partial global::System.Text.RegularExpressions.Regex DataSourceRegex() => global::System.Text.RegularExpressions.Generated.DataSourceRegex_1.Instance;
     }
 }
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Instrumentation
         /// ○ Match '\\'.<br/>
         /// </code>
         /// </remarks>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.16921")]
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.22922")]
         private static partial global::System.Text.RegularExpressions.Regex NamedPipeRegex() => global::System.Text.RegularExpressions.Generated.NamedPipeRegex_2.Instance;
     }
 }
@@ -104,7 +104,7 @@ namespace System.Text.RegularExpressions.Generated
     using System.Threading;
 
     /// <summary>Custom <see cref="Regex"/>-derived type for the GetEnvVarRegex method.</summary>
-    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.16921")]
+    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.22922")]
     file sealed class GetEnvVarRegex_0 : Regex
     {
         /// <summary>Cached, thread-safe singleton instance.</summary>
@@ -385,7 +385,7 @@ namespace System.Text.RegularExpressions.Generated
     }
     
     /// <summary>Custom <see cref="Regex"/>-derived type for the DataSourceRegex method.</summary>
-    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.16921")]
+    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.22922")]
     file sealed class DataSourceRegex_1 : Regex
     {
         /// <summary>Cached, thread-safe singleton instance.</summary>
@@ -1039,7 +1039,7 @@ namespace System.Text.RegularExpressions.Generated
     }
     
     /// <summary>Custom <see cref="Regex"/>-derived type for the NamedPipeRegex method.</summary>
-    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.16921")]
+    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.22922")]
     file sealed class NamedPipeRegex_2 : Regex
     {
         /// <summary>Cached, thread-safe singleton instance.</summary>
@@ -1200,7 +1200,7 @@ namespace System.Text.RegularExpressions.Generated
     }
     
     /// <summary>Helper methods used by generated <see cref="Regex"/>-derived implementations.</summary>
-    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.16921")]
+    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "8.0.14.22922")]
     file static class Utilities
     {
         /// <summary>Default timeout value set in <see cref="AppContext"/>, or <see cref="Regex.InfiniteMatchTimeout"/> if none was set.</summary>

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedTracesSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedTracesSettingsTests.cs
@@ -14,8 +14,8 @@ public class FilebasedTracesSettingsTests
 {
     public static TheoryData<SkipConfigurationTestCase> LoadMethod_SkipWrongExporterConfiguration_Data()
     {
-        return
-        [
+        return new TheoryData<SkipConfigurationTestCase>
+        {
             new(new YamlConfiguration
             {
                 TracerProvider = new TracerProviderConfiguration
@@ -224,7 +224,7 @@ public class FilebasedTracesSettingsTests
                     ]
                 }
             }),
-        ];
+        };
     }
 
     [Fact]

--- a/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
+++ b/test/test-applications/integrations/TestApplication.MongoDB/TestApplication.MongoDB.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="MongoDB.Driver" VersionOverride="$(LibraryVersion)" />
     <!-- Snappier is transitive dependency of MongoDB.Driver. All versions up to 3.8.0 references v1.0.0
     All versions pruor to 1.3.1 are vulnerable for https://github.com/advisories/GHSA-pggp-6c3x-2xmx -->
-    <PackageReference Include="Snappier"  Condition="'$(OS)' == 'Windows_NT' and '$(LibraryVersion)' != '' and $([MSBuild]::VersionLessThan('$(LibraryVersion)', '3.8.1'))" />
+    <PackageReference Include="Snappier"  Condition="'$(LibraryVersion)' != '' and $([MSBuild]::VersionLessThan('$(LibraryVersion)', '3.8.1'))" />
     <!-- SharpCompress is a transitive dependency of MongoDB.Driver. Version up to 0.47.4 are vulnerable.
     for https://github.com/advisories/GHSA-6c8g-7p36-r338 -->
     <PackageReference Include="SharpCompress" />


### PR DESCRIPTION
## Why & What

Bump .NET SDK to 10.0.300/9.0.314/8.0.412

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
