### PR TITLE
Bump OTel core packages to 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 #### Dependency updates
 
+- Updated [Core components](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/VERSIONING.md#core-components):
+  [`1.16.0`](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.16.0).
 - Following packages updated
   - `Google.Protobuf` updated from `3.31.1` to `3.35.0`,
   - `OpenTelemetry.OpAmp.Client` from `0.3.0-alpha.1` to `0.4.0-alpha.1`.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,10 @@
   <ItemGroup>
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Wcf" Version="1.15.1-beta.2" />
     <PackageVersion Include="OpenTelemetry.OpAmp.Client" Version="0.4.0-alpha.1" />

--- a/docs/config.md
+++ b/docs/config.md
@@ -360,7 +360,7 @@ To enable the OTLP exporter, set the `OTEL_TRACES_EXPORTER`/`OTEL_METRICS_EXPORT
 environment variable to `otlp`.
 
 To customize the OTLP exporter using environment variables, see the
-[OTLP exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.15.3/src/OpenTelemetry.Exporter.OpenTelemetryProtocol#environment-variables).
+[OTLP exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.16.0/src/OpenTelemetry.Exporter.OpenTelemetryProtocol#environment-variables).
 Important environment variables include:
 
 | Environment variable                                | Description                                                                                                                                                                                                | Default value                                                                        | Status                                                                                                                      |
@@ -447,7 +447,7 @@ The exporter exposes the metrics HTTP endpoint on `http://localhost:9464/metrics
 and it caches the responses for 300 milliseconds.
 
 See the
-[Prometheus Exporter HttpListener documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/coreunstable-1.15.3-beta.1/src/OpenTelemetry.Exporter.Prometheus.HttpListener).
+[Prometheus Exporter HttpListener documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/coreunstable-1.16.0-beta.1/src/OpenTelemetry.Exporter.Prometheus.HttpListener).
 to learn more.
 
 ### Zipkin
@@ -458,7 +458,7 @@ To enable the Zipkin exporter, set the `OTEL_TRACES_EXPORTER` environment
 variable to `zipkin`.
 
 To customize the Zipkin exporter using environment variables,
-see the [Zipkin exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.15.3/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables).
+see the [Zipkin exporter documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.16.0/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables).
 Important environment variables include:
 
 | Environment variable            | Description | Default value                        | Status                                                                                                                      |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -145,9 +145,9 @@ public class MyOpAmpPlugin
 
 | Options type                                                                              | NuGet package                                     | NuGet version |
 |-------------------------------------------------------------------------------------------|---------------------------------------------------|---------------|
-| OpenTelemetry.Exporter.ConsoleExporterOptions                                             | OpenTelemetry.Exporter.Console                    | 1.15.3        |
-| OpenTelemetry.Exporter.ZipkinExporterOptions  **Deprecated**                              | OpenTelemetry.Exporter.Zipkin                     | 1.15.3        |
-| OpenTelemetry.Exporter.OtlpExporterOptions                                                | OpenTelemetry.Exporter.OpenTelemetryProtocol      | 1.15.3        |
+| OpenTelemetry.Exporter.ConsoleExporterOptions                                             | OpenTelemetry.Exporter.Console                    | 1.16.0        |
+| OpenTelemetry.Exporter.ZipkinExporterOptions  **Deprecated**                              | OpenTelemetry.Exporter.Zipkin                     | 1.16.0        |
+| OpenTelemetry.Exporter.OtlpExporterOptions                                                | OpenTelemetry.Exporter.OpenTelemetryProtocol      | 1.16.0        |
 | OpenTelemetry.Instrumentation.AspNet.AspNetTraceInstrumentationOptions                    | OpenTelemetry.Instrumentation.AspNet              | 1.15.2        |
 | OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreTraceInstrumentationOptions            | OpenTelemetry.Instrumentation.AspNetCore          | 1.15.2        |
 | OpenTelemetry.Instrumentation.EntityFrameworkCore.EntityFrameworkInstrumentationOptions   | OpenTelemetry.Instrumentation.EntityFrameworkCore | 1.15.1-beta.1 |
@@ -162,10 +162,10 @@ public class MyOpAmpPlugin
 
 | Options type                                                             | NuGet package                                  | NuGet version |
 |--------------------------------------------------------------------------|------------------------------------------------|---------------|
-| OpenTelemetry.Metrics.MetricReaderOptions                                | OpenTelemetry                                  | 1.15.3        |
-| OpenTelemetry.Exporter.ConsoleExporterOptions                            | OpenTelemetry.Exporter.Console                 | 1.15.3        |
-| OpenTelemetry.Exporter.PrometheusExporterOptions                         | OpenTelemetry.Exporter.Prometheus.HttpListener | 1.15.3-beta.1 |
-| OpenTelemetry.Exporter.OtlpExporterOptions                               | OpenTelemetry.Exporter.OpenTelemetryProtocol   | 1.15.3        |
+| OpenTelemetry.Metrics.MetricReaderOptions                                | OpenTelemetry                                  | 1.16.0        |
+| OpenTelemetry.Exporter.ConsoleExporterOptions                            | OpenTelemetry.Exporter.Console                 | 1.16.0        |
+| OpenTelemetry.Exporter.PrometheusExporterOptions                         | OpenTelemetry.Exporter.Prometheus.HttpListener | 1.16.0-beta.1 |
+| OpenTelemetry.Exporter.OtlpExporterOptions                               | OpenTelemetry.Exporter.OpenTelemetryProtocol   | 1.16.0        |
 | OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions | OpenTelemetry.Instrumentation.AspNet           | 1.15.2        |
 | OpenTelemetry.Instrumentation.Runtime.RuntimeInstrumentationOptions      | OpenTelemetry.Instrumentation.Runtime          | 1.15.1        |
 
@@ -173,9 +173,9 @@ public class MyOpAmpPlugin
 
 | Options type                                  | NuGet package                                | NuGet version |
 |-----------------------------------------------|----------------------------------------------|---------------|
-| OpenTelemetry.Logs.OpenTelemetryLoggerOptions | OpenTelemetry                                | 1.15.3        |
-| OpenTelemetry.Exporter.ConsoleExporterOptions | OpenTelemetry.Exporter.Console               | 1.15.3        |
-| OpenTelemetry.Exporter.OtlpExporterOptions    | OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.3        |
+| OpenTelemetry.Logs.OpenTelemetryLoggerOptions | OpenTelemetry                                | 1.16.0        |
+| OpenTelemetry.Exporter.ConsoleExporterOptions | OpenTelemetry.Exporter.Console               | 1.16.0        |
+| OpenTelemetry.Exporter.OtlpExporterOptions    | OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.16.0        |
 
 ### OpAMP
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,10 +9,10 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetVersioningVersion)" />
   </ItemGroup>
   <ItemGroup Label="Versions from OpenTelemetry.AutoInstrumentation.csproj and OTEL transitive dependencies">
-    <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.3-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.16.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNet" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
@@ -23,7 +23,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.2" />
-    <PackageVersion Include="OpenTelemetry.Shims.OpenTracing" Version="1.15.3-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Shims.OpenTracing" Version="1.16.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.15.1-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.15.1-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.15.1-beta.1" />

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/Otlp/OtlpSettings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/Otlp/OtlpSettings.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Net.Http;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Logging;
 using OpenTelemetry.Exporter;
@@ -14,6 +15,7 @@ namespace OpenTelemetry.AutoInstrumentation.Configurations.Otlp;
 internal class OtlpSettings
 {
     private static readonly IOtelLogger Logger = OtelLogging.GetLogger();
+    private static readonly Func<HttpClient> DefaultHttpClientFactory = static () => new HttpClient();
 
     public OtlpSettings(OtlpSignalType signalType, Configuration configuration)
     {
@@ -95,6 +97,13 @@ internal class OtlpSettings
         if (TimeoutMilliseconds.HasValue)
         {
             options.TimeoutMilliseconds = TimeoutMilliseconds.Value;
+        }
+
+        if (Protocol == OtlpExportProtocol.HttpProtobuf)
+        {
+            // Avoid the SDK's DI-backed IHttpClientFactory fallback, which can resolve
+            // services after the application IServiceProvider has been disposed.
+            options.HttpClientFactory = DefaultHttpClientFactory;
         }
     }
 

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Log4Net/Bridge/OpenTelemetryLogHelpers.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Log4Net/Bridge/OpenTelemetryLogHelpers.cs
@@ -55,6 +55,7 @@ internal static class OpenTelemetryLogHelpers
         //         .Default(System.Void)
         //     };
         //     .Call $instance.set_Timestamp($timestamp);
+        //     .Call $instance.set_ObservedTimestamp(System.DateTime.UtcNow);
         //     .If ($severityText != null) {
         //         .Call $instance.set_SeverityText($severityText)
         //     } .Else {
@@ -65,9 +66,11 @@ internal static class OpenTelemetryLogHelpers
         // }
 
         var timestampSetterMethodInfo = logRecordDataType.GetProperty("Timestamp")!.GetSetMethod()!;
+        var observedTimestampSetterMethodInfo = logRecordDataType.GetProperty("ObservedTimestamp")!.GetSetMethod()!;
         var bodySetterMethodInfo = logRecordDataType.GetProperty("Body")!.GetSetMethod()!;
         var severityTextSetterMethodInfo = logRecordDataType.GetProperty("SeverityText")!.GetSetMethod()!;
         var severityLevelSetterMethodInfo = logRecordDataType.GetProperty("Severity")!.GetSetMethod()!;
+        var utcNowPropertyInfo = typeof(DateTime).GetProperty(nameof(DateTime.UtcNow))!;
 
         var instanceVar = Expression.Variable(bodySetterMethodInfo.DeclaringType!, "instance");
 
@@ -75,6 +78,7 @@ internal static class OpenTelemetryLogHelpers
         var assignInstanceVar = Expression.Assign(instanceVar, Expression.New(constructorInfo, activity));
         var setBody = Expression.IfThen(Expression.NotEqual(body, Expression.Constant(null)), Expression.Call(instanceVar, bodySetterMethodInfo, body));
         var setTimestamp = Expression.Call(instanceVar, timestampSetterMethodInfo, timestamp);
+        var setObservedTimestamp = Expression.Call(instanceVar, observedTimestampSetterMethodInfo, Expression.Property(null, utcNowPropertyInfo));
         var setSeverityText = Expression.IfThen(Expression.NotEqual(severityText, Expression.Constant(null)), Expression.Call(instanceVar, severityTextSetterMethodInfo, severityText));
         var setSeverityLevel = Expression.Call(instanceVar, severityLevelSetterMethodInfo, Expression.Convert(severityLevel, typeof(Nullable<>).MakeGenericType(severityType)));
 
@@ -83,6 +87,7 @@ internal static class OpenTelemetryLogHelpers
             assignInstanceVar,
             setBody,
             setTimestamp,
+            setObservedTimestamp,
             setSeverityText,
             setSeverityLevel,
             instanceVar);

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/Bridge/OpenTelemetryLogHelpers.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/NLog/Bridge/OpenTelemetryLogHelpers.cs
@@ -91,14 +91,17 @@ internal static class OpenTelemetryLogHelpers
         // var instance = new LogRecordData(activity);
         // if (body != null) instance.Body = body;
         // instance.Timestamp = timestamp;
+        // instance.ObservedTimestamp = DateTime.UtcNow;
         // if (severityText != null) instance.SeverityText = severityText;
         // instance.Severity = (LogRecordSeverity?)severityLevel;
         // return instance;
 
         var timestampSetterMethodInfo = logRecordDataType.GetProperty("Timestamp")!.GetSetMethod()!;
+        var observedTimestampSetterMethodInfo = logRecordDataType.GetProperty("ObservedTimestamp")!.GetSetMethod()!;
         var bodySetterMethodInfo = logRecordDataType.GetProperty("Body")!.GetSetMethod()!;
         var severityTextSetterMethodInfo = logRecordDataType.GetProperty("SeverityText")!.GetSetMethod()!;
         var severityLevelSetterMethodInfo = logRecordDataType.GetProperty("Severity")!.GetSetMethod()!;
+        var utcNowPropertyInfo = typeof(DateTime).GetProperty(nameof(DateTime.UtcNow))!;
 
         var instanceVar = Expression.Variable(bodySetterMethodInfo.DeclaringType!, "instance");
 
@@ -106,6 +109,7 @@ internal static class OpenTelemetryLogHelpers
         var assignInstanceVar = Expression.Assign(instanceVar, Expression.New(constructorInfo, activity));
         var setBody = Expression.IfThen(Expression.NotEqual(body, Expression.Constant(null)), Expression.Call(instanceVar, bodySetterMethodInfo, body));
         var setTimestamp = Expression.Call(instanceVar, timestampSetterMethodInfo, timestamp);
+        var setObservedTimestamp = Expression.Call(instanceVar, observedTimestampSetterMethodInfo, Expression.Property(null, utcNowPropertyInfo));
         var setSeverityText = Expression.IfThen(Expression.NotEqual(severityText, Expression.Constant(null)), Expression.Call(instanceVar, severityTextSetterMethodInfo, severityText));
         var setSeverityLevel = Expression.Call(instanceVar, severityLevelSetterMethodInfo, Expression.Convert(severityLevel, typeof(Nullable<>).MakeGenericType(severityType)));
 
@@ -114,6 +118,7 @@ internal static class OpenTelemetryLogHelpers
             assignInstanceVar,
             setBody,
             setTimestamp,
+            setObservedTimestamp,
             setSeverityText,
             setSeverityLevel,
             instanceVar);

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/SettingsTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Globalization;
+using System.Net.Http;
 using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
 using OpenTelemetry.Exporter;
@@ -448,6 +449,37 @@ public sealed class SettingsTests
         // null values for expected data will be handled by OTel .NET SDK
         Assert.NotNull(settings.OtlpSettings);
         Assert.Equal(expectedOtlpExportProtocol, settings.OtlpSettings.Protocol);
+    }
+
+    [Theory]
+    [InlineData("http/protobuf", true)]
+#if NETFRAMEWORK
+    [InlineData("grpc", true)]
+#else
+    [InlineData("grpc", false)]
+#endif
+    internal void OtlpSettings_CopyTo_OverridesHttpClientFactoryForHttpProtobufOnly(string otlpProtocol, bool expectHttpClientFactoryOverride)
+    {
+        using var envScope = new EnvironmentScope(new Dictionary<string, string?>()
+        {
+            { AutoOtlpDefinitions.DefaultProtocolEnvVarName, otlpProtocol }
+        });
+
+        var settings = Settings.FromDefaultSources<TracerSettings>(false).OtlpSettings;
+        var options = new OtlpExporterOptions();
+        Func<HttpClient> originalHttpClientFactory = static () => new HttpClient();
+        options.HttpClientFactory = originalHttpClientFactory;
+
+        settings?.CopyTo(options);
+
+        if (expectHttpClientFactoryOverride)
+        {
+            Assert.NotSame(originalHttpClientFactory, options.HttpClientFactory);
+        }
+        else
+        {
+            Assert.Same(originalHttpClientFactory, options.HttpClientFactory);
+        }
     }
 
     [Theory]

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/OpenTelemetryLogHelpersTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/OpenTelemetryLogHelpersTests.cs
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+using OpenTelemetry.Logs;
+using Log4NetLogHelpers = OpenTelemetry.AutoInstrumentation.Instrumentations.Log4Net.Bridge.OpenTelemetryLogHelpers;
+using NLogLogHelpers = OpenTelemetry.AutoInstrumentation.Instrumentations.NLog.Bridge.OpenTelemetryLogHelpers;
+
+namespace OpenTelemetry.AutoInstrumentation.Tests;
+
+public class OpenTelemetryLogHelpersTests
+{
+    [Theory]
+    [InlineData(typeof(Log4NetLogHelpers))]
+    [InlineData(typeof(NLogLogHelpers))]
+    internal void BuildLogRecord_SetsObservedTimestampToUtcNow(Type logHelpersType)
+    {
+        var logRecordDataType = typeof(LoggerProvider).Assembly.GetType("OpenTelemetry.Logs.LogRecordData")!;
+        var severityType = typeof(LoggerProvider).Assembly.GetType("OpenTelemetry.Logs.LogRecordSeverity")!;
+
+        var body = Expression.Parameter(typeof(string), "body");
+        var timestamp = Expression.Parameter(typeof(DateTime), "timestamp");
+        var severityText = Expression.Parameter(typeof(string), "severityText");
+        var severityLevel = Expression.Parameter(typeof(int), "severityLevel");
+        var activity = Expression.Parameter(typeof(Activity), "activity");
+
+        var buildLogRecord = logHelpersType.GetMethod("BuildLogRecord", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var logRecordExpression = (BlockExpression)buildLogRecord.Invoke(
+            null,
+            [logRecordDataType, severityType, body, timestamp, severityText, severityLevel, activity])!;
+        var factory = Expression.Lambda<Func<string, DateTime, string, int, Activity?, object>>(
+                Expression.Convert(logRecordExpression, typeof(object)),
+                body,
+                timestamp,
+                severityText,
+                severityLevel,
+                activity)
+            .Compile();
+
+        var logTimestamp = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var beforeEmit = DateTime.UtcNow;
+
+        var logRecord = factory("body", logTimestamp, "Info", 9, null);
+
+        var afterEmit = DateTime.UtcNow;
+        var actualTimestamp = (DateTime)logRecordDataType.GetProperty("Timestamp")!.GetValue(logRecord)!;
+        var observedTimestamp = (DateTime)logRecordDataType.GetProperty("ObservedTimestamp")!.GetValue(logRecord)!;
+
+        Assert.Equal(logTimestamp, actualTimestamp);
+        Assert.InRange(observedTimestamp, beforeEmit, afterEmit);
+        Assert.Equal(DateTimeKind.Utc, observedTimestamp.Kind);
+    }
+}


### PR DESCRIPTION
## Why

Towards #4941

 ## What

Handles
https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.16.0
https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/coreunstable-1.16.0-beta.1

and https://github.com/open-telemetry/opentelemetry-dotnet/pull/6979


## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
