### PR TITLE
[OpAMP] Suppress instrumentation to avoid tracing internal transport calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
+- Suppress instrumentation while starting the OpAMP client to prevent internal
+  OpAMP transport calls from being collected as traces.
+
 ## [v1.16.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.16.0-beta.1)
 
 ### Added

--- a/src/OpenTelemetry.AutoInstrumentation/OpAmpHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/OpAmpHelper.cs
@@ -67,6 +67,8 @@ internal static class OpAmpHelper
 
         try
         {
+            using var suppressInstrumentation = SuppressInstrumentationScope.Begin();
+
             _client?.StopAsync().GetAwaiter().GetResult();
 
             if (_clientStartupTask != null)

--- a/src/OpenTelemetry.AutoInstrumentation/OpAmpHelper.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/OpAmpHelper.cs
@@ -33,6 +33,8 @@ internal static class OpAmpHelper
             {
                 try
                 {
+                    using var suppressInstrumentation = SuppressInstrumentationScope.Begin();
+
                     IsRunning = true;
 
                     await _client.StartAsync(_cts.Token).ConfigureAwait(false);

--- a/test/IntegrationTests/Helpers/MockSpansCollector.cs
+++ b/test/IntegrationTests/Helpers/MockSpansCollector.cs
@@ -27,6 +27,7 @@ internal sealed class MockSpansCollector : IDisposable
     private readonly BlockingCollection<Collected> _spans = new(100); // bounded to avoid memory leak
     private readonly List<Expectation> _expectations = new();
     private Func<ICollection<Collected>, bool>? _collectedExpectation;
+    private Func<ICollection<Collected>, bool>? _allCollectedExpectation;
 
     public MockSpansCollector(ITestOutputHelper output, string host = "localhost")
     {
@@ -70,6 +71,11 @@ internal sealed class MockSpansCollector : IDisposable
     public void ExpectCollected(Func<ICollection<Collected>, bool> collectedExpectation)
     {
         _collectedExpectation = collectedExpectation;
+    }
+
+    public void ExpectAllCollected(Func<ICollection<Collected>, bool> collectedExpectation)
+    {
+        _allCollectedExpectation = collectedExpectation;
     }
 
     public void AssertExpectations(TimeSpan? timeout = null)
@@ -132,6 +138,17 @@ internal sealed class MockSpansCollector : IDisposable
                     if (_collectedExpectation != null && !_collectedExpectation(expectationsMet))
                     {
                         FailCollectedExpectation(expectationsMet);
+                    }
+
+                    if (_allCollectedExpectation != null)
+                    {
+                        var allCollected = expectationsMet.Concat(additionalEntries).ToList();
+                        DrainAvailable(allCollected);
+
+                        if (!_allCollectedExpectation(allCollected))
+                        {
+                            FailCollectedExpectation(allCollected);
+                        }
                     }
 
                     return;
@@ -199,6 +216,14 @@ internal sealed class MockSpansCollector : IDisposable
         }
 
         Assert.Fail(message.ToString());
+    }
+
+    private void DrainAvailable(List<Collected> collected)
+    {
+        while (_spans.TryTake(out var resourceSpan, TestTimeout.NoExpectation))
+        {
+            collected.Add(resourceSpan);
+        }
     }
 
 #if NETFRAMEWORK

--- a/test/IntegrationTests/OpAmpTests.cs
+++ b/test/IntegrationTests/OpAmpTests.cs
@@ -1,8 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Globalization;
 using IntegrationTests.Helpers;
 using OpAmp.Proto.V1;
+using OpenTelemetry.Proto.Trace.V1;
 
 namespace IntegrationTests;
 
@@ -44,5 +46,77 @@ public class OpAmpTests : TestHelper
 
         Assert.NotNull(agentDescriptionFrame);
         Assert.Contains(agentDescriptionFrame.NonIdentifyingAttributes, a => a.Key == "opamp.test");
+    }
+
+    [Fact]
+    [Trait("Category", "EndToEnd")]
+    public void OpAmpClient_DoesNotCollectInternalTransportTraces()
+    {
+        using var server = new MockOpAmpServer(Output);
+        using var collector = new MockSpansCollector(Output);
+
+        SetExporter(collector);
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_OPAMP_ENABLED", "true");
+        SetEnvironmentVariable("OTEL_DOTNET_AUTO_OPAMP_SERVER_URL", $"http://localhost:{server.Port}/v1/opamp");
+
+#if NET
+        collector.Expect(
+            "System.Net.Http",
+            span => span.Kind == Span.Types.SpanKind.Client && !IsOpAmpTransportSpan(span, server.Port),
+            "Has application HTTP client span");
+        collector.Expect(
+            "Microsoft.AspNetCore",
+            span => span.Kind == Span.Types.SpanKind.Server,
+            "Has application ASP.NET Core server span");
+        collector.Expect(
+            "TestApplication.Http",
+            span => span.Name == "manual span",
+            "Has application manual span");
+#else
+        collector.Expect(
+            "OpenTelemetry.Instrumentation.Http.HttpWebRequest",
+            span => span.Kind == Span.Types.SpanKind.Client && !IsOpAmpTransportSpan(span, server.Port),
+            "Has application HTTP client span");
+#endif
+        collector.ExpectAllCollected(collected => collected.All(span => !IsOpAmpTransportSpan(span.Span, server.Port)));
+
+        server.Expect(f => f.AgentDescription != null, "Has AgentDescription frame");
+        server.Expect(f => f.AgentDisconnect != null, "Has AgentDisconnect frame");
+
+        RunTestApplication();
+
+        server.AssertExpectations();
+        collector.AssertExpectations();
+    }
+
+    private static bool IsOpAmpTransportSpan(Span span, int serverPort)
+    {
+        return span.Kind == Span.Types.SpanKind.Client &&
+               HasOpAmpEndpointAttribute(span) &&
+               HasServerPortAttribute(span, serverPort);
+    }
+
+    private static bool HasOpAmpEndpointAttribute(Span span)
+    {
+        return Contains(span.Name, "/v1/opamp") ||
+               span.Attributes.Any(attribute => Contains(attribute.Value.StringValue, "/v1/opamp"));
+    }
+
+    private static bool HasServerPortAttribute(Span span, int serverPort)
+    {
+        var serverPortString = serverPort.ToString(CultureInfo.InvariantCulture);
+
+        return span.Attributes.Any(attribute =>
+            (attribute.Key == "server.port" && attribute.Value.IntValue == serverPort) ||
+            Contains(attribute.Value.StringValue, $":{serverPortString}/v1/opamp"));
+    }
+
+    private static bool Contains(string value, string expected)
+    {
+#if NET
+        return value.Contains(expected, StringComparison.OrdinalIgnoreCase);
+#else
+        return value.IndexOf(expected, StringComparison.OrdinalIgnoreCase) >= 0;
+#endif
     }
 }


### PR DESCRIPTION
## Why & What

During OpAMP client startup, internal transport calls can be unintentionally instrumented and traced. These startup-time traces add noise, may create misleading telemetry, and do not provide meaningful observability value because they originate from the client's own initialization process rather than user workloads.

## Tests

Ci

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- ~[ ] Documentation is updated.~
- [x] New features are covered by tests.
