### PR TITLE
.NET 11 preparation - better handling for using/IDE0005

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/FileBasedConfiguration/MetricPeriodicExporterConfig.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/FileBasedConfiguration/MetricPeriodicExporterConfig.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser;
-using OpenTelemetry.Metrics;
 using Vendors.YamlDotNet.Serialization;
 
 namespace OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/Bridge/OpenTelemetryLogHelpers.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/Bridge/OpenTelemetryLogHelpers.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/Bridge/OpenTelemetryNLogConverter.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/Bridge/OpenTelemetryNLogConverter.cs
@@ -8,10 +8,10 @@ using System.Reflection;
 using OpenTelemetry.AutoInstrumentation.DuckTyping;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NLog.TraceContextInjection;
 using OpenTelemetry.AutoInstrumentation.Logging;
+using OpenTelemetry.Logs;
 #if NET
 using OpenTelemetry.AutoInstrumentation.Logger;  // Only needed for LoggerInitializer
 #endif
-using OpenTelemetry.Logs;
 using Exception = System.Exception;
 
 namespace OpenTelemetry.AutoInstrumentation.Instrumentations.NLog.Bridge;

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/StackExchangeRedis/StackExchangeRedisIntegration.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.CallTarget;
-using OpenTelemetry.AutoInstrumentation.Configurations;
 
 namespace OpenTelemetry.AutoInstrumentation.Instrumentations.StackExchangeRedis;
 

--- a/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientTracerInitializer.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Loading/Initializers/SqlClientTracerInitializer.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Plugins;
 
 namespace OpenTelemetry.AutoInstrumentation.Loading.Initializers;

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -15,6 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />

--- a/test/IntegrationTests/AdoNetStubTests.cs
+++ b/test/IntegrationTests/AdoNetStubTests.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/AspNetTests.cs
+++ b/test/IntegrationTests/AspNetTests.cs
@@ -4,7 +4,6 @@
 #if NETFRAMEWORK
 using System.Net.Http;
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/AssemblyRedirectionTests.cs
+++ b/test/IntegrationTests/AssemblyRedirectionTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/AzureTests.cs
+++ b/test/IntegrationTests/AzureTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/ContinuousProfilerContextTrackingTests.cs
+++ b/test/IntegrationTests/ContinuousProfilerContextTrackingTests.cs
@@ -3,7 +3,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Collector.Profiles.V1Development;
 using OpenTelemetry.Proto.Profiles.V1Development;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/ContinuousProfilerSpanStoppageHandlingTests.cs
+++ b/test/IntegrationTests/ContinuousProfilerSpanStoppageHandlingTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #if NET
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/ContinuousProfilerTests.cs
+++ b/test/IntegrationTests/ContinuousProfilerTests.cs
@@ -3,7 +3,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Collector.Profiles.V1Development;
 using OpenTelemetry.Proto.Profiles.V1Development;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/CustomSdkTests.cs
+++ b/test/IntegrationTests/CustomSdkTests.cs
@@ -5,7 +5,6 @@
 using Google.Protobuf;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/DomainNeutralTests.cs
+++ b/test/IntegrationTests/DomainNeutralTests.cs
@@ -3,7 +3,6 @@
 
 #if NETFRAMEWORK
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/DotNetCliTests.cs
+++ b/test/IntegrationTests/DotNetCliTests.cs
@@ -4,7 +4,6 @@
 #if NET
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/ElasticsearchTests.cs
+++ b/test/IntegrationTests/ElasticsearchTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/EntityFrameworkCoreNpgsqlTests.cs
+++ b/test/IntegrationTests/EntityFrameworkCoreNpgsqlTests.cs
@@ -4,7 +4,6 @@
 #if NET
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/EntityFrameworkCorePomeloMySqlTests.cs
+++ b/test/IntegrationTests/EntityFrameworkCorePomeloMySqlTests.cs
@@ -4,7 +4,6 @@
 #if NET
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/EntityFrameworkCoreTests.cs
+++ b/test/IntegrationTests/EntityFrameworkCoreTests.cs
@@ -4,7 +4,6 @@
 #if NET
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/GraphQLTests.cs
+++ b/test/IntegrationTests/GraphQLTests.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Text;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/GrpcNetClientTests.cs
+++ b/test/IntegrationTests/GrpcNetClientTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/test/IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/Helpers/FirewallHelper.cs
+++ b/test/IntegrationTests/Helpers/FirewallHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit.Abstractions;
-
 namespace IntegrationTests.Helpers;
 
 internal static class FirewallHelper

--- a/test/IntegrationTests/Helpers/FirewallPort.cs
+++ b/test/IntegrationTests/Helpers/FirewallPort.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit.Abstractions;
-
 namespace IntegrationTests.Helpers;
 
 internal sealed class FirewallPort : IDisposable

--- a/test/IntegrationTests/Helpers/HealthzHelper.cs
+++ b/test/IntegrationTests/Helpers/HealthzHelper.cs
@@ -5,7 +5,6 @@ using System.Net;
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/Helpers/MockCorrelationCollector.cs
+++ b/test/IntegrationTests/Helpers/MockCorrelationCollector.cs
@@ -8,7 +8,6 @@ using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Collector.Trace.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/Helpers/MockLogsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockLogsCollector.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Logs.V1;
-using Xunit.Abstractions;
 #if NETFRAMEWORK
 using System.Net;
 #else

--- a/test/IntegrationTests/Helpers/MockMetricsCollector.cs
+++ b/test/IntegrationTests/Helpers/MockMetricsCollector.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
 using OpenTelemetry.Proto.Metrics.V1;
-using Xunit.Abstractions;
 
 #if NETFRAMEWORK
 using System.Net;

--- a/test/IntegrationTests/Helpers/MockOpAmpServer.cs
+++ b/test/IntegrationTests/Helpers/MockOpAmpServer.cs
@@ -13,7 +13,6 @@ using System.Net;
 using System.Text;
 using Google.Protobuf;
 using OpAmp.Proto.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/Helpers/MockProfilesCollector.cs
+++ b/test/IntegrationTests/Helpers/MockProfilesCollector.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text;
 using OpenTelemetry.Proto.Collector.Profiles.V1Development;
 using OpenTelemetry.Proto.Profiles.V1Development;
-using Xunit.Abstractions;
 
 #if NETFRAMEWORK
 using System.Net;

--- a/test/IntegrationTests/Helpers/MockSpansCollector.cs
+++ b/test/IntegrationTests/Helpers/MockSpansCollector.cs
@@ -7,7 +7,6 @@ using System.Text;
 using OpenTelemetry.Proto.Collector.Trace.V1;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 #if NETFRAMEWORK
 using System.Net;

--- a/test/IntegrationTests/Helpers/MockZipkinCollector.cs
+++ b/test/IntegrationTests/Helpers/MockZipkinCollector.cs
@@ -8,7 +8,6 @@ using System.Runtime.Serialization;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Xunit.Abstractions;
 
 #if NETFRAMEWORK
 using System.Net;

--- a/test/IntegrationTests/Helpers/OutputHelper.cs
+++ b/test/IntegrationTests/Helpers/OutputHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit.Abstractions;
-
 namespace IntegrationTests.Helpers;
 
 internal static class OutputHelper

--- a/test/IntegrationTests/Helpers/PowershellHelper.cs
+++ b/test/IntegrationTests/Helpers/PowershellHelper.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/Helpers/TestHelper.cs
+++ b/test/IntegrationTests/Helpers/TestHelper.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Reflection;
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
+++ b/test/IntegrationTests/Helpers/TestHttpServer.AspNetCore.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/Helpers/TestHttpServer.NetFramework.cs
+++ b/test/IntegrationTests/Helpers/TestHttpServer.NetFramework.cs
@@ -4,7 +4,6 @@
 #if NETFRAMEWORK
 
 using System.Net;
-using Xunit.Abstractions;
 
 namespace IntegrationTests.Helpers;
 

--- a/test/IntegrationTests/HttpNetFrameworkTests.cs
+++ b/test/IntegrationTests/HttpNetFrameworkTests.cs
@@ -3,7 +3,6 @@
 
 #if NETFRAMEWORK
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/HttpTests.cs
+++ b/test/IntegrationTests/HttpTests.cs
@@ -4,7 +4,6 @@
 #if NET
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/IISContainerTestHelper.cs
+++ b/test/IntegrationTests/IISContainerTestHelper.cs
@@ -5,7 +5,6 @@
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/KafkaTests.cs
+++ b/test/IntegrationTests/KafkaTests.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/Log4NetBridgeTests.cs
+++ b/test/IntegrationTests/Log4NetBridgeTests.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using Google.Protobuf;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Logs.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/LogTests.cs
+++ b/test/IntegrationTests/LogTests.cs
@@ -5,7 +5,6 @@
 using System.Globalization;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Logs.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/MassTransitTests.cs
+++ b/test/IntegrationTests/MassTransitTests.cs
@@ -3,7 +3,6 @@
 
 #if NET
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 using static OpenTelemetry.Proto.Trace.V1.Span.Types;
 
 namespace IntegrationTests;

--- a/test/IntegrationTests/MinimalApiTests.cs
+++ b/test/IntegrationTests/MinimalApiTests.cs
@@ -6,7 +6,6 @@
 using System.Globalization;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Logs.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/ModuleTests.cs
+++ b/test/IntegrationTests/ModuleTests.cs
@@ -5,7 +5,6 @@ using IntegrationTests.Helpers;
 using Newtonsoft.Json;
 using OpenTelemetry.AutoInstrumentation;
 using OpenTelemetry.AutoInstrumentation.Configurations;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/MongoDBTests.cs
+++ b/test/IntegrationTests/MongoDBTests.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/MultipleAppDomainsTests.cs
+++ b/test/IntegrationTests/MultipleAppDomainsTests.cs
@@ -3,7 +3,6 @@
 
 #if NETFRAMEWORK
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/MySqlConnectorTests.cs
+++ b/test/IntegrationTests/MySqlConnectorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/MySqlDataTests.cs
+++ b/test/IntegrationTests/MySqlDataTests.cs
@@ -3,7 +3,6 @@
 
 #if NET
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/NLogBridgeTests.cs
+++ b/test/IntegrationTests/NLogBridgeTests.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using Google.Protobuf;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Logs.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/NServiceBusTests.cs
+++ b/test/IntegrationTests/NServiceBusTests.cs
@@ -3,7 +3,6 @@
 
 using IntegrationTests.Helpers;
 using OpenTelemetry.AutoInstrumentation.Configurations;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/NoCodeTests.cs
+++ b/test/IntegrationTests/NoCodeTests.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/NpqsqlTests.cs
+++ b/test/IntegrationTests/NpqsqlTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/OpAmpTests.cs
+++ b/test/IntegrationTests/OpAmpTests.cs
@@ -3,7 +3,6 @@
 
 using IntegrationTests.Helpers;
 using OpAmp.Proto.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/OpenTracingTests.cs
+++ b/test/IntegrationTests/OpenTracingTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/OracleMdaTests.cs
+++ b/test/IntegrationTests/OracleMdaTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/OwinIISTests.cs
+++ b/test/IntegrationTests/OwinIISTests.cs
@@ -5,7 +5,6 @@
 using System.Net.Http;
 using Google.Protobuf;
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/PluginsTests.cs
+++ b/test/IntegrationTests/PluginsTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/ProcessTests.cs
+++ b/test/IntegrationTests/ProcessTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/QuartzTests.cs
+++ b/test/IntegrationTests/QuartzTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/RabbitMqTests.cs
+++ b/test/IntegrationTests/RabbitMqTests.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/RuntimeTests.cs
+++ b/test/IntegrationTests/RuntimeTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/SelectiveSamplerTests.cs
+++ b/test/IntegrationTests/SelectiveSamplerTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 #if NETFRAMEWORK
 using System.Net;

--- a/test/IntegrationTests/SqlClientMicrosoftTests.cs
+++ b/test/IntegrationTests/SqlClientMicrosoftTests.cs
@@ -3,7 +3,6 @@
 
 using IntegrationTests.Helpers;
 using OpenTelemetry.AutoInstrumentation.Configurations;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/SqlClientSystemDataTests.cs
+++ b/test/IntegrationTests/SqlClientSystemDataTests.cs
@@ -4,7 +4,6 @@
 #if NETFRAMEWORK
 using IntegrationTests.Helpers;
 using OpenTelemetry.AutoInstrumentation.Configurations;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/SqlClientSystemTests.cs
+++ b/test/IntegrationTests/SqlClientSystemTests.cs
@@ -3,7 +3,6 @@
 
 using IntegrationTests.Helpers;
 using OpenTelemetry.AutoInstrumentation.Configurations;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/SqliteMicrosoftTests.cs
+++ b/test/IntegrationTests/SqliteMicrosoftTests.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/IntegrationTests/StackExchangeRedisTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/StartupHookIsolationTests.cs
+++ b/test/IntegrationTests/StartupHookIsolationTests.cs
@@ -5,7 +5,6 @@
 using System.Security.Cryptography;
 using IntegrationTests.Helpers;
 using OpenTelemetry.AutoInstrumentation;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/StrongNamedTests.cs
+++ b/test/IntegrationTests/StrongNamedTests.cs
@@ -5,7 +5,6 @@
 using System.Reflection;
 #endif
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/VerboseTestFramework.cs
+++ b/test/IntegrationTests/VerboseTestFramework.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Reflection;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 [assembly: TestFramework("IntegrationTests.Helpers.VerboseTestFramework", "IntegrationTests")]

--- a/test/IntegrationTests/WcfCoreServerTestHelper.cs
+++ b/test/IntegrationTests/WcfCoreServerTestHelper.cs
@@ -4,7 +4,6 @@
 #if NET
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/WcfDotNetTests.cs
+++ b/test/IntegrationTests/WcfDotNetTests.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NET
-using Xunit.Abstractions;
-
 namespace IntegrationTests;
 
 public class WcfDotNetTests : WcfTestsBase

--- a/test/IntegrationTests/WcfIISTests.cs
+++ b/test/IntegrationTests/WcfIISTests.cs
@@ -7,7 +7,6 @@ using DotNet.Testcontainers.Containers;
 using Google.Protobuf;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/WcfNetFrameworkTests.cs
+++ b/test/IntegrationTests/WcfNetFrameworkTests.cs
@@ -4,7 +4,6 @@
 #if NETFRAMEWORK
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Trace.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/WcfServerTestHelper.cs
+++ b/test/IntegrationTests/WcfServerTestHelper.cs
@@ -4,7 +4,6 @@
 #if _WINDOWS
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/WcfServerTestHelperBase.cs
+++ b/test/IntegrationTests/WcfServerTestHelperBase.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/IntegrationTests/WcfTestsBase.cs
+++ b/test/IntegrationTests/WcfTestsBase.cs
@@ -3,7 +3,6 @@
 
 using System.Net.Sockets;
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 using static OpenTelemetry.Proto.Trace.V1.Span.Types;
 
 namespace IntegrationTests;

--- a/test/IntegrationTests/WorkerTests.cs
+++ b/test/IntegrationTests/WorkerTests.cs
@@ -6,7 +6,6 @@
 using System.Globalization;
 using IntegrationTests.Helpers;
 using OpenTelemetry.Proto.Logs.V1;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/NuGetPackagesTests/InstrumentationTargetTests.cs
+++ b/test/NuGetPackagesTests/InstrumentationTargetTests.cs
@@ -4,7 +4,6 @@
 using IntegrationTests.Helpers;
 using Microsoft.Build.Evaluation;
 using NuGet.Versioning;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/NuGetPackagesTests/NugetSampleTests.cs
+++ b/test/NuGetPackagesTests/NugetSampleTests.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.InteropServices;
 using IntegrationTests.Helpers;
-using Xunit.Abstractions;
 
 namespace IntegrationTests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests/FactRequiringEnvVarAttribute.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests/FactRequiringEnvVarAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-
 namespace OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests;
 
 #pragma warning disable CA1812 // Mark members as static. There is some issue in dotnet format.

--- a/test/OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests/InstrumentationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests/InstrumentationTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Bootstrapping.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/CheckForInstrumentationPackagesTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/CheckForInstrumentationPackagesTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Build.Framework;
 using NSubstitute;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.BuildTasks.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/TargetsPackageVersionTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.BuildTasks.Tests/TargetsPackageVersionTests.cs
@@ -3,7 +3,6 @@
 
 using System.Xml.Linq;
 using IntegrationTests.Helpers;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.BuildTasks.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/AssemblyBindingUpdaterTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/AssemblyBindingUpdaterTests.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Xml.Linq;
 using Microsoft.CSharp;
 using OpenTelemetry.AutoInstrumentation.Logging;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Loader.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/LoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Loader.Tests/LoaderTests.cs
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
-using Xunit.Abstractions;
-
 namespace OpenTelemetry.AutoInstrumentation.Loader.Tests;
 
 public class LoaderTests(ITestOutputHelper testOutput)

--- a/test/OpenTelemetry.AutoInstrumentation.StartupHook.Tests/OpenTelemetrySdkMinimumVersionRuleTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.StartupHook.Tests/OpenTelemetrySdkMinimumVersionRuleTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.RulesEngine;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.StartupHook.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.StartupHook.Tests/RuleEngineTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.StartupHook.Tests/RuleEngineTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.RulesEngine;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.StartupHook.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/AssemblyInfo.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-using Xunit;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/ConfigurationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/ConfigurationTests.cs
@@ -7,7 +7,6 @@ using System.Text;
 #endif
 using NSubstitute;
 using OpenTelemetry.AutoInstrumentation.Configurations;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/EnvironmentInitializerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/EnvironmentInitializerTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Specialized;
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FileBasedOpAmpSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FileBasedOpAmpSettingsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FileBasedTestHelper.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FileBasedTestHelper.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using Vendors.YamlDotNet.Core;
 using Vendors.YamlDotNet.Serialization;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedGeneralSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedGeneralSettingsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedInstrumentationSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedInstrumentationSettingsTests.cs
@@ -4,7 +4,6 @@
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.HeadersCapture;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedLogsSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedLogsSettingsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedMetricsSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedMetricsSettingsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedPluginsSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedPluginsSettingsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedResourceSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedResourceSettingsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedSdkSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedSdkSettingsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedTracesSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FilebasedTracesSettingsTests.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ConditionalDeserializerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ConditionalDeserializerTests.cs
@@ -4,7 +4,6 @@
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser;
 using Vendors.YamlDotNet.Core;
 using Vendors.YamlDotNet.Serialization;
-using Xunit;
 using YamlParser = Vendors.YamlDotNet.Core.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/DefaultNamingConventionTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/DefaultNamingConventionTests.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/EnvVarTypeConverterTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/EnvVarTypeConverterTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = Vendors.YamlDotNet.Core.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserGeneralTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserGeneralTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserInstrumentationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserInstrumentationTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserLogsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserLogsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserMetricsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserMetricsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserNoCodeTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserNoCodeTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserOpAmpTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserOpAmpTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserPluginsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserPluginsTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserPropagatorTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserPropagatorTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserResourceTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserResourceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserTracesTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserTracesTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations.FileBased.Parser;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/PluginManagerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/PluginManagerTests.cs
@@ -10,7 +10,6 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/ServiceNameConfiguratorTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/ServiceNameConfiguratorTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
@@ -5,8 +5,6 @@ using System.Globalization;
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
 using OpenTelemetry.Exporter;
-using Xunit;
-
 using AutoOtlpDefinitions = OpenTelemetry.AutoInstrumentation.Configurations.Otlp.OtlpSpecConfigDefinitions;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations;

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/StringConfigurationSourceTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/StringConfigurationSourceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.Configurations;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Configurations;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Diagnostics/SdkSelfDiagnosticsEventListenerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Diagnostics/SdkSelfDiagnosticsEventListenerTests.cs
@@ -6,7 +6,6 @@
 using System.Diagnostics.Tracing;
 using OpenTelemetry.AutoInstrumentation.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.Logging;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Diagnostics;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/FrameworkDistroTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/FrameworkDistroTests.cs
@@ -11,7 +11,6 @@ using DependencyListGenerator;
 using Microsoft.Build.Evaluation;
 using NuGet.Configuration;
 using NuGet.Frameworks;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelErrorHandlingTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelErrorHandlingTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode.Cel;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Instrumentations.NoCode.Cel;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelExpressionTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelExpressionTests.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode.Cel;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Instrumentations.NoCode.Cel;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelHelpersTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelHelpersTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode.Cel;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Instrumentations.NoCode.Cel;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelIntegrationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelIntegrationTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode.Cel;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Instrumentations.NoCode.Cel;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelLexerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelLexerTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode.Cel;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Instrumentations.NoCode.Cel;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelOperatorPrecedenceTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelOperatorPrecedenceTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode.Cel;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Instrumentations.NoCode.Cel;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelParserTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Instrumentations/NoCode/Cel/CelParserTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NoCode.Cel;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Instrumentations.NoCode.Cel;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/InternalLoggerTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/InternalLoggerTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.Logging;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Loading/LazyInstrumentationLoaderTests.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using OpenTelemetry.AutoInstrumentation.Loading;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Loading;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Log4NetTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Log4NetTests.cs
@@ -4,7 +4,6 @@
 using log4net.Core;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.Log4Net.Bridge;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/NLogTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/NLogTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NLog.Bridge;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/OtelLoggingTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/OtelLoggingTests.cs
@@ -3,7 +3,6 @@
 
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ActivityHelperTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ActivityHelperTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.Util;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Util;
 

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ResourceHelperTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Util/ResourceHelperTests.cs
@@ -5,7 +5,6 @@ using OpenTelemetry.AutoInstrumentation.Util;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using Xunit;
 
 namespace OpenTelemetry.AutoInstrumentation.Tests.Util;
 

--- a/test/test-applications/integrations/TestApplication.GraphQL/GraphQLLoggingExtensions.cs
+++ b/test/test-applications/integrations/TestApplication.GraphQL/GraphQLLoggingExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Microsoft.Extensions.Logging;
-
 namespace TestApplication.GraphQL;
 
 internal static partial class GraphQLLoggingExtensions

--- a/test/test-applications/integrations/TestApplication.GrpcNetClient/Program.cs
+++ b/test/test-applications/integrations/TestApplication.GrpcNetClient/Program.cs
@@ -1,8 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
 using System.Net;
+#else
 using System.Net.Http;
+#endif
 using Greet;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -12,8 +15,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
-#endif
 using TestApplication.GrpcNetClient;
+#endif
 #if NETFRAMEWORK
 using Grpc.Net.Client.Web;
 #endif

--- a/tools/DependencyListGenerator/DotNetOutdated/Services/DotNetRunner.cs
+++ b/tools/DependencyListGenerator/DotNetOutdated/Services/DotNetRunner.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.IO;
 using System.Text;
 using McMaster.Extensions.CommandLineUtils;
 


### PR DESCRIPTION
## Why

Bring some changes for #5111
IDE0005 becomes error for .NET11 in our configuration.

## What

.NET 11 preparation - better handling for using/IDE0005

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
