### PR TITLE
Bump OpAmp.Client to 0.6.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
   - `OpenTelemetry.Instrumentation.SqlClient` from `1.15.2` to `1.16.0`,
   - `OpenTelemetry.Instrumentation.StackExchangeRedis` from `1.15.1-beta.2` to `1.16.0-beta.1`,
   - `OpenTelemetry.Instrumentation.Wcf` from `1.15.1-beta.2` to `1.16.0-beta.1`,
-  - `OpenTelemetry.OpAmp.Client` from `0.3.0-alpha.1` to `0.5.0-alpha.1`.
+  - `OpenTelemetry.OpAmp.Client` from `0.3.0-alpha.1` to `0.6.0-alpha.1`.
 - .NET only, following packages updated
   - `OpenTelemetry.Instrumentation.AspNetCore` from `1.15.2` to `1.16.0`,
   - `OpenTelemetry.Instrumentation.EntityFrameworkCore`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Wcf" Version="1.16.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.OpAmp.Client" Version="0.5.0-alpha.1" />
+    <PackageVersion Include="OpenTelemetry.OpAmp.Client" Version="0.6.0-alpha.1" />
   </ItemGroup>
 </Project>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -181,7 +181,7 @@ public class MyOpAmpPlugin
 
 | Settings type                                           | NuGet package              | NuGet version |
 |---------------------------------------------------------|----------------------------|---------------|
-| OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings | OpenTelemetry.OpAmp.Client | 0.5.0-alpha.1 |
+| OpenTelemetry.OpAmp.Client.Settings.OpAmpClientSettings | OpenTelemetry.OpAmp.Client | 0.6.0-alpha.1 |
 
 ## Requirements
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/assembly_redirection_net.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/assembly_redirection_net.h
@@ -42,7 +42,7 @@
         { _W("OpenTelemetry.Instrumentation.SqlClient"), {1, 16, 0, 1138} }, \
         { _W("OpenTelemetry.Instrumentation.StackExchangeRedis"), {1, 16, 0, 1137} }, \
         { _W("OpenTelemetry.Instrumentation.Wcf"), {1, 16, 0, 1139} }, \
-        { _W("OpenTelemetry.OpAmp.Client"), {0, 5, 0, 1149} }, \
+        { _W("OpenTelemetry.OpAmp.Client"), {0, 6, 0, 1162} }, \
         { _W("OpenTelemetry.Resources.Azure"), {1, 15, 1, 1031} }, \
         { _W("OpenTelemetry.Resources.Container"), {1, 15, 1, 1038} }, \
         { _W("OpenTelemetry.Resources.Host"), {1, 15, 1, 1036} }, \
@@ -93,7 +93,7 @@
         { _W("OpenTelemetry.Instrumentation.SqlClient"), {1, 16, 0, 1138} }, \
         { _W("OpenTelemetry.Instrumentation.StackExchangeRedis"), {1, 16, 0, 1137} }, \
         { _W("OpenTelemetry.Instrumentation.Wcf"), {1, 16, 0, 1139} }, \
-        { _W("OpenTelemetry.OpAmp.Client"), {0, 5, 0, 1149} }, \
+        { _W("OpenTelemetry.OpAmp.Client"), {0, 6, 0, 1162} }, \
         { _W("OpenTelemetry.Resources.Azure"), {1, 15, 1, 1031} }, \
         { _W("OpenTelemetry.Resources.Container"), {1, 15, 1, 1038} }, \
         { _W("OpenTelemetry.Resources.Host"), {1, 15, 1, 1036} }, \
@@ -144,7 +144,7 @@
         { _W("OpenTelemetry.Instrumentation.SqlClient"), {1, 16, 0, 1138} }, \
         { _W("OpenTelemetry.Instrumentation.StackExchangeRedis"), {1, 16, 0, 1137} }, \
         { _W("OpenTelemetry.Instrumentation.Wcf"), {1, 16, 0, 1139} }, \
-        { _W("OpenTelemetry.OpAmp.Client"), {0, 5, 0, 1149} }, \
+        { _W("OpenTelemetry.OpAmp.Client"), {0, 6, 0, 1162} }, \
         { _W("OpenTelemetry.Resources.Azure"), {1, 15, 1, 1031} }, \
         { _W("OpenTelemetry.Resources.Container"), {1, 15, 1, 1038} }, \
         { _W("OpenTelemetry.Resources.Host"), {1, 15, 1, 1036} }, \

--- a/src/OpenTelemetry.AutoInstrumentation.Native/assembly_redirection_netfx.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/assembly_redirection_netfx.h
@@ -41,7 +41,7 @@
         { _W("OpenTelemetry.Instrumentation.SqlClient"), {1, 16, 0, 1138} }, \
         { _W("OpenTelemetry.Instrumentation.StackExchangeRedis"), {1, 16, 0, 1137} }, \
         { _W("OpenTelemetry.Instrumentation.Wcf"), {1, 16, 0, 1139} }, \
-        { _W("OpenTelemetry.OpAmp.Client"), {0, 5, 0, 1149} }, \
+        { _W("OpenTelemetry.OpAmp.Client"), {0, 6, 0, 1162} }, \
         { _W("OpenTelemetry.Resources.Azure"), {1, 15, 1, 1031} }, \
         { _W("OpenTelemetry.Resources.Host"), {1, 15, 1, 1036} }, \
         { _W("OpenTelemetry.Resources.OperatingSystem"), {1, 15, 1, 1039} }, \
@@ -188,7 +188,7 @@
         { _W("OpenTelemetry.Instrumentation.SqlClient"), {1, 16, 0, 1138} }, \
         { _W("OpenTelemetry.Instrumentation.StackExchangeRedis"), {1, 16, 0, 1137} }, \
         { _W("OpenTelemetry.Instrumentation.Wcf"), {1, 16, 0, 1139} }, \
-        { _W("OpenTelemetry.OpAmp.Client"), {0, 5, 0, 1149} }, \
+        { _W("OpenTelemetry.OpAmp.Client"), {0, 6, 0, 1162} }, \
         { _W("OpenTelemetry.Resources.Azure"), {1, 15, 1, 1031} }, \
         { _W("OpenTelemetry.Resources.Host"), {1, 15, 1, 1036} }, \
         { _W("OpenTelemetry.Resources.OperatingSystem"), {1, 15, 1, 1039} }, \
@@ -334,7 +334,7 @@
         { _W("OpenTelemetry.Instrumentation.SqlClient"), {1, 16, 0, 1138} }, \
         { _W("OpenTelemetry.Instrumentation.StackExchangeRedis"), {1, 16, 0, 1137} }, \
         { _W("OpenTelemetry.Instrumentation.Wcf"), {1, 16, 0, 1139} }, \
-        { _W("OpenTelemetry.OpAmp.Client"), {0, 5, 0, 1149} }, \
+        { _W("OpenTelemetry.OpAmp.Client"), {0, 6, 0, 1162} }, \
         { _W("OpenTelemetry.Resources.Azure"), {1, 15, 1, 1031} }, \
         { _W("OpenTelemetry.Resources.Host"), {1, 15, 1, 1036} }, \
         { _W("OpenTelemetry.Resources.OperatingSystem"), {1, 15, 1, 1039} }, \
@@ -398,7 +398,7 @@
         { _W("OpenTelemetry.Instrumentation.SqlClient"), {1, 16, 0, 1138} }, \
         { _W("OpenTelemetry.Instrumentation.StackExchangeRedis"), {1, 16, 0, 1137} }, \
         { _W("OpenTelemetry.Instrumentation.Wcf"), {1, 16, 0, 1139} }, \
-        { _W("OpenTelemetry.OpAmp.Client"), {0, 5, 0, 1149} }, \
+        { _W("OpenTelemetry.OpAmp.Client"), {0, 6, 0, 1162} }, \
         { _W("OpenTelemetry.Resources.Azure"), {1, 15, 1, 1031} }, \
         { _W("OpenTelemetry.Resources.Host"), {1, 15, 1, 1036} }, \
         { _W("OpenTelemetry.Resources.OperatingSystem"), {1, 15, 1, 1039} }, \


### PR DESCRIPTION
## Why & What

Bump OpAmp.Client to 0.6.0-alpha.1

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] ~~New~~ features are covered by tests.
