### PR TITLE
[Infra] Add zizmor scan workflow and address findings

### DIFF
--- a/.github/actions/prepare-build-environment/action.yml
+++ b/.github/actions/prepare-build-environment/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Set up Docker Buildx
       if: inputs.environment-type == 'container'
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # tag: v4.0.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Resolve image name
       if: inputs.environment-type == 'container'
@@ -61,7 +61,7 @@ runs:
 
     - name: Build Docker image
       if: inputs.environment-type == 'container'
-      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # tag: v7.1.0
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
       with:
         context: .
         file: ${{ inputs.dockerfile }}

--- a/.github/actions/replace-build-artifacts/action.yml
+++ b/.github/actions/replace-build-artifacts/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Download replacement artifacts
       if: inputs.replace-artifacts != ''
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: bin/ci-artifacts/replacements
 

--- a/.github/actions/run-command-in-environment/action.yml
+++ b/.github/actions/run-command-in-environment/action.yml
@@ -3,7 +3,7 @@ description: Run a shell command on the host or inside an existing Docker contai
 
 inputs:
   execution-mode:
-    description: Either `container` or a shell name. If empty, defaults to `container` when container-name is set, otherwise uses `pwsh` on Windows and `bash` on non-Windows runners.
+    description: Either `container`, `bash`, `sh`, `pwsh`, or `powershell`. If empty, defaults to `container` when container-name is set, otherwise uses `pwsh` on Windows and `bash` on non-Windows runners.
     required: false
     default: ""
   container-name:
@@ -36,6 +36,10 @@ runs:
           throw 'container-name input is required when execution-mode is container.'
         }
 
+        if (-not [string]::IsNullOrEmpty($executionMode) -and $executionMode -notin @('container', 'bash', 'sh', 'pwsh', 'powershell')) {
+          throw "execution-mode must be empty or one of 'container', 'bash', 'sh', 'pwsh', or 'powershell'."
+        }
+
         if (-not [string]::IsNullOrEmpty($containerName) -and -not [string]::IsNullOrEmpty($executionMode) -and $executionMode -ne 'container') {
           throw 'container-name cannot be combined with a non-container execution-mode.'
         }
@@ -48,20 +52,44 @@ runs:
         CONTAINER_NAME: ${{ inputs.container-name }}
         CONTAINER_USER: ${{ inputs.container-user }}
 
-    - name: Run on host with default Windows shell
-      if: inputs.execution-mode == '' && inputs.container-name == '' && runner.os == 'Windows'
+    - name: Run on host
+      if: inputs.execution-mode != 'container' && inputs.container-name == ''
       shell: pwsh
-      run: ${{ inputs.run }}
+      run: |
+        $executionMode = $env:EXECUTION_MODE
 
-    - name: Run on host with default non-Windows shell
-      if: inputs.execution-mode == '' && inputs.container-name == '' && runner.os != 'Windows'
-      shell: bash
-      run: ${{ inputs.run }}
+        if ([string]::IsNullOrEmpty($executionMode)) {
+          $executionMode = if ($env:RUNNER_OS -eq 'Windows') { 'pwsh' } else { 'bash' }
+        }
 
-    - name: Run on host with explicit shell
-      if: inputs.execution-mode != '' && inputs.execution-mode != 'container'
-      shell: ${{ inputs.execution-mode }}
-      run: ${{ inputs.run }}
+        switch ($executionMode) {
+          'pwsh' {
+            $scriptPath = Join-Path $env:RUNNER_TEMP 'run-command-in-environment.ps1'
+            Set-Content -Path $scriptPath -Value $env:RUN_COMMAND -NoNewline
+            & pwsh -NoLogo -NoProfile -NonInteractive -File $scriptPath
+          }
+          'powershell' {
+            $scriptPath = Join-Path $env:RUNNER_TEMP 'run-command-in-environment.ps1'
+            Set-Content -Path $scriptPath -Value $env:RUN_COMMAND -NoNewline
+            & powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $scriptPath
+          }
+          'bash' {
+            $scriptPath = Join-Path $env:RUNNER_TEMP 'run-command-in-environment.sh'
+            Set-Content -Path $scriptPath -Value $env:RUN_COMMAND -NoNewline
+            & bash $scriptPath
+          }
+          'sh' {
+            $scriptPath = Join-Path $env:RUNNER_TEMP 'run-command-in-environment.sh'
+            Set-Content -Path $scriptPath -Value $env:RUN_COMMAND -NoNewline
+            & sh $scriptPath
+          }
+          default {
+            throw "Unsupported execution-mode '$executionMode'."
+          }
+        }
+      env:
+        EXECUTION_MODE: ${{ inputs.execution-mode }}
+        RUN_COMMAND: ${{ inputs.run }}
 
     - name: Run in container
       if: inputs.execution-mode == 'container' || (inputs.execution-mode == '' && inputs.container-name != '')

--- a/.github/actions/setup-dotnet/action.yml
+++ b/.github/actions/setup-dotnet/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # tag: v5.2.0
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: |
           8.0.421

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,22 +2,30 @@ version: 2
 updates:
 
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 3
     directory: /
     schedule:
       interval: "daily"
 
   # Maintain dependencies for Dockerfiles used in build pipeline
   - package-ecosystem: docker
+    cooldown:
+      default-days: 3
     directory: /docker
     schedule:
       interval: "daily"
 
   - package-ecosystem: docker
+    cooldown:
+      default-days: 3
     directory: /test/IntegrationTests/docker
     schedule:
       interval: "daily"
 
   - package-ecosystem: nuget
+    cooldown:
+      default-days: 3
     directory: /
     schedule:
       interval: "daily"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,19 @@
   additionalBranchPrefix: "{{manager}}/",
   commitBodyTable: true,
   commitMessageAction: "Bump",
+  customManagers: [
+    {
+      customType: "regex",
+      description: ["Update GitHub runner labels in workflow fields and matrix values"],
+      managerFilePatterns: [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/",
+      ],
+      matchStrings: [
+        "# renovate:\\s*datasource=(?<datasource>github-runners)(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*?(?:\\s+versioning=(?<versioning>[^\\s]+))?(?:\\s+[A-Za-z][A-Za-z0-9_-]*=[^\\s]+)*\\s*\\r?\\n\\s*(?:-\\s*)?(?:[A-Za-z0-9_-]+:\\s*)?['\"]?(?<depName>[a-zA-Z]+)-(?<currentValue>[A-Za-z0-9._-]+)['\"]?",
+      ],
+    },
+  ],
   dependencyDashboard: false,
   extends: ["config:best-practices"],
   labels: ["dependencies"],

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -61,7 +61,7 @@ jobs:
     env:
       SMOKE_TEST_APPLICATION: ./test/test-applications/integrations/bin/TestApplication.Smoke/Release/net10.0/publish/TestApplication.Smoke
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -62,9 +62,10 @@ jobs:
       SMOKE_TEST_APPLICATION: ./test/test-applications/integrations/bin/TestApplication.Smoke/Release/net10.0/publish/TestApplication.Smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
+          persist-credentials: false
 
       - name: Set build script
         shell: pwsh
@@ -87,7 +88,7 @@ jobs:
           dockerfile: ${{ inputs.dockerfile }}
 
       - name: Check for NuGet packages cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nuget-cache
         with:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
@@ -111,7 +112,7 @@ jobs:
 
       - name: Cache NuGet packages
         if: ${{ steps.nuget-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
           path: ${{ env.NUGET_PACKAGES }}
@@ -166,7 +167,7 @@ jobs:
 
       - name: Upload binaries
         if: ${{ always() && (inputs.environment-type != 'container' || !cancelled()) }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bin-${{ inputs.artifact-name }}
           path: bin/tracer-home
@@ -174,7 +175,7 @@ jobs:
 
       - name: Upload installation scripts
         if: ${{ always() && inputs.environment-type == 'host' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: installation-scripts-${{ inputs.artifact-name }}
           path: bin/installation-scripts

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -12,58 +12,60 @@ env:
 
 jobs:
   build-nuget-packages:
+    name: build-nuget-packages
     # In principle this job needs the build outputs, however that would cause the upstream reusable workflow
     # to run twice. Instead, we let the caller workflow handle the dependencies.
     runs-on: windows-2022
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nuget-cache
         with:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Download Windows Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-windows-2022
           path: bin/ci-artifacts/bin-windows-2022
 
       - name: Download Ubuntu x64 Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-ubuntu-22.04
           path: bin/ci-artifacts/bin-ubuntu-22.04
 
       - name: Download Ubuntu arm64 Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-ubuntu-22.04-arm
           path: bin/ci-artifacts/bin-ubuntu-22.04-arm
 
       - name: Download Alpine x64 Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-alpine-x64
           path: bin/ci-artifacts/bin-alpine-x64
 
       - name: Download Alpine arm64 Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-alpine-arm64
           path: bin/ci-artifacts/bin-alpine-arm64
 
       - name: Download Mac-OS Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-macos-14
           path: bin/ci-artifacts/bin-macos-14
@@ -92,7 +94,7 @@ jobs:
           }
         
       - name: Upload NuGet Artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bin-nuget-packages
           path: bin/nuget-artifacts/

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -12,13 +12,13 @@ env:
 
 jobs:
   build-nuget-packages:
-    name: build-nuget-packages
+    name: Build NuGet packages
     # In principle this job needs the build outputs, however that would cause the upstream reusable workflow
     # to run twice. Instead, we let the caller workflow handle the dependencies.
     runs-on: windows-2022
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version

--- a/.github/workflows/build-ubuntu1604-native-container.yml
+++ b/.github/workflows/build-ubuntu1604-native-container.yml
@@ -12,13 +12,15 @@ env:
 
 jobs:
   build-ubuntu1604-native-container:
+    name: build-ubuntu1604-native-container
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
+          persist-credentials: false
 
       - name: Prepare build environment
         id: prepare-build-environment
@@ -41,7 +43,7 @@ jobs:
 
       - name: Publish native library Linux build
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bin-ubuntu1604-native
           path: bin/tracer-home

--- a/.github/workflows/build-ubuntu1604-native-container.yml
+++ b/.github/workflows/build-ubuntu1604-native-container.yml
@@ -12,11 +12,11 @@ env:
 
 jobs:
   build-ubuntu1604-native-container:
-    name: build-ubuntu1604-native-container
+    name: Build native container on Ubuntu 16.04
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version

--- a/.github/workflows/check-sdk-versions.yml
+++ b/.github/workflows/check-sdk-versions.yml
@@ -16,11 +16,11 @@ permissions:
 
 jobs:
   check-sdk-versions:
-    name: check-sdk-versions
+    name: Check .NET SDK versions
     runs-on: windows-latest
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/check-sdk-versions.yml
+++ b/.github/workflows/check-sdk-versions.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   check-sdk-versions:
     name: check-sdk-versions # Matches required status check
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
 
       - name: Checkout code

--- a/.github/workflows/check-sdk-versions.yml
+++ b/.github/workflows/check-sdk-versions.yml
@@ -7,16 +7,23 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   check-sdk-versions:
+    name: check-sdk-versions
     runs-on: windows-latest
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet

--- a/.github/workflows/check-sdk-versions.yml
+++ b/.github/workflows/check-sdk-versions.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check-sdk-versions:
-    name: Check .NET SDK versions
+    name: check-sdk-versions # Matches required status check
     runs-on: windows-latest
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,25 +20,25 @@ permissions:
 
 jobs:
   build-ubuntu1604-native:
-    name: build-ubuntu1604-native
+    name: Build native on Ubuntu 16.04 container
     uses: ./.github/workflows/build-ubuntu1604-native-container.yml
 
   build-windows:
-    name: build-windows
+    name: Build on Windows
     uses: ./.github/workflows/build-windows.yml
 
   build:
-    name: build
+    name: Build
     needs: [ build-windows, build-ubuntu1604-native ]
     uses: ./.github/workflows/build.yml
 
   build-nuget-packages:
-    name: build-nuget-packages
+    name: Build NuGet packages
     needs: [ build-windows, build ]
     uses: ./.github/workflows/build-nuget-packages.yml
 
   test-build-managed:
-    name: test-build-managed
+    name: Test ${{ matrix.test-tfm }} on ${{ matrix.machine }} (managed)
     needs: [ build-windows, build ]
     strategy:
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.machine }}
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
@@ -119,7 +119,7 @@ jobs:
         run: rm SqlLocalDB.msi
 
   test-build-native:
-    name: test-build-native
+    name: Test on ${{ matrix.machine }} (native)
     needs: build-windows
     strategy:
       fail-fast: false
@@ -132,7 +132,7 @@ jobs:
     runs-on: ${{ matrix.machine }}
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
@@ -158,7 +158,7 @@ jobs:
         run: ./build.cmd NativeTests
 
   test-build-windows-container-tests:
-    name: test-build-windows-container-tests
+    name: Test Windows container on ${{ matrix.machine }}
     needs: build-windows
     strategy:
       fail-fast: false
@@ -173,7 +173,7 @@ jobs:
     runs-on: ${{ matrix.machine }}
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
@@ -215,7 +215,7 @@ jobs:
           path: test-artifacts/
 
   test-build-container:
-    name: test-build-container
+    name: Test in container on ${{ matrix.machine }} (${{ matrix.os-type }}) with ${{ matrix.base-image }}
     needs: build
     strategy:
       fail-fast: false
@@ -245,7 +245,7 @@ jobs:
     timeout-minutes: 60
     steps:
 
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0 # fetching all, needed to correctly calculate version
@@ -275,7 +275,7 @@ jobs:
         path: test-artifacts/
 
   test-nuget-packages:
-    name: test-nuget-packages
+    name: Test NuGet packages on ${{ matrix.machine }}
     needs: build-nuget-packages
     strategy:
       fail-fast: false
@@ -289,7 +289,7 @@ jobs:
     runs-on: ${{ matrix.machine }}
     steps:
       
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
@@ -322,7 +322,7 @@ jobs:
           path: test-artifacts/
 
   test-jobs:
-    name: test-jobs
+    name: test-jobs # Matches required status check
     runs-on: ubuntu-22.04
     needs:
       - test-build-managed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
       fail-fast: false
       matrix:
         test-tfm: [ net10.0, net9.0, net8.0, net462 ]
-        machine: [ windows-2022, windows-2025, ubuntu-22.04, macos-14, ubuntu-22.04-arm ]
+        machine:
+        - windows-2022
+        - windows-2025
+        - macos-14
+        - ubuntu-22.04
+        - ubuntu-22.04-arm
         exclude:
           - test-tfm: net462
             machine: macos-14
@@ -282,10 +287,10 @@ jobs:
       matrix:
         include:
           - machine: ubuntu-22.04
+          - machine: ubuntu-22.04-arm
           - machine: macos-14
           - machine: windows-2022
           - machine: windows-2025
-          - machine: ubuntu-22.04-arm
     runs-on: ${{ matrix.machine }}
     steps:
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/packages
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -16,20 +20,25 @@ permissions:
 
 jobs:
   build-ubuntu1604-native:
+    name: build-ubuntu1604-native
     uses: ./.github/workflows/build-ubuntu1604-native-container.yml
 
   build-windows:
+    name: build-windows
     uses: ./.github/workflows/build-windows.yml
 
   build:
+    name: build
     needs: [ build-windows, build-ubuntu1604-native ]
     uses: ./.github/workflows/build.yml
 
   build-nuget-packages:
+    name: build-nuget-packages
     needs: [ build-windows, build ]
     uses: ./.github/workflows/build-nuget-packages.yml
 
   test-build-managed:
+    name: test-build-managed
     needs: [ build-windows, build ]
     strategy:
       fail-fast: false
@@ -63,38 +72,43 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nuget-cache
         with:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Download Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-${{ matrix.artifact-name }}
           path: bin/tracer-home
 
       - name: Install SQL Server (localdb)
         if: ${{ runner.os == 'Windows' }}
-        uses: potatoqualitee/mssqlsuite@2291d923e83859edd871679c05b379037376761f # tag: v1.12
+        uses: potatoqualitee/mssqlsuite@2291d923e83859edd871679c05b379037376761f # v1.12
         with: 
           install: localdb
 
       - name: Run TestWorkflow
-        run: ./build.cmd --skip NativeTests --target TestWorkflow --test-target-framework ${{ matrix.test-tfm }} --containers ${{ matrix.containers }}
+        shell: bash
+        env:
+          CONTAINERS: ${{ matrix.containers }}
+          TEST_TARGET_FRAMEWORK: ${{ matrix.test-tfm }}
+        run: ./build.cmd --skip NativeTests --target TestWorkflow --test-target-framework "${TEST_TARGET_FRAMEWORK}" --containers "${CONTAINERS}"
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ matrix.machine }}-${{ matrix.test-tfm }}-containers-${{ matrix.containers }}
           path: test-artifacts/
@@ -105,6 +119,7 @@ jobs:
         run: rm SqlLocalDB.msi
 
   test-build-native:
+    name: test-build-native
     needs: build-windows
     strategy:
       fail-fast: false
@@ -118,22 +133,23 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nuget-cache
         with:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Download Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-${{ matrix.artifact-name }}
           path: bin/tracer-home
@@ -142,6 +158,7 @@ jobs:
         run: ./build.cmd NativeTests
 
   test-build-windows-container-tests:
+    name: test-build-windows-container-tests
     needs: build-windows
     strategy:
       fail-fast: false
@@ -157,40 +174,48 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nuget-cache
         with:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Download Artifacts from build job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-${{ matrix.artifact-name }}
           path: bin/tracer-home
 
       - name: Build artifacts required for the test (no native tests)
-        run: ./build.cmd --skip RunManagedTests --target ManagedTests --containers ${{ matrix.containers }}
+        shell: bash
+        env:
+          CONTAINERS: ${{ matrix.containers }}
+        run: ./build.cmd --skip RunManagedTests --target ManagedTests --containers "${CONTAINERS}"
 
       - name: Run the integration tests
-        run: ./build.cmd --target RunManagedIntegrationTests --containers ${{ matrix.containers }} --test-target-framework net462
+        shell: bash
+        env:
+          CONTAINERS: ${{ matrix.containers }}
+        run: ./build.cmd --target RunManagedIntegrationTests --containers "${CONTAINERS}" --test-target-framework net462
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-${{ matrix.machine }}-containers-${{ matrix.containers }}
           path: test-artifacts/
 
   test-build-container:
+    name: test-build-container
     needs: build
     strategy:
       fail-fast: false
@@ -221,12 +246,13 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0 # fetching all, needed to correctly calculate version
+        persist-credentials: false
 
     - name: Download Artifacts from build job
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: bin-${{ matrix.build-source }}
         path: bin/tracer-home
@@ -243,12 +269,13 @@ jobs:
 
     - name: Upload test logs
       if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-logs-container-${{ matrix.machine }}-${{ matrix.base-image }}
         path: test-artifacts/
 
   test-nuget-packages:
+    name: test-nuget-packages
     needs: build-nuget-packages
     strategy:
       fail-fast: false
@@ -263,22 +290,23 @@ jobs:
     steps:
       
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetching all, needed to correctly calculate version
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nuget-cache
         with:
           key: ${{ hashFiles('**/Directory.packages.props', './build/LibraryVersions.g.cs', '**/packages.config' ) }}
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Download NuGet Artifacts from build-nuget-packages job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bin-nuget-packages
           path: bin/nuget-artifacts/
@@ -288,12 +316,13 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-logs-nuget-packages-${{ matrix.machine }}
           path: test-artifacts/
 
   test-jobs:
+    name: test-jobs
     runs-on: ubuntu-22.04
     needs:
       - test-build-managed

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
         maximum-size: 32GB
         disk-root: "D:"
 
-    - name: Checkout repository
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         filter: 'tree:0'
@@ -76,7 +76,7 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    - name: Setup dotnet
+    - name: Setup .NET
       uses: ./.github/actions/setup-dotnet
       if: matrix.language == 'csharp'
 
@@ -96,7 +96,7 @@ jobs:
         category: "/language:${{matrix.language}}"
 
   results:
-    name: results
+    name: results # Matches required status check
     if: ${{ !cancelled() }}
     needs: [ analyze ]
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,12 +22,7 @@ permissions: {}
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'csharp' && 'windows-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.machine }}
     permissions:
       actions: read  # for github/codeql-action/init to get workflow details
       contents: read  # for actions/checkout to fetch code
@@ -38,8 +33,12 @@ jobs:
       matrix:
         include:
         - language: actions
+          # renovate: datasource=github-runners depType=github-runner
+          machine: ubuntu-24.04
         - language: csharp
           build-mode: manual
+          # renovate: datasource=github-runners depType=github-runner
+          machine: windows-2025
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -99,7 +98,7 @@ jobs:
     name: results # Matches required status check
     if: ${{ !cancelled() }}
     needs: [ analyze ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Report status

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,10 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -47,21 +51,21 @@ jobs:
     steps:
     - name: Configure Pagefile
       if: matrix.language == 'csharp'
-      uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # tag: v1.5
+      uses: al-cheb/configure-pagefile-action@9b6da52fb72a3c6147c1aad2df22d8d905681adc # v1.5
       with:
         minimum-size: 8GB
         maximum-size: 32GB
         disk-root: "D:"
 
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         filter: 'tree:0'
         persist-credentials: false
         show-progress: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # tag: v4.35.5
+      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -87,11 +91,12 @@ jobs:
       run: ./build.cmd BuildTracer
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # tag: v4.35.5
+      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
       with:
         category: "/language:${{matrix.language}}"
 
   results:
+    name: results
     if: ${{ !cancelled() }}
     needs: [ analyze ]
     runs-on: ubuntu-latest

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: Build demo
     strategy:
       matrix:
         os:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,11 +11,16 @@ on:
     - examples/demo/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   build:
+    name: build
     strategy:
       matrix:
         os:
@@ -25,7 +30,9 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Test demo
       run: make test

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -24,7 +24,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          # renovate: datasource=github-runners depType=github-runner
+          - ubuntu-24.04
+          # renovate: datasource=github-runners depType=github-runner
           - ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   check-format:
     name: dotnet format
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       
     - name: Checkout code

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -23,11 +23,11 @@ permissions:
 
 jobs:
   check-format:
-    name: check-format
+    name: dotnet format
     runs-on: windows-latest
     steps:
       
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -14,16 +14,23 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   check-format:
+    name: check-format
     runs-on: windows-latest
     steps:
       
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Setup .NET
       uses: ./.github/actions/setup-dotnet

--- a/.github/workflows/format-native.yml
+++ b/.github/workflows/format-native.yml
@@ -7,6 +7,10 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -29,7 +33,9 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install Clang tools
       shell: bash
@@ -40,14 +46,17 @@ jobs:
       run: ./scripts/format-native.sh
 
   check-native-headers:
+    name: check-native-headers
     runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # tag: v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.23.5'
           cache: false # Suppress a warning given that there are no go.sum files in the repo

--- a/.github/workflows/format-native.yml
+++ b/.github/workflows/format-native.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
 
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
@@ -46,11 +46,11 @@ jobs:
       run: ./scripts/format-native.sh
 
   check-native-headers:
-    name: check-native-headers
+    name: check-native-headers # Matches required status check
     runs-on: ubuntu-22.04
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/format-native.yml
+++ b/.github/workflows/format-native.yml
@@ -24,10 +24,13 @@ jobs:
       matrix:
         include:
           - step-name: native-format-macos
+            # renovate: datasource=github-runners depType=github-runner
             runner: macos-14-xlarge
           - step-name: native-format-linux
+            # renovate: datasource=github-runners depType=github-runner
             runner: ubuntu-22.04
           - step-name: native-format-windows
+            # renovate: datasource=github-runners depType=github-runner
             runner: windows-2022
 
     steps:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -14,15 +14,17 @@ permissions:
 
 jobs:
   fossa:
-    name: fossa
+    name: Run FOSSA scan
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+      - name: Run FOSSA analysis
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           team: OpenTelemetry

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,15 +5,22 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   fossa:
+    name: fossa
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   fossa:
     name: Run FOSSA scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.repository.fork == false
     steps:
       - name: Checkout code

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -8,18 +8,25 @@ on:
     - cron: "15 2 * * 3" # once a week
   workflow_dispatch:
 
-permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions: {}
 
 jobs:
   analysis:
+    name: analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed for Code scanning upload
-      security-events: write
-      # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
+      checks: read # Read CI results
+      contents: read # Checkout the repository
+      id-token: write # Publish Scorecard results with GitHub OIDC
+      issues: read # Read issues
+      pull-requests: read # Read pull requests
+      security-events: write # Upload the SARIF results to code scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -33,7 +40,7 @@ jobs:
       # uploads of run results in SARIF format to the repository Actions tab.
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -42,6 +49,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # tag: v4.35.5
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: results.sarif

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -16,7 +16,7 @@ permissions: {}
 
 jobs:
   analysis:
-    name: analysis
+    name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
       checks: read # Read CI results
@@ -26,11 +26,13 @@ jobs:
       pull-requests: read # Read pull requests
       security-events: write # Upload the SARIF results to code scanning
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       checks: read # Read CI results
       contents: read # Checkout the repository

--- a/.github/workflows/release-nextgen-forwarder-packages.yml
+++ b/.github/workflows/release-nextgen-forwarder-packages.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.version }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -17,6 +21,7 @@ env:
 
 jobs:
   build-nextgen-forwarder:
+    name: build-nextgen-forwarder
     runs-on: windows-2022
     defaults:
       run:
@@ -24,16 +29,17 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: out-of-process-collection
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: nuget-cache
         with:
           key: ${{ hashFiles('**/Directory.packages.props', '**/packages.config' ) }}
@@ -103,7 +109,7 @@ jobs:
           }
 
       - name: Upload NuGet Artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opentelemetry-nextgen-forwarder-packages
           path: |

--- a/.github/workflows/release-nextgen-forwarder-packages.yml
+++ b/.github/workflows/release-nextgen-forwarder-packages.yml
@@ -21,14 +21,14 @@ env:
 
 jobs:
   build-nextgen-forwarder:
-    name: build-nextgen-forwarder
+    name: Build NextGen forwarder
     runs-on: windows-2022
     defaults:
       run:
         working-directory: next-gen
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -126,9 +126,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # renovate: datasource=github-runners depType=github-runner
           - machine: ubuntu-22.04
             base-image: alpine
             net-version: net10.0
+          # renovate: datasource=github-runners depType=github-runner
           - machine: ubuntu-22.04-arm
             base-image: alpine
             net-version: net10.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,16 +4,23 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   powershell-script:
+    name: powershell-script
     runs-on: windows-2022
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
@@ -49,6 +56,7 @@ jobs:
           if (Test-Path $install_dir) { throw "Core files exist. Core uninstall failed." }
 
   shell-scripts:
+    name: shell-scripts
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +75,9 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
@@ -105,6 +115,7 @@ jobs:
             test "$(ls -A "${LOG_DIRECTORY}" )"
 
   shell-scripts-container:
+    name: shell-scripts-container
     strategy:
       fail-fast: false
       matrix:
@@ -119,7 +130,9 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Test the Shell scripts from README.md in Docker container
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,11 +13,17 @@ permissions:
 
 jobs:
   powershell-script:
-    name: powershell-script
-    runs-on: windows-2022
+    name: Run PowerShell script on ${{ matrix.machine }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - machine: windows-2022
+          - machine: windows-2025
+    runs-on: ${{ matrix.machine }}
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -56,7 +62,7 @@ jobs:
           if (Test-Path $install_dir) { throw "Core files exist. Core uninstall failed." }
 
   shell-scripts:
-    name: shell-scripts
+    name: Run shell scripts on ${{ matrix.machine }}
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.machine }}
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -115,7 +121,7 @@ jobs:
             test "$(ls -A "${LOG_DIRECTORY}" )"
 
   shell-scripts-container:
-    name: shell-scripts-container
+    name: Run shell scripts in Docker container on ${{ matrix.machine }}
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +135,7 @@ jobs:
     runs-on: ${{ matrix.machine }}
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 10
     steps:
 
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags: [ v* ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -32,23 +36,25 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [ build-windows, build, build-nuget-packages ]
     permissions:
-      attestations: write
-      contents: write
-      id-token: write
-      artifact-metadata: write
+      attestations: write # for actions/attest to create release attestations
+      contents: write # for publishing the GitHub release and its assets
+      id-token: write # for OIDC-based artifact attestations
+      artifact-metadata: write # for artifact metadata required by release attestations
     timeout-minutes: 10
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: .
 
       - name: Install zip
-        uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # tag: v1.0.0
+        uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # v1.0.0
 
       - name: Create ZIP artifacts
         shell: bash

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,10 +16,11 @@ permissions:
 
 jobs:
   shellcheck:
-    name: shellcheck
+    name: Run shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,14 +7,21 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   shellcheck:
+    name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install shellcheck
         run: sudo apt update && sudo apt install --assume-yes shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   shellcheck:
     name: Run shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-dotnet-install-script.yml
+++ b/.github/workflows/update-dotnet-install-script.yml
@@ -41,15 +41,13 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         filter: 'tree:0'
-        persist-credentials: false
+        persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
         show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Update .NET installation script
       id: update-script
       shell: pwsh
-      env:
-        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
       run: |
         $ErrorActionPreference = "Stop"
         $ProgressPreference = "SilentlyContinue"
@@ -90,12 +88,10 @@ jobs:
 
         # Configure Git and check whether the branch already exists
         $BranchName = ${env:UPDATE_BRANCH_NAME}
-        $TokenBytes = [System.Text.Encoding]::ASCII.GetBytes("x-access-token:${env:GH_TOKEN}")
-        $AuthorizationHeader = [Convert]::ToBase64String($TokenBytes)
 
         git config user.email "${env:GIT_COMMIT_USER_EMAIL}" | Out-Null
         git config user.name "${env:GIT_COMMIT_USER_NAME}" | Out-Null
-        git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AuthorizationHeader}" fetch origin --no-tags | Out-Null
+        git fetch origin --no-tags | Out-Null
         git rev-parse --verify --quiet "remotes/origin/${BranchName}" | Out-Null
 
         if ($LASTEXITCODE -eq 0) {
@@ -107,7 +103,7 @@ jobs:
         git checkout -b $BranchName
         git add $InstallScriptFileName
         git commit -m "Update .NET Installation Script`n`nUpdate .NET installation script from ${InstallScriptUrl}." -s
-        git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AuthorizationHeader}" push -u origin $BranchName
+        git push -u origin $BranchName
 
         "updated-script=true" >> ${env:GITHUB_OUTPUT}
 

--- a/.github/workflows/update-dotnet-install-script.yml
+++ b/.github/workflows/update-dotnet-install-script.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   update-dotnet-install-script:
     name: Update .NET installation script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.repository.fork == false
 
     env:

--- a/.github/workflows/update-dotnet-install-script.yml
+++ b/.github/workflows/update-dotnet-install-script.yml
@@ -5,10 +5,15 @@ on:
     - cron:  '0 4 1 * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
   update-dotnet-install-script:
+    name: update-dotnet-install-script
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
 
@@ -36,12 +41,15 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
         token: ${{ steps.otelbot-token.outputs.token }}
 
     - name: Update .NET installation script
       id: update-script
       shell: pwsh
+      env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
       run: |
         $ErrorActionPreference = "Stop"
         $ProgressPreference = "SilentlyContinue"
@@ -82,10 +90,12 @@ jobs:
 
         # Configure Git and check whether the branch already exists
         $BranchName = ${env:UPDATE_BRANCH_NAME}
+        $TokenBytes = [System.Text.Encoding]::ASCII.GetBytes("x-access-token:${env:GH_TOKEN}")
+        $AuthorizationHeader = [Convert]::ToBase64String($TokenBytes)
 
         git config user.email "${env:GIT_COMMIT_USER_EMAIL}" | Out-Null
         git config user.name "${env:GIT_COMMIT_USER_NAME}" | Out-Null
-        git fetch origin --no-tags | Out-Null
+        git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AuthorizationHeader}" fetch origin --no-tags | Out-Null
         git rev-parse --verify --quiet "remotes/origin/${BranchName}" | Out-Null
 
         if ($LASTEXITCODE -eq 0) {
@@ -97,7 +107,7 @@ jobs:
         git checkout -b $BranchName
         git add $InstallScriptFileName
         git commit -m "Update .NET Installation Script`n`nUpdate .NET installation script from ${InstallScriptUrl}." -s
-        git push -u origin $BranchName
+        git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AuthorizationHeader}" push -u origin $BranchName
 
         "updated-script=true" >> ${env:GITHUB_OUTPUT}
 

--- a/.github/workflows/update-dotnet-install-script.yml
+++ b/.github/workflows/update-dotnet-install-script.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   update-dotnet-install-script:
-    name: update-dotnet-install-script
+    name: Update .NET installation script
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
 

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -16,19 +16,26 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   build:
+    name: build
     runs-on: ubuntu-latest
     steps:
 
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Restore lychee cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache-restore
       with:
         path: .lycheecache
@@ -37,25 +44,25 @@ jobs:
 
     - name: Run markdown links checks
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'release PR') }}
-      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # tag: v2.8.0
+      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
       with:
         fail: true
         args: "--cache --max-cache-age 1d --threads 1 --max-concurrency 1 --verbose --retry-wait-time 5 --max-retries 3 --timeout 60 --no-progress './**/*.md' './**/*.html'"
 
     - name: Run markdownlint
-      uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # tag: v8.4.0
+      uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
       with:
         files: '**/*.md'
 
     - name: Run cspell
-      uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # tag: v23.2.0
+      uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
       with:
         globs: '**/*.md;!.github/**;!lychee/out.md'
         separator: ';'
 
     - name: Save lychee cache
       if: always()
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag: v5.0.5
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .lycheecache
         key: ${{ steps.cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   build:
     name: Build documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Checkout code

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -25,11 +25,11 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: Build documentation
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -32,10 +32,10 @@ jobs:
             containers: windows
           - machine: ubuntu-22.04
             containers: linux
-          - machine: macos-14
-            containers: none
           - machine: ubuntu-22.04-arm
             containers: linux
+          - machine: macos-14
+            containers: none
     runs-on: ${{ matrix.machine }}
     steps:
       

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   verify-test:
-    name: verify-test
+    name: Verify test
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.machine }}
     steps:
       
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -12,11 +12,16 @@ on:
         description: 'Test execution count'
         default: '20'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   verify-test:
+    name: verify-test
     strategy:
       fail-fast: false
       matrix:
@@ -35,17 +40,25 @@ jobs:
     steps:
       
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag: v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
 
       - name: Run BuildTracer and ManagedTests
-        run: ./build.cmd BuildTracer ManagedTests --containers ${{ matrix.containers }} --test-project "${{ github.event.inputs.testProject }}" --test-name '"${{ github.event.inputs.testName }}"' --test-count ${{ github.event.inputs.count }}
+        shell: bash
+        env:
+          CONTAINERS: ${{ matrix.containers }}
+          TEST_COUNT: ${{ github.event.inputs.count }}
+          TEST_NAME: ${{ github.event.inputs.testName }}
+          TEST_PROJECT: ${{ github.event.inputs.testProject }}
+        run: ./build.cmd BuildTracer ManagedTests --containers "${CONTAINERS}" --test-project "${TEST_PROJECT}" --test-name "\"${TEST_NAME}\"" --test-count "${TEST_COUNT}"
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: logs-${{ matrix.machine }}
           path: test-artifacts/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,41 @@
+name: zizmor scan
+
+on:
+  pull_request:
+  push:
+    branches: [ 'main*' ]
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 3
+  TERM: xterm
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-24.04
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
+
+    permissions:
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
+
+      - name: Scan workflows with zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          persona: pedantic

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,7 @@ name: zizmor scan
 on:
   pull_request:
   push:
-    branches: [ 'main*' ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   zizmor:
-    name: zizmor
+    name: Scan with zizmor
     runs-on: ubuntu-24.04
 
     concurrency:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  secrets-outside-env:
+    disable: true


### PR DESCRIPTION
## Why

Fixes #5043

## What

- Add a workflow that scans the repository with zizmor.
- Address all zizmor findings.
- Add 3 day dependabot cooldown (as was copy-pasting a zizmor config that already contained it and will generate a finding post-merge without).
- Add a missing validation with Windows 2025 I spotted while adding pretty job namess.

## Tests

This PR - [this workflow run](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/26229879211/job/77186965773?pr=5077#step:3:121) shows zizmor running with 0 findings.

## Checklist

- [ ] ~~`CHANGELOG.md` is updated.~~
- [ ] ~~Documentation is updated.~~
- [ ] ~~New features are covered by tests.~~
