### PR TITLE
 Update development observability images

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -20,6 +20,6 @@ services:
       - jaeger
 
   jaeger:
-    image: jaegertracing/all-in-one:1.76.0@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     ports:
       - "16686:16686"

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - loki
 
   jaeger:
-    image: jaegertracing/all-in-one:1.50.0
+    image: jaegertracing/jaeger:2.19.0
     ports:
       - "16686:16686" # Jaeger Web UI
 


### PR DESCRIPTION
## Why

The current jaegar tracing image is eol

Fixes #

## What

The jaegar tracing image has been switched as existing image is eol jaegertracing/jaeger#6321

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
