### PR TITLE
Remove support for OTEL_EXPERIMENTAL_CONFIG_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Removed
 
- - Remove support for `OTEL_EXPERIMENTAL_CONFIG_FILE`.
+- Remove support for `OTEL_EXPERIMENTAL_CONFIG_FILE`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Removed
 
+ - Remove support for `OTEL_EXPERIMENTAL_CONFIG_FILE`.
+
 ### Fixed
 
 - Suppress instrumentation while starting the OpAMP client to prevent internal

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/ConfigurationKeys.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/ConfigurationKeys.cs
@@ -89,12 +89,6 @@ internal partial class ConfigurationKeys
         public const string Enabled = "OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED";
 
         /// <summary>
-        /// Configuration key for the deprecated path to the configuration file.
-        /// Default is <c>"config.yaml"</c>.
-        /// </summary>
-        public const string ExperimentalFileName = "OTEL_EXPERIMENTAL_CONFIG_FILE";
-
-        /// <summary>
         /// Configuration key for the path to the configuration file.
         /// Default is <c>"config.yaml"</c>.
         /// </summary>

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/Settings.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/Settings.cs
@@ -60,24 +60,9 @@ internal abstract class Settings
 
     private static YamlConfiguration ReadYamlConfiguration()
     {
-        var experimentalConfigFile = Environment.GetEnvironmentVariable(ConfigurationKeys.FileBasedConfiguration.ExperimentalFileName);
-
         var configFile = Environment.GetEnvironmentVariable(ConfigurationKeys.FileBasedConfiguration.FileName);
 
-        if (!string.IsNullOrEmpty(configFile))
-        {
-            if (!string.IsNullOrEmpty(experimentalConfigFile))
-            {
-                Logger.Warning("Both OTEL_EXPERIMENTAL_CONFIG_FILE (deprecated) and OTEL_CONFIG_FILE are set. " +
-                    "Using OTEL_CONFIG_FILE and ignoring the deprecated variable.");
-            }
-        }
-        else if (!string.IsNullOrEmpty(experimentalConfigFile))
-        {
-            Logger.Warning("OTEL_EXPERIMENTAL_CONFIG_FILE is deprecated. Please use OTEL_CONFIG_FILE instead.");
-            configFile = experimentalConfigFile;
-        }
-        else
+        if (string.IsNullOrEmpty(configFile))
         {
             configFile = "config.yaml";
         }


### PR DESCRIPTION
## Why

OTEL_CONFIG_FILE is in place. Just cleanup functionalities

## What

Remove support for OTEL_EXPERIMENTAL_CONFIG_FILE

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.
