### PR TITLE
centos9 image hash update

### DIFF
--- a/docker/centos-stream9.dockerfile
+++ b/docker/centos-stream9.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9@sha256:04bad0b08ac68a63b1810ea78a9d2ed4fb431e11d9c4c3916418edd4932856bd
+FROM quay.io/centos/centos:stream9@sha256:64e5a212e4f2e7b706dbd822968914bb8def7de0a7fdfd3bf248241f8758101c
 
 # Install dotnet sdk
 RUN dnf install -y \


### PR DESCRIPTION
## Why && What
Update hash.
This should generally be taken care of by renovatebot.
Causes failures in other PRs, e.g. https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/actions/runs/32234115052/job/96019606911