### PR TITLE
Generate SBOM for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,13 @@ jobs:
       - name: Install zip
         uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # v1.0.0
 
-      - name: Create ZIP artifacts
+      - name: Create ZIP artifacts and prepare SBOM source
         shell: bash
         run: |
           set -euo pipefail
+          sbom_source="${RUNNER_TEMP}/sbom-source"
+          mkdir -p "${sbom_source}"
+
           packages=(
             "alpine-x64 linux-musl-x64"
             "alpine-arm64 linux-musl-arm64"
@@ -73,27 +76,9 @@ jobs:
           for package in "${packages[@]}"; do
             read -r dir archive <<< "${package}"
             src="./bin-${dir}"
-            (cd "${src}" && zip -qq -r "../opentelemetry-dotnet-instrumentation-${archive}.zip" ./* && cd ..)
-          done
-
-      # Syft accepts one source per SBOM, so extract each final ZIP under a
-      # distinct root and scan the combined tree for the single release SBOM.
-      - name: Extract release ZIPs for SBOM
-        shell: bash
-        run: |
-          set -euo pipefail
-          sbom_source="${RUNNER_TEMP}/sbom-source"
-          archives=(./opentelemetry-dotnet-instrumentation-*.zip)
-
-          if [[ "${#archives[@]}" -ne 7 ]]; then
-            echo "Expected 7 release ZIPs, found ${#archives[@]}" >&2
-            exit 1
-          fi
-
-          mkdir -p "${sbom_source}"
-          for archive in "${archives[@]}"; do
-            archive_name="$(basename "${archive}" .zip)"
-            unzip -q "${archive}" -d "${sbom_source}/${archive_name}"
+            archive_file="opentelemetry-dotnet-instrumentation-${archive}.zip"
+            (cd "${src}" && zip -qq -r "../${archive_file}" ./* && cd ..)
+            unzip -q "${archive_file}" -d "${sbom_source}/${archive}"
           done
 
       - name: Generate SBOM from release ZIPs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,34 @@ jobs:
             (cd "${src}" && zip -qq -r "../opentelemetry-dotnet-instrumentation-${archive}.zip" ./* && cd ..)
           done
 
+      # Syft accepts one source per SBOM, so extract each final ZIP under a
+      # distinct root and scan the combined tree for the single release SBOM.
+      - name: Extract release ZIPs for SBOM
+        shell: bash
+        run: |
+          set -euo pipefail
+          sbom_source="${RUNNER_TEMP}/sbom-source"
+          archives=(./opentelemetry-dotnet-instrumentation-*.zip)
+
+          if [[ "${#archives[@]}" -ne 7 ]]; then
+            echo "Expected 7 release ZIPs, found ${#archives[@]}" >&2
+            exit 1
+          fi
+
+          mkdir -p "${sbom_source}"
+          for archive in "${archives[@]}"; do
+            archive_name="$(basename "${archive}" .zip)"
+            unzip -q "${archive}" -d "${sbom_source}/${archive_name}"
+          done
+
+      - name: Generate SBOM from release ZIPs
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          output-file: ./sbom.spdx.json
+          path: ${{ runner.temp }}/sbom-source
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Collect install scripts
         shell: bash
         run: |
@@ -102,6 +130,7 @@ jobs:
             "opentelemetry-dotnet-instrumentation-macos.zip"
             "opentelemetry-dotnet-instrumentation-nuget-packages.zip"
             "opentelemetry-dotnet-instrumentation-windows.zip"
+            "sbom.spdx.json"
             "otel-dotnet-auto-install.sh"
             "OpenTelemetry.DotNet.Auto.psm1"
           )
@@ -123,6 +152,7 @@ jobs:
             ./otel-dotnet-auto-install.sh
             ./OpenTelemetry.DotNet.Auto.psm1
             ./checksums.txt
+            ./sbom.spdx.json
 
       - name: Attest bin-alpine-x64
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -168,3 +198,4 @@ jobs:
           ./otel-dotnet-auto-install.sh
           ./OpenTelemetry.DotNet.Auto.psm1
           ./checksums.txt
+          ./sbom.spdx.json


### PR DESCRIPTION
## Why

The GitHub release should provide a software bill of materials for its downloadable artifacts and satisfy the [CLOMonitor SBOM check](https://clomonitor.io/projects/cncf/open-telemetry#opentelemetry-dotnet-instrumentation) .

The SBOM should describe the contents of the final release ZIPs while remaining a single release asset.

## What

- Generate one aggregate SPDX SBOM from the final release ZIP contents.
- Publish it as `sbom.spdx.json`.
- Include the SBOM in `checksums.txt`.
- Include the SBOM in the existing release-files provenance attestation.

## Tests

Will be fully tested during the next release process.

## Checklist

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~