### PR TITLE
chore: Pin GitHub Action digests to semver

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,10 @@
   commitBodyTable: true,
   commitMessageAction: "Bump",
   dependencyDashboard: false,
-  extends: ["config:best-practices"],
+  extends: [
+    "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
   labels: ["dependencies"],
   prConcurrentLimit: 20,
   customManagers: [


### PR DESCRIPTION
## Changes

This enables `helpers:pinGitHubActionDigestsToSemver` as mentioned in https://github.com/open-telemetry/sig-security/issues/116

Setting is explained at https://docs.renovatebot.com/presets-helpers/

This just brings consistency to the versions specified for github actions.
## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
