### PR TITLE
Update .NET Framework docker images

### DIFF
--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9@sha256:dbd9d8293d90c33829dab178cb2713218855c11d30353ea1b2e06fb168a7ceba
+FROM quay.io/centos/centos:stream9@sha256:9432fef2ceeff573ac2fae04778afbeb955f3d31b2c0fae4f3d15f56d3473f24
 
 # Install dotnet sdk
 RUN dnf install -y \

--- a/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.AspNet.NetFramework/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:84079c734ab5aec702409ef7967ec47af9468c56ff4046882239cabacda78097 AS integrated-base
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:ec04e733695f49a0dc9132184f6b06704866b34f422004093c1972512c86259e AS integrated-base
 ARG configuration=Debug
 ARG platform=x64
 WORKDIR /opentelemetry

--- a/test/test-applications/integrations/TestApplication.Owin.IIS.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.Owin.IIS.NetFramework/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:84079c734ab5aec702409ef7967ec47af9468c56ff4046882239cabacda78097
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022@sha256:ec04e733695f49a0dc9132184f6b06704866b34f422004093c1972512c86259e
 ARG configuration=Debug
 ARG platform=x64
 WORKDIR /opentelemetry

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/Dockerfile
@@ -1,7 +1,6 @@
 # escape=`
 
-FROM mcr.microsoft.com/dotnet/framework/wcf:4.8-windowsservercore-ltsc2022@sha256:5ae98afc5e31680c31662897ee453655f103f5923588991017bc561bc6312e08
-ARG configuration=Debug
+FROM mcr.microsoft.com/dotnet/framework/wcf:4.8-windowsservercore-ltsc2022@sha256:966b3863c9e3605f9c0dbbc883cddd3b287d50feded8f85060b3d583ccd26aa6
 ARG platform=x64
 WORKDIR /opentelemetry
 COPY bin/tracer.zip .

--- a/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/Dockerfile
+++ b/test/test-applications/integrations/TestApplication.Wcf.Server.IIS.NetFramework/Dockerfile
@@ -1,6 +1,7 @@
 # escape=`
 
 FROM mcr.microsoft.com/dotnet/framework/wcf:4.8-windowsservercore-ltsc2022@sha256:966b3863c9e3605f9c0dbbc883cddd3b287d50feded8f85060b3d583ccd26aa6
+ARG configuration=Debug
 ARG platform=x64
 WORKDIR /opentelemetry
 COPY bin/tracer.zip .


### PR DESCRIPTION
## Why &  What

Update .NET Framework docker images. Downloading old versions was failing from time to time on the CI.

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
