### PR TITLE
feat(kafka): add messaging.kafka.cluster.id span attribute

### DIFF
--- a/.cspell/other.txt
+++ b/.cspell/other.txt
@@ -60,6 +60,7 @@ proto
 protobuf
 protos
 RABBITMQ
+SASL
 Serilog
 Sonoma
 spdlog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ release.
 
 ### Added
 
+- Add `messaging.kafka.cluster.id` span attribute to Confluent.Kafka producer
+  and consumer spans (Confluent.Kafka ≥2.0.0). The cluster UUID is fetched
+  once per unique bootstrap-servers string via a background
+  `AdminClient.DescribeClusterAsync()` call and cached; no overhead on the
+  produce/consume hot path. SASL and SSL client configuration is forwarded to
+  the `AdminClient` so authenticated clusters are supported. If the cluster ID
+  is not yet resolved, the attribute is omitted for that span.
 - Support for `11.*` versions for following libraries:
   - `Microsoft.Data.Sqlite`,
   - `Microsoft.Extensions.Logging`,

--- a/docs/config.md
+++ b/docs/config.md
@@ -196,6 +196,11 @@ due to lack of stable semantic convention.
 
 \[8\]: `Confluent.Kafka` is supported from version ≥1.8.2 on ARM64
        for Windows and Linux, and ≥1.9.2 on macOS.
+       For versions ≥2.0.0, the `messaging.kafka.cluster.id` span attribute
+       is populated automatically. Cluster ID is fetched once per unique
+       bootstrap-servers string via a background `AdminClient` call;
+       SASL/SSL client configuration is forwarded so authenticated
+       clusters are supported.
 
 \[9\]: `MongoDB.Driver` needs bytecode instrumentation only for < `3.7.0`
         versions, `3.7.0+` uses only source instrumentation.

--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerConstructorIntegration

--- a/src/OpenTelemetry.AutoInstrumentation/.publicApi/net8.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.AutoInstrumentation/.publicApi/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerConstructorIntegration

--- a/src/OpenTelemetry.AutoInstrumentation/Generated/net462/SourceGenerators/SourceGenerators.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Generated/net462/SourceGenerators/SourceGenerators.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -17,7 +17,7 @@ internal static partial class InstrumentationDefinitions
 {
     private static NativeCallTargetDefinition[] GetDefinitionsArray()
     {
-        var nativeCallTargetDefinitions = new List<NativeCallTargetDefinition>(60);
+        var nativeCallTargetDefinitions = new List<NativeCallTargetDefinition>(61);
         // Traces
         var tracerSettings = Instrumentation.TracerSettings.Value;
         if (tracerSettings.TracesEnabled)
@@ -48,6 +48,7 @@ internal static partial class InstrumentationDefinitions
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Consumer`2", ".ctor", ["System.Void", "Confluent.Kafka.ConsumerBuilder`2[!0,!1]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ConsumerConstructorIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Consume", ["Confluent.Kafka.ConsumeResult`2[!0,!1]", "System.Int32"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ConsumerConsumeSyncIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Dispose", ["System.Void"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ConsumerDisposeIntegration"));
+                nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2", ".ctor", ["System.Void", "Confluent.Kafka.ProducerBuilder`2[!0,!1]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerConstructorIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2+TypedDeliveryHandlerShim_Action", ".ctor", ["System.Void", "System.String", "!0", "!1", "System.Action`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerDeliveryHandlerActionIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2", "ProduceAsync", ["System.Threading.Tasks.Task`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Threading.CancellationToken"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerProduceAsyncIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2", "Produce", ["System.Void", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Action`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerProduceSyncIntegration"));

--- a/src/OpenTelemetry.AutoInstrumentation/Generated/net8.0/SourceGenerators/SourceGenerators.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Generated/net8.0/SourceGenerators/SourceGenerators.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -17,7 +17,7 @@ internal static partial class InstrumentationDefinitions
 {
     private static NativeCallTargetDefinition[] GetDefinitionsArray()
     {
-        var nativeCallTargetDefinitions = new List<NativeCallTargetDefinition>(58);
+        var nativeCallTargetDefinitions = new List<NativeCallTargetDefinition>(59);
         // Traces
         var tracerSettings = Instrumentation.TracerSettings.Value;
         if (tracerSettings.TracesEnabled)
@@ -42,6 +42,7 @@ internal static partial class InstrumentationDefinitions
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Consumer`2", ".ctor", ["System.Void", "Confluent.Kafka.ConsumerBuilder`2[!0,!1]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ConsumerConstructorIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Consume", ["Confluent.Kafka.ConsumeResult`2[!0,!1]", "System.Int32"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ConsumerConsumeSyncIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Dispose", ["System.Void"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ConsumerDisposeIntegration"));
+                nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2", ".ctor", ["System.Void", "Confluent.Kafka.ProducerBuilder`2[!0,!1]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerConstructorIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2+TypedDeliveryHandlerShim_Action", ".ctor", ["System.Void", "System.String", "!0", "!1", "System.Action`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerDeliveryHandlerActionIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2", "ProduceAsync", ["System.Threading.Tasks.Task`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Threading.CancellationToken"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerProduceAsyncIntegration"));
                 nativeCallTargetDefinitions.Add(new("Confluent.Kafka", "Confluent.Kafka.Producer`2", "Produce", ["System.Void", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Action`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]"], 1, 4, 0, 2, 65535, 65535, AssemblyFullName, "OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations.ProducerProduceSyncIntegration"));

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/BootstrapServersCache.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/BootstrapServersCache.cs
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+
+namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka;
+
+internal static class BootstrapServersCache
+{
+    private static readonly ConditionalWeakTable<object, string> InstanceBootstrapServersMap = new();
+
+    public static void Add(object instance, string bootstrapServers)
+    {
+        InstanceBootstrapServersMap.GetValue(instance, createValueCallback: _ => bootstrapServers);
+    }
+
+    public static bool TryGet(object instance, out string? bootstrapServers)
+    {
+        bootstrapServers = null;
+        return InstanceBootstrapServersMap.TryGetValue(instance, out bootstrapServers);
+    }
+
+    public static void Remove(object instance)
+    {
+        InstanceBootstrapServersMap.Remove(instance);
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IDescribeClusterResult.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IDescribeClusterResult.cs
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.DuckTypes;
+
+// wraps https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/src/Confluent.Kafka/Admin/DescribeClusterResult.cs
+internal interface IDescribeClusterResult
+{
+    public string ClusterId { get; }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IKafkaClientHandle.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IKafkaClientHandle.cs
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.DuckTypes;
+
+// wraps https://github.com/confluentinc/confluent-kafka-dotnet/blob/master/src/Confluent.Kafka/IClient.cs
+internal interface IKafkaClientHandle
+{
+    public object Handle { get; }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IProducerBuilder.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/DuckTypes/IProducerBuilder.cs
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.DuckTypes;
+
+// wraps https://github.com/confluentinc/confluent-kafka-dotnet/blob/07de95ed647af80a0db39ce6a8891a630423b952/src/Confluent.Kafka/ProducerBuilder.cs
+internal interface IProducerBuilder
+{
+    public IEnumerable<KeyValuePair<string, string>>? Config { get; set; }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/IntegrationConstants.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/IntegrationConstants.cs
@@ -13,6 +13,7 @@ internal static class IntegrationConstants
     public const string ProducerDeliveryHandlerShimTypeName = "Confluent.Kafka.Producer`2+TypedDeliveryHandlerShim_Action";
     public const string ConsumerTypeName = "Confluent.Kafka.Consumer`2";
     public const string ConsumerBuilderTypeName = "Confluent.Kafka.ConsumerBuilder`2[!0,!1]";
+    public const string ProducerBuilderTypeName = "Confluent.Kafka.ProducerBuilder`2[!0,!1]";
     public const string ProduceSyncMethodName = "Produce";
     public const string ProduceAsyncMethodName = "ProduceAsync";
     public const string ConsumeSyncMethodName = "Consume";

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerCloseIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerCloseIntegration.cs
@@ -23,6 +23,7 @@ public static class ConsumerCloseIntegration
     internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception? exception, in CallTargetState state)
     {
         ConsumerCache.Remove(instance!);
+        BootstrapServersCache.Remove(instance!);
         return CallTargetReturn.GetDefault();
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerDisposeIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ConsumerDisposeIntegration.cs
@@ -23,6 +23,7 @@ public static class ConsumerDisposeIntegration
     internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception? exception, in CallTargetState state)
     {
         ConsumerCache.Remove(instance!);
+        BootstrapServersCache.Remove(instance!);
         return CallTargetReturn.GetDefault();
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/KafkaConstructorFetchState.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/KafkaConstructorFetchState.cs
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations;
+
+internal sealed class KafkaConstructorFetchState
+{
+    internal KafkaConstructorFetchState(string bootstrapServers, List<KeyValuePair<string, string>>? config)
+    {
+        BootstrapServers = bootstrapServers;
+        Config = config;
+    }
+
+    internal string BootstrapServers { get; }
+
+    internal List<KeyValuePair<string, string>>? Config { get; }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerConstructorIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerConstructorIntegration.cs
@@ -9,51 +9,42 @@ using OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.DuckTypes;
 namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.Integrations;
 
 /// <summary>
-/// Kafka consumer ctor instrumentation
+/// Kafka producer ctor instrumentation
 /// </summary>
 [InstrumentMethod(
     assemblyName: IntegrationConstants.ConfluentKafkaAssemblyName,
-    typeName: IntegrationConstants.ConsumerTypeName,
+    typeName: IntegrationConstants.ProducerTypeName,
     methodName: ".ctor",
     returnTypeName: ClrNames.Void,
-    parameterTypeNames: [IntegrationConstants.ConsumerBuilderTypeName],
+    parameterTypeNames: [IntegrationConstants.ProducerBuilderTypeName],
     minimumVersion: IntegrationConstants.MinVersion,
     maximumVersion: IntegrationConstants.MaxVersion,
     integrationName: IntegrationConstants.IntegrationName,
     type: InstrumentationType.Trace)]
-public static class ConsumerConstructorIntegration
+public static class ProducerConstructorIntegration
 {
-    private const string ConsumerGroupIdConfigKey = "group.id";
     private const string BootstrapServersConfigKey = "bootstrap.servers";
 
-    internal static CallTargetState OnMethodBegin<TTarget, TConsumerBuilder>(TTarget instance, TConsumerBuilder consumerBuilder)
-    where TConsumerBuilder : IConsumerBuilder, IDuckType
+    internal static CallTargetState OnMethodBegin<TTarget, TProducerBuilder>(TTarget instance, TProducerBuilder producerBuilder)
+    where TProducerBuilder : IProducerBuilder, IDuckType
     {
-        // duck type created for consumer builder is a struct
-        if (consumerBuilder.Instance is null)
+        // Duck type created for producer builder is a struct
+        if (producerBuilder.Instance is null)
         {
             // invalid parameters, exit early
             return CallTargetState.GetDefault();
         }
 
-        string? consumerGroupId = null;
         string? bootstrapServers = null;
         List<KeyValuePair<string, string>>? configList = null;
 
-        if (consumerBuilder.Config is not null)
+        if (producerBuilder.Config is not null)
         {
             configList = new List<KeyValuePair<string, string>>();
-            foreach (var keyValuePair in consumerBuilder.Config)
+            foreach (var keyValuePair in producerBuilder.Config)
             {
                 configList.Add(keyValuePair);
                 if (string.Equals(
-                        keyValuePair.Key,
-                        ConsumerGroupIdConfigKey,
-                        StringComparison.OrdinalIgnoreCase))
-                {
-                    consumerGroupId = keyValuePair.Value;
-                }
-                else if (string.Equals(
                         keyValuePair.Key,
                         BootstrapServersConfigKey,
                         StringComparison.OrdinalIgnoreCase))
@@ -63,21 +54,13 @@ public static class ConsumerConstructorIntegration
             }
         }
 
-        // https://github.com/confluentinc/confluent-kafka-dotnet/wiki/Consumer#misc-points states GroupId is required
-        if (consumerGroupId is not null)
-        {
-            // Store the association between consumer instance and "group.id" from configuration,
-            // will be used to populate "messaging.kafka.consumer.group" attribute value
-            ConsumerCache.Add(instance!, consumerGroupId);
-        }
-
         if (!string.IsNullOrEmpty(bootstrapServers))
         {
-            // Store the association between consumer instance and bootstrap servers from configuration.
-            // Will be used to populate "messaging.kafka.cluster.id" attribute value.
+            // Store the association between producer instance and bootstrap servers from configuration.
+            // Will be used to schedule cluster ID fetch and populate "messaging.kafka.cluster.id" attribute.
             BootstrapServersCache.Add(instance!, bootstrapServers!);
             // Stash state so OnMethodEnd can schedule the fetch after the constructor completes
-            // and the consumer's rdkafka handle is fully initialized.
+            // and the producer's rdkafka handle is fully initialized.
             return new CallTargetState(null, new KafkaConstructorFetchState(bootstrapServers!, configList));
         }
 
@@ -88,12 +71,11 @@ public static class ConsumerConstructorIntegration
     {
         if (exception is not null)
         {
-            ConsumerCache.Remove(instance!);
             BootstrapServersCache.Remove(instance!);
         }
         else if (state.State is KafkaConstructorFetchState fetchState)
         {
-            // Constructor succeeded — the consumer's rdkafka handle is now ready.
+            // Constructor succeeded — the producer's rdkafka handle is now ready.
             // Pass the instance so the fetch can use DependentAdminClientBuilder
             // and avoid allocating new rdkafka handles that would shift client-id counters.
             KafkaClusterIdCache.ScheduleFetch(fetchState.BootstrapServers, fetchState.Config, instance);

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceAsyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceAsyncIntegration.cs
@@ -36,7 +36,7 @@ public static class ProducerProduceAsyncIntegration
             return CallTargetState.GetDefault();
         }
 
-        var activity = KafkaInstrumentation.StartProducerActivity(topicPartition.DuckCast<ITopicPartition>(), message, instance.DuckCast<INamedClient>()!);
+        var activity = KafkaInstrumentation.StartProducerActivity(topicPartition.DuckCast<ITopicPartition>(), message, instance.DuckCast<INamedClient>()!, instance);
         if (activity is not null)
         {
             KafkaInstrumentation.InjectContext<TTopicPartition, TMessage>(message, activity);

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceSyncIntegration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/Integrations/ProducerProduceSyncIntegration.cs
@@ -37,7 +37,7 @@ public static class ProducerProduceSyncIntegration
             return CallTargetState.GetDefault();
         }
 
-        var activity = KafkaInstrumentation.StartProducerActivity(topicPartition.DuckCast<ITopicPartition>(), message, instance.DuckCast<INamedClient>()!);
+        var activity = KafkaInstrumentation.StartProducerActivity(topicPartition.DuckCast<ITopicPartition>(), message, instance.DuckCast<INamedClient>()!, instance);
         if (activity is not null)
         {
             KafkaInstrumentation.InjectContext<TTopicPartition, TMessage>(message, activity);

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaClusterIdCache.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaClusterIdCache.cs
@@ -1,0 +1,357 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using OpenTelemetry.AutoInstrumentation.DuckTyping;
+using OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka.DuckTypes;
+
+namespace OpenTelemetry.AutoInstrumentation.Instrumentations.Kafka;
+
+internal static class KafkaClusterIdCache
+{
+    private const long TtlMs = 60L * 60 * 1000;
+
+    // Minimum spacing between fetch attempts for a given bootstrapServers while it is
+    // unresolved or being refreshed. Prevents probing an unreachable broker on every span.
+    private const long RetryFloorMs = 30L * 1000;
+
+    // Only holds successfully resolved entries; no sentinel values.
+    private static readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.Ordinal);
+
+    // Key presence indicates a background fetch is currently running.
+    private static readonly ConcurrentDictionary<string, byte> _inFlight = new(StringComparer.Ordinal);
+
+    // Last fetch attempt time (success or failure) per bootstrapServers; rate-limits retries.
+    private static readonly ConcurrentDictionary<string, long> _lastAttemptAt = new(StringComparer.Ordinal);
+
+    // Auth config from the first constructor call per bootstrapServers; re-used for re-fetches.
+    private static readonly ConcurrentDictionary<string, IReadOnlyList<KeyValuePair<string, string>>?> _configCache = new(StringComparer.Ordinal);
+
+#if NET5_0_OR_GREATER
+    private static long TickCountMs => Environment.TickCount64;
+#else
+    // net462: TickCount64 is .NET 5+; fall back to TickCount (int, wraps ~25 days).
+    private static long TickCountMs => (long)Environment.TickCount;
+#endif
+
+    /// <summary>
+    /// Schedules a background fetch of the cluster ID for the given bootstrap servers string.
+    /// No-ops if a fetch is already in-flight, the cached value is still within its TTL, or a
+    /// previous attempt was made within the retry floor. Triggers a (re-)fetch otherwise — both
+    /// when no value has been resolved yet and when the cached value has expired.
+    /// When <paramref name="clientInstance"/> is provided (fully-constructed producer/consumer),
+    /// the fetch uses DependentAdminClientBuilder so no new rdkafka handles are allocated.
+    /// </summary>
+    internal static void ScheduleFetch(string bootstrapServers, IReadOnlyList<KeyValuePair<string, string>>? config = null, object? clientInstance = null)
+    {
+        if (string.IsNullOrEmpty(bootstrapServers))
+        {
+            return;
+        }
+
+        // On first call config is non-null and gets stored; on later re-fetch calls config is null
+        // and GetOrAdd returns the originally stored value so auth credentials are preserved.
+        var cfg = _configCache.GetOrAdd(bootstrapServers, config);
+
+        if (_inFlight.ContainsKey(bootstrapServers))
+        {
+            return; // fetch already in progress
+        }
+
+        if (_cache.TryGetValue(bootstrapServers, out var existing) &&
+            TickCountMs - existing.FetchedAt <= TtlMs)
+        {
+            return; // still fresh
+        }
+
+        // Negative-backoff: if a recent attempt did not leave us with a fresh value (initial
+        // failure, or a stale entry whose refresh just failed), wait before retrying so an
+        // unreachable broker is not probed on every span.
+        if (_lastAttemptAt.TryGetValue(bootstrapServers, out var lastAttempt) &&
+            TickCountMs - lastAttempt < RetryFloorMs)
+        {
+            return;
+        }
+
+        // TryAdd is the atomic guard; ContainsKey above is an optimistic fast-path only.
+        if (!_inFlight.TryAdd(bootstrapServers, 0))
+        {
+            return; // another thread won the race
+        }
+
+        _lastAttemptAt[bootstrapServers] = TickCountMs;
+        _ = Task.Run(() => FetchAndStore(bootstrapServers, cfg, clientInstance));
+    }
+
+    /// <summary>
+    /// Returns the resolved cluster ID for <paramref name="bootstrapServers"/>,
+    /// or <c>null</c> if no value has ever been resolved.
+    /// </summary>
+    internal static string? GetClusterId(string? bootstrapServers)
+    {
+        if (string.IsNullOrEmpty(bootstrapServers))
+        {
+            return null;
+        }
+
+        return _cache.TryGetValue(bootstrapServers!, out var entry) ? entry.Value : null;
+    }
+
+    /// <summary>
+    /// Returns the resolved cluster ID for <paramref name="bootstrapServers"/>.
+    /// If nothing has been resolved yet (e.g. the initial fetch failed or is still running),
+    /// schedules a background fetch and returns <c>null</c> so the attribute becomes available
+    /// on a later span. If the cached value has expired, schedules a background re-fetch and
+    /// returns the stale value for this span (it stays correct unless the cluster was recreated).
+    /// </summary>
+    internal static string? GetClusterIdAndScheduleRefresh(string? bootstrapServers)
+    {
+        if (string.IsNullOrEmpty(bootstrapServers))
+        {
+            return null;
+        }
+
+        if (!_cache.TryGetValue(bootstrapServers!, out var entry))
+        {
+            // No value resolved yet — schedule a fetch so it becomes available on a later span.
+            // ScheduleFetch is guarded by the in-flight and retry-floor checks, so this does not
+            // hammer an unreachable broker even though it is called from the hot path.
+            ScheduleFetch(bootstrapServers!);
+            return null;
+        }
+
+        // TTL expired — trigger a background re-fetch, return stale value for this span.
+        if (TickCountMs - entry.FetchedAt > TtlMs)
+        {
+            ScheduleFetch(bootstrapServers!);
+        }
+
+        return entry.Value;
+    }
+
+    private static void FetchAndStore(string bootstrapServers, IReadOnlyList<KeyValuePair<string, string>>? config, object? clientInstance)
+    {
+        try
+        {
+            var clusterId = FetchClusterIdViaReflection(bootstrapServers, config, clientInstance);
+            if (!string.IsNullOrEmpty(clusterId))
+            {
+                _cache[bootstrapServers] = new CacheEntry(clusterId!, TickCountMs);
+            }
+
+            // On empty/failed result, keep any existing entry (serve last-known-good). The
+            // cluster ID does not change unless the cluster was recreated, so a stale value is
+            // preferable to none; a later scheduled fetch (after the retry floor) will retry.
+        }
+        catch (Exception)
+        {
+            // Swallow and keep any existing entry; a later scheduled fetch will retry.
+        }
+        finally
+        {
+            _inFlight.TryRemove(bootstrapServers, out _);
+        }
+    }
+
+    private static string? FetchClusterIdViaReflection(string bootstrapServers, IReadOnlyList<KeyValuePair<string, string>>? extraConfig, object? clientInstance)
+    {
+        // Confluent.Kafka is the instrumented assembly – it is already loaded in the process.
+        var kafkaAssembly = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .FirstOrDefault(a => string.Equals(a.GetName().Name, IntegrationConstants.ConfluentKafkaAssemblyName, StringComparison.Ordinal));
+
+        if (kafkaAssembly is null)
+        {
+            return null;
+        }
+
+        // DescribeClusterAsync and DescribeClusterOptions only exist in Confluent.Kafka ≥ 2.x.
+        // Early-exit for older versions to avoid allocating an AdminClient that cannot provide cluster ID.
+        var describeClusterOptionsType = kafkaAssembly.GetType("Confluent.Kafka.Admin.DescribeClusterOptions");
+        if (describeClusterOptionsType is null)
+        {
+            return null;
+        }
+
+        // When we have the fully-constructed client instance (producer or consumer), use
+        // DependentAdminClientBuilder to share its existing rdkafka handle.  This avoids
+        // allocating new rdkafka producer/consumer handles that would shift the sequential
+        // client-id counters (rdkafka#producer-N / rdkafka#consumer-N) seen on spans.
+        if (clientInstance is not null)
+        {
+            var result = TryFetchViaDependentAdmin(kafkaAssembly, clientInstance, describeClusterOptionsType);
+            if (!string.IsNullOrEmpty(result))
+            {
+                return result;
+            }
+
+            // Fall through to standalone AdminClient if DependentAdminClientBuilder is unavailable.
+        }
+
+        // AdminClientBuilder(IEnumerable<KeyValuePair<string,string>>) accepts a plain list directly;
+        // there is no need to create an AdminClientConfig via reflection.
+        var config = new List<KeyValuePair<string, string>>
+        {
+            new("bootstrap.servers", bootstrapServers)
+        };
+        if (extraConfig is not null)
+        {
+            foreach (var kvp in extraConfig)
+            {
+                if (!string.Equals(kvp.Key, "bootstrap.servers", StringComparison.OrdinalIgnoreCase))
+                {
+                    config.Add(kvp);
+                }
+            }
+        }
+
+        var adminClientBuilderType = kafkaAssembly.GetType("Confluent.Kafka.AdminClientBuilder");
+        if (adminClientBuilderType is null)
+        {
+            return null;
+        }
+
+        var builderCtor = adminClientBuilderType.GetConstructor([typeof(IEnumerable<KeyValuePair<string, string>>)]);
+        if (builderCtor is null)
+        {
+            return null;
+        }
+
+        var buildMethod = adminClientBuilderType.GetMethod("Build", BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes, null);
+        if (buildMethod is null)
+        {
+            return null;
+        }
+
+        var builderInstance = builderCtor.Invoke([config]);
+        var adminClientInstance = buildMethod.Invoke(builderInstance, null);
+        if (adminClientInstance is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return FetchFromAdminClient(adminClientInstance, describeClusterOptionsType);
+        }
+        finally
+        {
+            if (adminClientInstance is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempts to fetch the cluster ID by building an AdminClient that shares the
+    /// handle of an existing producer or consumer instance via DependentAdminClientBuilder.
+    /// Returns null if DependentAdminClientBuilder is not available or any step fails.
+    /// </summary>
+    private static string? TryFetchViaDependentAdmin(Assembly kafkaAssembly, object clientInstance, Type describeClusterOptionsType)
+    {
+        try
+        {
+            // IKafkaClientHandle duck-types the Handle property from IClient without reflection overhead.
+            var handle = clientInstance.DuckCast<IKafkaClientHandle>()?.Handle;
+            if (handle is null)
+            {
+                return null;
+            }
+
+            var dependentBuilderType = kafkaAssembly.GetType("Confluent.Kafka.DependentAdminClientBuilder");
+            if (dependentBuilderType is null)
+            {
+                return null;
+            }
+
+            var ctor = dependentBuilderType.GetConstructor([handle.GetType()]);
+            if (ctor is null)
+            {
+                return null;
+            }
+
+            var buildMethod = dependentBuilderType.GetMethod("Build", BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes, null);
+            if (buildMethod is null)
+            {
+                return null;
+            }
+
+            var builder = ctor.Invoke([handle]);
+            var adminClientInstance = buildMethod.Invoke(builder, null);
+            if (adminClientInstance is null)
+            {
+                return null;
+            }
+
+            // The AdminClient shares the caller's handle and does not own it, so disposing
+            // releases only admin-specific resources without closing the underlying connection.
+            try
+            {
+                return FetchFromAdminClient(adminClientInstance, describeClusterOptionsType);
+            }
+            finally
+            {
+                if (adminClientInstance is IDisposable disposable)
+                {
+                    try { disposable.Dispose(); } catch { }
+                }
+            }
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fetches the cluster ID from an already-constructed admin client instance using
+    /// DescribeClusterAsync (Confluent.Kafka ≥ 2.x).
+    /// </summary>
+    private static string? FetchFromAdminClient(object adminClientInstance, Type describeClusterOptionsType)
+    {
+        var adminClientType = adminClientInstance.GetType();
+
+        // DescribeClusterAsync(DescribeClusterOptions options) → Task<DescribeClusterResult>
+        var describeClusterMethod = adminClientType.GetMethod(
+            "DescribeClusterAsync",
+            BindingFlags.Public | BindingFlags.Instance,
+            null,
+            [describeClusterOptionsType],
+            null);
+        if (describeClusterMethod is null)
+        {
+            return null;
+        }
+
+        var taskObj = describeClusterMethod.Invoke(adminClientInstance, [null]);
+        if (taskObj is not Task task)
+        {
+            return null;
+        }
+
+        if (!task.Wait(TimeSpan.FromSeconds(10)))
+        {
+            return null;
+        }
+
+        var resultProp = taskObj.GetType().GetProperty("Result");
+        var describeResult = resultProp?.GetValue(taskObj);
+        // IDescribeClusterResult duck-types ClusterId from DescribeClusterResult without reflection.
+        return describeResult?.DuckCast<IDescribeClusterResult>()?.ClusterId;
+    }
+
+    private readonly struct CacheEntry
+    {
+        internal CacheEntry(string value, long fetchedAt)
+        {
+            Value = value;
+            FetchedAt = fetchedAt;
+        }
+
+        internal string Value { get; }
+
+        internal long FetchedAt { get; }
+    }
+}

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/Kafka/KafkaInstrumentation.cs
@@ -31,6 +31,15 @@ internal static class KafkaInstrumentation
             {
                 activity.SetTag(MessagingAttributes.Keys.Kafka.ConsumerGroupId, groupId);
             }
+
+            if (BootstrapServersCache.TryGet(consumer, out var bootstrapServers))
+            {
+                var clusterId = KafkaClusterIdCache.GetClusterIdAndScheduleRefresh(bootstrapServers);
+                if (clusterId is not null)
+                {
+                    activity.SetTag(MessagingAttributes.Keys.Kafka.ClusterId, clusterId);
+                }
+            }
         }
 
         return activity;
@@ -62,7 +71,8 @@ internal static class KafkaInstrumentation
     public static Activity? StartProducerActivity<TTopicPartition, TMessage, TClient>(
         TTopicPartition partition,
         TMessage message,
-        TClient producer)
+        TClient producer,
+        object? rawProducer = null)
     where TTopicPartition : ITopicPartition
     where TMessage : IKafkaMessage
     where TClient : INamedClient
@@ -81,6 +91,16 @@ internal static class KafkaInstrumentation
                 producer);
 
             activity.SetTag(MessagingAttributes.Keys.Kafka.IsTombstone, message.Value is null);
+
+            if (rawProducer is not null &&
+                BootstrapServersCache.TryGet(rawProducer, out var bootstrapServers))
+            {
+                var clusterId = KafkaClusterIdCache.GetClusterIdAndScheduleRefresh(bootstrapServers);
+                if (clusterId is not null)
+                {
+                    activity.SetTag(MessagingAttributes.Keys.Kafka.ClusterId, clusterId);
+                }
+            }
         }
 
         return activity;

--- a/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MessagingAttributes.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Instrumentations/MessagingAttributes.cs
@@ -24,6 +24,7 @@ internal static class MessagingAttributes
             public const string MessageKey = "messaging.kafka.message.key";
             public const string PartitionOffset = "messaging.kafka.message.offset";
             public const string IsTombstone = "messaging.kafka.message.tombstone";
+            public const string ClusterId = "messaging.kafka.cluster.id";
         }
 
         internal static class RabbitMq

--- a/test/IntegrationTests/KafkaTests.cs
+++ b/test/IntegrationTests/KafkaTests.cs
@@ -24,6 +24,7 @@ public class KafkaTests : TestHelper
     private const string KafkaDestinationPartitionAttributeName = "messaging.kafka.destination.partition";
     private const string KafkaMessageOffsetAttributeName = "messaging.kafka.message.offset";
     private const string KafkaMessageTombstoneAttributeName = "messaging.kafka.message.tombstone";
+    private const string KafkaClusterIdAttributeName = "messaging.kafka.cluster.id";
     private const string KafkaInstrumentationScopeName = "OpenTelemetry.AutoInstrumentation.Kafka";
     private const string KafkaProducerClientIdAttributeValue = "rdkafka#producer-1";
     private const string KafkaConsumerClientIdAttributeValue = "rdkafka#consumer-2";
@@ -48,6 +49,7 @@ public class KafkaTests : TestHelper
         SkipIfUnsupportedPlatform(packageVersion);
 
         var topicName = $"test-topic-{packageVersion}";
+        var supportsClusterId = packageVersion.Length == 0 || Version.Parse(packageVersion) >= new Version(2, 0, 0);
 
         using var collector = new MockSpansCollector(Output);
         SetExporter(collector);
@@ -67,7 +69,7 @@ public class KafkaTests : TestHelper
                 "Failed Consume attempt.");
         }
 
-        // Successful produce attempts after topic was created with admin client.
+        // Successful produce attempts.
         collector.Expect(KafkaInstrumentationScopeName, VersionHelper.AutoInstrumentationVersion, span => span.Kind == Span.Types.SpanKind.Producer && ValidateProducerSpan(span, topicName, 0), "Successful ProduceAsync attempt.");
         collector.Expect(KafkaInstrumentationScopeName, VersionHelper.AutoInstrumentationVersion, span => span.Kind == Span.Types.SpanKind.Producer && ValidateProducerSpan(span, topicName, -1), "Successful Produce attempt without delivery handler set.");
         collector.Expect(KafkaInstrumentationScopeName, VersionHelper.AutoInstrumentationVersion, span => span.Kind == Span.Types.SpanKind.Producer && ValidateProducerSpan(span, topicName, 0), "Successful Produce attempt with delivery handler set.");
@@ -81,6 +83,16 @@ public class KafkaTests : TestHelper
         collector.Expect(KafkaInstrumentationScopeName, VersionHelper.AutoInstrumentationVersion, span => span.Kind == Span.Types.SpanKind.Consumer && ValidateConsumerSpan(span, topicName, 2), "Third successful Consume attempt.");
 
         collector.ExpectCollected(collection => ValidatePropagation(collection, topicName));
+
+        if (supportsClusterId)
+        {
+            // messaging.kafka.cluster.id is resolved asynchronously in the background, so it may
+            // be absent on the earliest spans. Assert it is eventually present on at least one
+            // producer and one consumer span, rather than requiring it on every span.
+            collector.ExpectCollected(collection => collection.Any(c => c.Span.Kind == Span.Types.SpanKind.Producer && HasNonEmptyClusterId(c.Span.Attributes)));
+            collector.ExpectCollected(collection => collection.Any(c => c.Span.Kind == Span.Types.SpanKind.Consumer && HasNonEmptyClusterId(c.Span.Attributes)));
+        }
+
         EnableBytecodeInstrumentation();
 
         RunTestApplication(new TestSettings
@@ -171,6 +183,12 @@ public class KafkaTests : TestHelper
         return ValidateCommonAttributes(span.Attributes, topicName, KafkaProducerClientIdAttributeValue, MessagingPublishOperationAttributeValue, partition, KafkaMessageKeyAttributeValue) &&
                isTombstone == tombstoneExpected &&
                span.Status is null;
+    }
+
+    private static bool HasNonEmptyClusterId(IReadOnlyCollection<KeyValue> attributes)
+    {
+        var clusterId = attributes.SingleOrDefault(kv => kv.Key == KafkaClusterIdAttributeName)?.Value.StringValue;
+        return !string.IsNullOrEmpty(clusterId);
     }
 
     private static bool ValidateCommonAttributes(IReadOnlyCollection<KeyValue> attributes, string topicName, string clientId, string operationName, int partition, string? expectedMessageKey)

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/KafkaInstrumentationTests.cs
@@ -34,4 +34,59 @@ public class KafkaInstrumentationTests
         var value = new byte[] { 1, 2, 3 };
         Assert.Null(KafkaInstrumentation.ExtractMessageKeyValue(value));
     }
+
+    [Fact]
+    public void BootstrapServersCache_AddAndTryGet_RoundTrips()
+    {
+        var instance = new object();
+        BootstrapServersCache.Add(instance, "broker:9092");
+
+        Assert.True(BootstrapServersCache.TryGet(instance, out var result));
+        Assert.Equal("broker:9092", result);
+    }
+
+    [Fact]
+    public void BootstrapServersCache_TryGet_ReturnsFalseForUnknownInstance()
+    {
+        var instance = new object();
+        Assert.False(BootstrapServersCache.TryGet(instance, out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void BootstrapServersCache_Remove_ClearsEntry()
+    {
+        var instance = new object();
+        BootstrapServersCache.Add(instance, "broker:9092");
+        BootstrapServersCache.Remove(instance);
+
+        Assert.False(BootstrapServersCache.TryGet(instance, out _));
+    }
+
+    [Fact]
+    public void KafkaClusterIdCache_GetClusterId_ReturnsNullForNullOrEmpty()
+    {
+        Assert.Null(KafkaClusterIdCache.GetClusterId(null));
+        Assert.Null(KafkaClusterIdCache.GetClusterId(string.Empty));
+    }
+
+    [Fact]
+    public void KafkaClusterIdCache_GetClusterId_ReturnsNullWhenNotCached()
+    {
+        Assert.Null(KafkaClusterIdCache.GetClusterId("not-cached-host-unit-test:9999"));
+    }
+
+    [Fact]
+    public void KafkaClusterIdCache_ScheduleFetch_NoOpsForEmpty()
+    {
+        KafkaClusterIdCache.ScheduleFetch(string.Empty);
+    }
+
+    [Fact]
+    public void KafkaClusterIdCache_ScheduleFetch_DeduplicatesInFlightRequests()
+    {
+        const string key = "dedup-test-host-unit-test:9999";
+        KafkaClusterIdCache.ScheduleFetch(key);
+        KafkaClusterIdCache.ScheduleFetch(key);
+    }
 }


### PR DESCRIPTION
## Summary

Adds `messaging.kafka.cluster.id` ([semantic-conventions #3819](https://github.com/open-telemetry/semantic-conventions/pull/3819), merged) to Confluent.Kafka producer and consumer spans.

`messaging.kafka.cluster.id` is a **Recommended** attribute in the messaging semantic conventions, so it is emitted **by default** — there is no configuration flag. It is populated for Confluent.Kafka ≥ 2.0.0; older versions are unaffected.

### How it works

- The cluster ID is resolved **once per unique `bootstrap.servers`** via a background `AdminClient.DescribeClusterAsync()` call and cached with a TTL. The produce/consume hot path only reads the cached value — no per-span broker calls.
- When a fully-constructed producer/consumer is available, `DependentAdminClientBuilder` reuses its existing `rdkafka` handle, so no additional client handles are allocated.
- SASL/SSL client configuration is forwarded so authenticated clusters are supported.
- If the cluster ID has not been resolved yet, the attribute is omitted for that span (no blocking on the hot path).

## Testing

- Unit tests for `BootstrapServersCache` and `KafkaClusterIdCache`.
- Integration test `SubmitsTraces` asserts `messaging.kafka.cluster.id` is present and non-empty on producer and consumer spans for Confluent.Kafka ≥ 2.0.0.

Fixes #5278

Assisted-by: Claude Sonnet 4.6
