### PR TITLE
.NET 11 preparation - dotnet format

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -35,5 +35,9 @@ jobs:
     - name: Setup .NET
       uses: ./.github/actions/setup-dotnet
 
+    - name: Create local NuGet package source
+      run: New-Item -ItemType Directory -Path .\bin\nuget-artifacts -Force
+      shell: pwsh
+
     - name: dotnet format
-      run: dotnet format .\OpenTelemetry.AutoInstrumentation.sln --no-restore --verify-no-changes
+      run: dotnet format .\OpenTelemetry.AutoInstrumentation.sln --verify-no-changes

--- a/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
@@ -1,8 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+
+#if NETFRAMEWORK
+using System.Reflection.Emit;
+#endif
 
 namespace OpenTelemetry.AutoInstrumentation.CallTarget.Handlers.Continuations;
 

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/FileBasedConfiguration/SqlClientConfiguration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/FileBasedConfiguration/SqlClientConfiguration.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser;
+#if NETFRAMEWORK
 using Vendors.YamlDotNet.Serialization;
+#endif
 
 namespace OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 

--- a/src/OpenTelemetry.AutoInstrumentation/ContinuousProfiler/CanaryThreadManager.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/ContinuousProfiler/CanaryThreadManager.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
-using System.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.Logging;
 
 namespace OpenTelemetry.AutoInstrumentation.ContinuousProfiler;

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Log4Net/Bridge/Integrations/AppenderCollectionIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Log4Net/Bridge/Integrations/AppenderCollectionIntegration.cs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.AutoInstrumentation.CallTarget;
-using OpenTelemetry.AutoInstrumentation.Logging;
 #if NET
 using OpenTelemetry.AutoInstrumentation.Logger;
+using OpenTelemetry.AutoInstrumentation.Logging;
 #endif
 
 namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Log4Net.Bridge.Integrations;

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/TraceContextInjection/Integrations/NLogIntegrationHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/TraceContextInjection/Integrations/NLogIntegrationHelper.cs
@@ -5,9 +5,9 @@ using System.Diagnostics;
 using OpenTelemetry.AutoInstrumentation.CallTarget;
 using OpenTelemetry.AutoInstrumentation.DuckTyping;
 using OpenTelemetry.AutoInstrumentation.Instrumentations.NLog.Bridge;
-using OpenTelemetry.AutoInstrumentation.Logging;
 #if NET
 using OpenTelemetry.AutoInstrumentation.Logger;
+using OpenTelemetry.AutoInstrumentation.Logging;
 #endif
 
 namespace OpenTelemetry.AutoInstrumentation.Instrumentations.NLog.TraceContextInjection.Integrations;

--- a/test/IntegrationTests/Helpers/MockCorrelationCollector.cs
+++ b/test/IntegrationTests/Helpers/MockCorrelationCollector.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #if NET
 using System.Collections.Concurrent;
+#if !NET11_0_OR_GREATER
 using System.Diagnostics;
+#endif
 using Microsoft.AspNetCore.Http;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Collector.Trace.V1;

--- a/test/IntegrationTests/SmokeTests.cs
+++ b/test/IntegrationTests/SmokeTests.cs
@@ -1,8 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NETFRAMEWORK
 using System.Diagnostics;
+#endif
+#if NET
 using System.Globalization;
+#endif
 using IntegrationTests.Helpers;
 
 #if NETFRAMEWORK

--- a/test/NuGetPackagesTests/NugetSampleTests.cs
+++ b/test/NuGetPackagesTests/NugetSampleTests.cs
@@ -1,7 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET
 using System.Runtime.InteropServices;
+#endif
 using IntegrationTests.Helpers;
 
 namespace IntegrationTests;

--- a/test/test-applications/integrations/TestApplication.AspNet.NetFramework/TestApplication.AspNet.NetFramework.csproj
+++ b/test/test-applications/integrations/TestApplication.AspNet.NetFramework/TestApplication.AspNet.NetFramework.csproj
@@ -32,6 +32,7 @@
         LangVersion needs to be 13.0 as it is dependency on Windows 2022 without VS2026.
     -->
     <LangVersion>13.0</LangVersion>
+    <DefineConstants>$(DefineConstants);ASPNET_NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -142,7 +143,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -150,7 +151,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -159,7 +160,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -167,7 +168,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -176,7 +177,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -184,7 +185,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>

--- a/test/test-applications/integrations/dependency-libs/TestApplication.Shared/ProfilerHelper.cs
+++ b/test/test-applications/integrations/dependency-libs/TestApplication.Shared/ProfilerHelper.cs
@@ -1,10 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Collections;
+#if ASPNET_NETFRAMEWORK
+using System;
 using System.Collections.Generic;
 using System.Linq;
+#endif
 
 namespace TestApplication.Shared;
 


### PR DESCRIPTION
## Why

Extracted from #5111
Follow up to #5133

## What

dotnet-format - restore before formatting 
without this .NET 11 is not able to correctly understand code
+ detected fixes, mostly IDE0005 leftovers,

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
