### PR TITLE
[Tests] Suppress SQlite related GHSA-2m69-gcr7-jv3q

### DIFF
--- a/test/test-applications/integrations/TestApplication.EntityFrameworkCore/TestApplication.EntityFrameworkCore.csproj
+++ b/test/test-applications/integrations/TestApplication.EntityFrameworkCore/TestApplication.EntityFrameworkCore.csproj
@@ -8,4 +8,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="$(LibraryVersion)" Condition=" '$(LibraryVersion)' != '' or '$(TargetFramework)' == 'net10.0' " />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="9.0.17" Condition=" '$(LibraryVersion)' == '' and ('$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net8.0' ) " />
   </ItemGroup>
+
+  <!-- TODO remove when https://github.com/dotnet/efcore/issues/38257 is fixed by: https://github.com/dotnet/efcore/pull/38402 -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why

Fix failing CI. The same fix was applied in contrib: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4544

## What

[Tests] Suppress SQlite related security issue
for now the fix is not yet available

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
