### PR TITLE
[docs] Fix Links for Nuke

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -458,7 +458,7 @@ To enable the Zipkin exporter, set the `OTEL_TRACES_EXPORTER` environment
 variable to `zipkin`.
 
 To customize the Zipkin exporter using environment variables,
-see the [Zipkin exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.15.4/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables).
+see the [Zipkin exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.15.3/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables).
 Important environment variables include:
 
 | Environment variable            | Description | Default value                        | Status                                                                                                                      |

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -41,14 +41,14 @@ Run:
 
 ## Build
 
-This repository uses [Nuke](https://nuke.build/) for build automation.
+This repository uses [Nuke](https://github.com/nuke-build/nuke) for build automation.
 
 Support plugins are available for:
 
-- JetBrains ReSharper        <https://nuke.build/docs/ide/resharper/>
-- JetBrains Rider            <https://nuke.build/docs/ide/rider/>
-- Microsoft VisualStudio     <https://nuke.build/docs/ide/visual-studio>
-- Microsoft VSCode           <https://nuke.build/docs/ide/vscode/>
+- JetBrains ReSharper        <https://github.com/nuke-build/nuke/blob/develop/docs/07-ide/resharper.md>
+- JetBrains Rider            <https://github.com/nuke-build/nuke/blob/develop/docs/07-ide/rider.md>
+- Microsoft VisualStudio     <https://github.com/nuke-build/nuke/blob/develop/docs/07-ide/visual-studio.md>
+- Microsoft VSCode           <https://github.com/nuke-build/nuke/blob/develop/docs/07-ide/vscode.md>
 
 Restore dotnet tools to prepare build tools for solution.
 This installs the dotnet `nuke` tool locally.


### PR DESCRIPTION
## Why & What

`nuke.build` domain is dead, migrate to the GitHub nuke repo

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~[ ] `CHANGELOG.md` is updated.~
- ~[ ] Documentation is updated.~
- ~[ ] New features are covered by tests.~
