### PR TITLE
[Tests] Bump CoreWCF packages

### DIFF
--- a/build/LibraryVersions.g.cs
+++ b/build/LibraryVersions.g.cs
@@ -220,8 +220,8 @@ public static partial class LibraryVersion
         {
             "TestApplication.Wcf.Core",
             [
-                new("1.8.0", supportedFrameworks: [ "net10.0", "net9.0", "net8.0" ]),
-                new("1.9.0", supportedFrameworks: [ "net10.0", "net9.0", "net8.0" ]),
+                new("1.8.1", supportedFrameworks: [ "net10.0", "net9.0", "net8.0" ]),
+                new("1.9.1", supportedFrameworks: [ "net10.0", "net9.0", "net8.0" ]),
             ]
         },
     };

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,9 +3,9 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageVersion Include="Confluent.Kafka" Version="2.14.2" />
-    <PackageVersion Include="CoreWCF.Http" Version="1.9.0" />
-    <PackageVersion Include="CoreWCF.NetTcp" Version="1.9.0" />
-    <PackageVersion Include="CoreWCF.Primitives" Version="1.9.0" />
+    <PackageVersion Include="CoreWCF.Http" Version="1.9.1" />
+    <PackageVersion Include="CoreWCF.NetTcp" Version="1.9.1" />
+    <PackageVersion Include="CoreWCF.Primitives" Version="1.9.1" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.4.2" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="GraphQL" Version="8.8.4" />

--- a/test/IntegrationTests/LibraryVersions.g.cs
+++ b/test/IntegrationTests/LibraryVersions.g.cs
@@ -494,10 +494,10 @@ public static partial class LibraryVersion
                 string.Empty,
 #else
 #if NET10_0 || NET9_0 || NET8_0
-                "1.8.0",
+                "1.8.1",
 #endif
 #if NET10_0 || NET9_0 || NET8_0
-                "1.9.0",
+                "1.9.1",
 #endif
 #endif
             ];

--- a/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
+++ b/tools/LibraryVersionsGenerator/PackageVersionDefinitions.cs
@@ -358,7 +358,7 @@ internal static class PackageVersionDefinitions
             TestApplicationName = "TestApplication.Wcf.Core",
             Versions =
             [
-                new("1.8.0", supportedTargetFrameworks: ["net10.0", "net9.0", "net8.0"], supportedExecutionFrameworks: ["net10.0", "net9.0", "net8.0"]),
+                new("1.8.1", supportedTargetFrameworks: ["net10.0", "net9.0", "net8.0"], supportedExecutionFrameworks: ["net10.0", "net9.0", "net8.0"]),
                 new("*", supportedTargetFrameworks: ["net10.0", "net9.0", "net8.0"], supportedExecutionFrameworks: ["net10.0", "net9.0", "net8.0"])
             ]
         }


### PR DESCRIPTION
## Why & What

[Tests] Bump CoreWCF packages
to avoid vulnerable dependencies including CVSS10.0 GHSA-xjr9-gg9q-jx3v

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.
