### PR TITLE
[Native] Dynamic continuous profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 
+- Added a protocol-neutral native runtime configuration contract for dynamically
+  enabling, updating, disabling, and re-enabling continuous profiling producers.
+  ([#5360](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/5360))
 - Support for [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis)
   traces instrumentation for versions `3.1.x`+ for .NET only.
 

--- a/docs/internal/continuous-profiler.md
+++ b/docs/internal/continuous-profiler.md
@@ -16,6 +16,168 @@ events:
 
 You can export stack traces to any observability back end that supports profiling.
 
+## Shared service definition
+
+> [!NOTE]
+> This section defines protocol-neutral service contract for
+> dynamic continuous profiler configuration.
+> It is the target data-plane contract for the native profiler.
+
+The continuous profiler is one process-wide data-plane service. It coordinates
+three sampling modes:
+
+| Sampling mode | Producer | Captured data |
+| ------------- | -------- | ------------- |
+| Continuous thread sampling (CPU sampling) | Shared thread-sampling worker | Complete stacks for eligible managed threads |
+| Selective thread sampling | Shared thread-sampling worker | Complete stacks for threads associated with selected trace contexts |
+| Allocation sampling | Allocation EventPipe session | Sampled allocation and the complete stack that caused it |
+
+Continuous and selective thread sampling share at most one native worker.
+Allocation sampling has a separate producer lifecycle because an inactive
+EventPipe session has a runtime cost. Managed buffer readers and exporters are
+consumers of these native producers. How configuration reaches the service and
+how samples are transported after a consumer reads them are outside this
+definition.
+
+### Process-wide invariants
+
+The native service preserves these observable invariants:
+
+1. There is one continuous profiler service and one effective configuration per
+   process. A .NET Framework `AppDomain` does not own either one.
+2. Repeated managed initialization cannot replace process-wide configuration by
+   accident. Unloading an `AppDomain` is not terminal profiler shutdown and does
+   not reset the effective configuration.
+3. Native bootstrap establishes profiling capability, not sampling policy.
+   Bootstrap alone starts no thread-sampling producer worker or EventPipe
+   session. It may create dormant safety helpers that are required before a
+   later enablement.
+4. An all-disabled process that has never sampled has no thread-sampling
+   producer worker and no allocation EventPipe session.
+5. At most one managed consumer may destructively read the process-wide native
+   buffers. Native producers must not continue indefinitely when no consumer can
+   drain them.
+6. Invalid configuration or a failed producer transition leaves the previous
+   effective configuration in force.
+7. Native profiling failures are bounded, logged, and contained. They must not
+   escape into the instrumented application.
+
+The mechanism used to select or replace the managed consumer is intentionally not
+defined here. Only the single-consumer and no-unconsumed-production guarantees are
+shared profiler semantics.
+
+### Configuration semantics
+
+A configuration transition is atomic from the producers' point of view. This is
+an observable guarantee and does not require a particular interop API shape. A
+single complete request and a serialized set of field operations are both valid
+implementation choices if producers cannot observe an invalid intermediate state.
+
+Configuration is observed at a capture-cycle boundary. A cycle that already
+started, or was already scheduled using a coherent previous configuration, may
+finish with that configuration. Its data remains valid: the corresponding batch
+contains the sampling interval that was actually used. A configuration change does
+not retroactively invalidate a complete sample or batch.
+
+Enable, disable, and re-enable operations are idempotent. Enabling the first
+thread-sampling mode creates or activates the shared worker. Disabling the final
+thread-sampling mode stops production promptly. Re-enabling sampling must not
+create duplicate workers. Whether an idle worker is retained in a quiescent state
+or joined and recreated later is an internal lifecycle choice, provided these
+observable guarantees hold.
+
+When both continuous and selective thread sampling are enabled, their intervals
+must form a valid pair as described in the
+[selective sampling limits](./selective-sampling.md#limits). A transition that
+would expose an invalid pair is rejected as a whole.
+
+### Producer lifecycle
+
+The shared thread-sampling producer has these logical states:
+
+| State | Required behavior |
+| ----- | ----------------- |
+| Never activated | No worker exists and no thread sampling occurs. |
+| Active | Exactly one worker serves every enabled thread-sampling mode. |
+| Inactive after use | No thread sampling occurs; a worker may be quiescent or may have been joined. |
+| Terminal | The worker is joined, resources are released, and sampling cannot restart. |
+
+An interval update takes effect at a capture-cycle boundary. Disabling one
+thread-sampling mode does not stop the shared worker while the other mode remains
+active.
+
+Allocation sampling has an independent lifecycle:
+
+| Transition | Required behavior |
+| ---------- | ----------------- |
+| Enable | Lazily start one EventPipe session. |
+| Rate update | Replace the sampling rate without creating a duplicate session. |
+| Disable | Stop the session, finish protected in-flight writes, and release allocation-specific resources. |
+| Re-enable | Establish one new session. |
+| Terminal shutdown | Stop the session once and prevent restart. |
+
+An allocation enable request on an unsupported runtime, or an EventPipe start or
+stop failure, must not leave a partially applied effective configuration.
+
+### Capture, buffering, and shutdown
+
+Ordinary disable and terminal shutdown have different urgency, but both preserve
+the safety of the instrumented process:
+
+* A reversible disable may let already-started work reach a safe boundary. Any
+  published sample must contain a complete stack.
+* Terminal shutdown may abort the current stack walk. An incomplete current stack
+  is discarded; complete stacks captured earlier remain valid.
+* Runtime and per-thread suspension are always released through the normal guard
+  path before the transition completes.
+
+Native buffers are bounded. When a consumer cannot keep up, the profiler may skip
+a capture cycle or discard a complete sample according to the existing escape-hatch
+behavior. Back pressure must not block the application indefinitely, corrupt a
+batch, or expose an incomplete stack as an ordinary sample.
+
+Producer and consumer transitions follow this ordering:
+
+```text
+Enable:
+    prepare consumer -> enable native producer
+
+Disable:
+    stop native production at a safe boundary -> drain complete buffers -> quiesce consumer
+```
+
+This ordering is independent of the configuration transport.
+
+### Native implementation requirements
+
+A native implementation of this definition must:
+
+* select foundational CLR profiling capabilities early enough to permit later
+  enablement when the runtime does not allow those capabilities to be added safely;
+* bootstrap process-wide state once without treating the first configuration
+  source or `AppDomain` as the service owner;
+* validate a coherent candidate before changing producer state;
+* ensure the shared worker observes one coherent configuration per capture cycle;
+* preserve the actual sampling interval with each continuous-thread batch;
+* make ordinary disable and terminal shutdown idempotent and race-safe; and
+* cover startup-disabled, enable, update, disable, re-enable, transition failure,
+  and shutdown races with deterministic native tests.
+
+### Deferred contracts
+
+This shared definition deliberately does not choose or define:
+
+* OpAMP documents, merge rules, hashes, status reporting, or transport behavior;
+* precedence between startup and control-plane configuration;
+* revisions, generations, compare-and-apply, or an exact versioned interop ABI;
+* a managed-host claim, token, lease, or `AppDomain` recovery protocol;
+* whether the shared worker is retained while inactive; or
+* changes to the public plugin API.
+
+Those mechanisms require separate review after the sampling semantics above are
+agreed. A native implementation can then select mechanisms that preserve this
+contract without coupling the data plane to OpAMP.
+
 ## Thread sampling
 
 You can enable thread sampling using the custom plugin, which

--- a/docs/internal/continuous-profiler.md
+++ b/docs/internal/continuous-profiler.md
@@ -48,12 +48,12 @@ The native service preserves these observable invariants:
 2. Repeated managed initialization cannot replace process-wide configuration by
    accident. Unloading an `AppDomain` is not terminal profiler shutdown and does
    not reset the effective configuration.
-3. Native bootstrap establishes profiling capability, not sampling policy.
-   Bootstrap alone starts no thread-sampling producer worker or EventPipe
-   session. It may create dormant safety helpers that are required before a
-   later enablement.
-4. An all-disabled process that has never sampled has no thread-sampling
-   producer worker and no allocation EventPipe session.
+3. Profiler initialization and an initially all-disabled configuration do not
+   enable continuous-profiler-specific CLR events or bootstrap native continuous
+   profiler machinery. The first valid configuration that enables a sampling
+   feature performs this initialization once.
+4. Until that first enablement, the process has no thread-sampling producer
+   worker and no allocation EventPipe session.
 5. At most one managed consumer may destructively read the process-wide native
    buffers. Native producers must not continue indefinitely when no consumer can
    drain them.
@@ -80,11 +80,10 @@ contains the sampling interval that was actually used. A configuration change do
 not retroactively invalidate a complete sample or batch.
 
 Enable, disable, and re-enable operations are idempotent. Enabling the first
-thread-sampling mode creates or activates the shared worker. Disabling the final
-thread-sampling mode stops production promptly. Re-enabling sampling must not
-create duplicate workers. Whether an idle worker is retained in a quiescent state
-or joined and recreated later is an internal lifecycle choice, provided these
-observable guarantees hold.
+thread-sampling mode lazily creates the shared worker once. Disabling the final
+thread-sampling mode stops production promptly and retains the worker in a
+non-producing quiescent wait. Re-enabling sampling wakes the retained worker.
+Only terminal shutdown joins it.
 
 When both continuous and selective thread sampling are enabled, their intervals
 must form a valid pair as described in the
@@ -99,8 +98,8 @@ The shared thread-sampling producer has these logical states:
 | ----- | ----------------- |
 | Never activated | No worker exists and no thread sampling occurs. |
 | Active | Exactly one worker serves every enabled thread-sampling mode. |
-| Inactive after use | No thread sampling occurs; a worker may be quiescent or may have been joined. |
-| Terminal | The worker is joined, resources are released, and sampling cannot restart. |
+| Quiescent after use | The retained worker waits without producing thread samples. |
+| Terminal | The worker is joined exactly once, resources are released, and sampling cannot restart. |
 
 An interval update takes effect at a capture-cycle boundary. Disabling one
 thread-sampling mode does not stop the shared worker while the other mode remains
@@ -152,12 +151,16 @@ This ordering is independent of the configuration transport.
 
 A native implementation of this definition must:
 
-* select foundational CLR profiling capabilities early enough to permit later
-  enablement when the runtime does not allow those capabilities to be added safely;
-* bootstrap process-wide state once without treating the first configuration
-  source or `AppDomain` as the service owner;
+* defer continuous-profiler-specific CLR event-mask configuration and native
+  bootstrap until the first valid configuration enables a sampling feature;
+* bootstrap process-wide state once without treating that configuration source
+  or `AppDomain` as the service owner;
+* keep one authoritative complete configuration, while producer workers retain
+  only the execution state needed to observe it;
 * validate a coherent candidate before changing producer state;
 * ensure the shared worker observes one coherent configuration per capture cycle;
+* lazily create the shared worker once, quiesce it on ordinary disable, wake it
+  on re-enable, and join it only during terminal shutdown;
 * preserve the actual sampling interval with each continuous-thread batch;
 * make ordinary disable and terminal shutdown idempotent and race-safe; and
 * cover startup-disabled, enable, update, disable, re-enable, transition failure,
@@ -171,7 +174,6 @@ This shared definition deliberately does not choose or define:
 * precedence between startup and control-plane configuration;
 * revisions, generations, compare-and-apply, or an exact versioned interop ABI;
 * a managed-host claim, token, lease, or `AppDomain` recovery protocol;
-* whether the shared worker is retained while inactive; or
 * changes to the public plugin API.
 
 Those mechanisms require separate review after the sampling semantics above are

--- a/docs/internal/selective-sampling.md
+++ b/docs/internal/selective-sampling.md
@@ -3,8 +3,10 @@
 > [!IMPORTANT]
 > Selective sampling is an experimental feature.
 
-This feature builds on top of the continuous profiling capabilities.
-See [Continuous profiling](./continuous-profiler.md) for more details.
+This feature builds on top of the continuous profiling capabilities and shares
+the native thread-sampling worker. See the
+[continuous profiler shared service definition](./continuous-profiler.md#shared-service-definition)
+for the common lifecycle and configuration semantics.
 
 Selective sampling API allows you to enable span-based sampling.
 After span is selected for frequent sampling, any thread associated with

--- a/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/CMakeLists.txt
@@ -209,6 +209,8 @@ add_library("OpenTelemetry.AutoInstrumentation.Native.static" STATIC
         configuration.cpp
         continuous_profiler_clr_helpers.cpp
         continuous_profiler.cpp
+        runtime_sampler_configuration.cpp
+        runtime_sampler_controller.cpp
         cor_profiler_base.cpp
         cor_profiler.cpp
         il_rewriter_wrapper.cpp

--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.def
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.def
@@ -10,7 +10,10 @@ EXPORTS
     SetSqlClientNetFxILRewriteEnabled
     InitializeTraceMethods
     ConfigureContinuousProfiler
+    ApplyContinuousProfilerConfigurationV1
+    GetContinuousProfilerStateV1
     ContinuousProfilerReadThreadSamples
+    ContinuousProfilerReadThreadSamplesV2
     ContinuousProfilerReadAllocationSamples
     SelectiveSamplerReadThreadSamples
     ContinuousProfilerSetNativeContext

--- a/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/OpenTelemetry.AutoInstrumentation.Native.vcxproj
@@ -193,6 +193,8 @@
     <ClInclude Include="configuration.h" />
     <ClInclude Include="continuous_profiler_clr_helpers.h" />
     <ClInclude Include="continuous_profiler.h" />
+    <ClInclude Include="runtime_sampler_configuration.h" />
+    <ClInclude Include="runtime_sampler_controller.h" />
     <ClInclude Include="cor_profiler.h" />
     <ClInclude Include="cor_profiler_base.h" />
     <ClInclude Include="deployment_detection.h" />
@@ -250,6 +252,8 @@
     <ClCompile Include="configuration.cpp" />
     <ClCompile Include="continuous_profiler_clr_helpers.cpp" />
     <ClCompile Include="continuous_profiler.cpp" />
+    <ClCompile Include="runtime_sampler_configuration.cpp" />
+    <ClCompile Include="runtime_sampler_controller.cpp" />
     <ClCompile Include="cor_profiler_base.cpp" />
     <ClCompile Include="cor_profiler.cpp" />
     <ClCompile Include="environment_variables_util.cpp" />

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.cpp
@@ -22,6 +22,15 @@ ClrRuntimeCapture::ClrRuntimeCapture(IProfilerApi* profilerApi, std::chrono::mil
 #endif
 }
 
+HRESULT ClrRuntimeCapture::PrepareForStackWalking() noexcept
+{
+#if defined(_WIN32) && defined(_M_AMD64)
+    return stackWalkGuard_ != nullptr && stackWalkGuard_->Start() ? S_OK : E_FAIL;
+#else
+    return S_OK;
+#endif
+}
+
 HRESULT ClrRuntimeCapture::SuspendRuntime()
 {
     if (profilerApi_ == nullptr)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.cpp
@@ -31,6 +31,16 @@ HRESULT ClrRuntimeCapture::PrepareForStackWalking() noexcept
 #endif
 }
 
+void ClrRuntimeCapture::Stop() noexcept
+{
+#if defined(_WIN32) && defined(_M_AMD64)
+    if (stackWalkGuard_ != nullptr)
+    {
+        stackWalkGuard_->Stop();
+    }
+#endif
+}
+
 HRESULT ClrRuntimeCapture::SuspendRuntime()
 {
     if (profilerApi_ == nullptr)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.h
@@ -39,17 +39,17 @@ public:
                                std::chrono::milliseconds probeTimeout = std::chrono::milliseconds(250));
     ~ClrRuntimeCapture() = default;
 
+    HRESULT PrepareForStackWalking() noexcept override;
     HRESULT SuspendRuntime() override;
     void    ResumeRuntime() noexcept override;
 
-    HRESULT CaptureStack(ThreadID                      managedThreadId,
-                         StackSnapshotCallbackContext* clientData) override;
+    HRESULT CaptureStack(ThreadID managedThreadId, StackSnapshotCallbackContext* clientData) override;
 
 private:
     IProfilerApi* profilerApi_;
 
 #if defined(_WIN32) && defined(_M_AMD64)
-    std::unique_ptr<StackWalkGuard> stackWalkGuard_;
+    std::unique_ptr<StackWalkGuard>        stackWalkGuard_;
     std::unique_ptr<SafeNativeWalkService> nativeWalk_;
 #endif
 };

--- a/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/clr_runtime_capture.h
@@ -40,6 +40,7 @@ public:
     ~ClrRuntimeCapture() = default;
 
     HRESULT PrepareForStackWalking() noexcept override;
+    void    Stop() noexcept override;
     HRESULT SuspendRuntime() override;
     void    ResumeRuntime() noexcept override;
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
@@ -1043,9 +1043,11 @@ static bool CaptureFunctionIdentifiersForThreads(
         const HRESULT                            hr = stackWalker->CaptureStacks(selectedThreads, &request);
         if (FAILED(hr))
         {
-            trace::Logger::Debug("Stack capture failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);
-            threadStacksBuffer.clear();
-            return false;
+            // CaptureStacks reports an aggregate failure when any requested thread cannot be captured.
+            // Preserve stacks captured for other threads and let the non-empty check below discard cycles
+            // that produced no usable stacks.
+            trace::Logger::Debug("Some thread stacks could not be captured. HRESULT=0x", std::setfill('0'),
+                                 std::setw(8), std::hex, hr);
         }
 
         return true;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
@@ -1444,39 +1444,61 @@ void ContinuousProfiler::SamplingThreadMain() noexcept
         while (true)
         {
             RuntimeSamplerConfiguration cycleConfiguration;
+            std::uint64_t               cycleGeneration;
             {
                 std::unique_lock<std::mutex> lock(sampling_state_mutex_);
-                if (shutdown_requested_.load(std::memory_order_acquire) || thread_sampling_stop_requested_)
+                if (shutdown_requested_.load(std::memory_order_acquire))
                 {
-                    return;
+                    break;
                 }
 
-                cycleConfiguration = configuration_;
-                if (!cycleConfiguration.HasThreadSampling())
+                if (!periodic_thread_sampling_interval_.has_value() && !selective_thread_sampling_interval_.has_value())
                 {
-                    return;
+                    const auto quiescentGeneration                = thread_configuration_generation_;
+                    acknowledged_thread_configuration_generation_ = quiescentGeneration;
+                    sampling_state_cv_.notify_all();
+                    sampling_state_cv_.wait(lock,
+                                            [this, quiescentGeneration]
+                                            {
+                                                return shutdown_requested_.load(std::memory_order_acquire) ||
+                                                       thread_configuration_generation_ != quiescentGeneration;
+                                            });
+                    continue;
                 }
 
-                if (observedGeneration != configuration_generation_)
+                cycleConfiguration = {periodic_thread_sampling_interval_, selective_thread_sampling_interval_,
+                                      std::nullopt};
+                cycleGeneration    = thread_configuration_generation_;
+
+                if (observedGeneration != cycleGeneration)
                 {
-                    observedGeneration = configuration_generation_;
+                    observedGeneration = cycleGeneration;
                     iteration          = 0;
                 }
 
                 const unsigned int sleepTime = GetSleepTime(cycleConfiguration);
                 if (sleepTime == 0)
                 {
-                    trace::Logger::Warn("Unexpected sampling interval configured, exiting sampling thread.");
-                    return;
+                    trace::Logger::Warn("Unexpected sampling interval configured, quiescing sampling thread.");
+                    sampling_state_cv_.wait(lock,
+                                            [this, cycleGeneration] {
+                                                return shutdown_requested_.load(std::memory_order_acquire) ||
+                                                       thread_configuration_generation_ != cycleGeneration;
+                                            });
+                    continue;
                 }
 
                 if (sampling_state_cv_.wait_for(lock, std::chrono::milliseconds(sleepTime),
-                                                [this] {
+                                                [this, cycleGeneration] {
                                                     return shutdown_requested_.load(std::memory_order_acquire) ||
-                                                           thread_sampling_stop_requested_;
+                                                           thread_configuration_generation_ != cycleGeneration;
                                                 }))
                 {
-                    return;
+                    if (shutdown_requested_.load(std::memory_order_acquire))
+                    {
+                        break;
+                    }
+                    continue;
                 }
             }
 
@@ -1501,7 +1523,7 @@ void ContinuousProfiler::SamplingThreadMain() noexcept
 
                 if (IsShutdownRequested())
                 {
-                    return;
+                    break;
                 }
 
                 const auto now = std::chrono::steady_clock::now();
@@ -1558,6 +1580,12 @@ void ContinuousProfiler::SamplingThreadMain() noexcept
         {
         }
     }
+
+    {
+        std::lock_guard<std::mutex> lock(sampling_state_mutex_);
+        thread_sampling_worker_exited_ = true;
+    }
+    sampling_state_cv_.notify_all();
 }
 
 void ContinuousProfiler::SetGlobalInfo7(ICorProfilerInfo7* cor_profiler_info7)
@@ -1639,185 +1667,178 @@ ContinuousProfiler::~ContinuousProfiler()
     managed_tid_to_state_.clear();
 }
 
-bool ContinuousProfiler::ApplyConfiguration(const RuntimeSamplerConfiguration& candidate)
+bool ContinuousProfiler::ApplyConfiguration(const RuntimeSamplerConfiguration& previous,
+                                            const RuntimeSamplerConfiguration& candidate)
 {
-    std::unique_lock<std::mutex> transitionLock(configuration_transition_mutex_);
+    std::unique_lock<std::mutex> stateLock(sampling_state_mutex_);
     if (shutdown_requested_.load(std::memory_order_acquire))
     {
         return false;
     }
 
-    std::unique_ptr<std::thread> threadToJoin;
-    bool                         transitionSucceeded = false;
-    bool                         stoppedActiveWorker = false;
-
+    if (previous == candidate)
     {
-        std::unique_lock<std::mutex> stateLock(sampling_state_mutex_);
-        const auto                   previous = configuration_;
-        if (previous == candidate)
+        return true;
+    }
+
+    if (candidate.selectiveThreadSamplingIntervalMilliseconds.has_value())
+    {
+        try
         {
-            return true;
+            std::call_once(selective_sampling_init_flag_, [] { InitSelectiveSamplingBuffer(); });
         }
-
-        if (candidate.selectiveThreadSamplingIntervalMilliseconds.has_value())
+        catch (const std::exception& exception)
         {
-            try
-            {
-                std::call_once(selective_sampling_init_flag_, [] { InitSelectiveSamplingBuffer(); });
-            }
-            catch (const std::exception& exception)
-            {
-                trace::Logger::Error("Unable to initialize selective sampling buffers: ", exception.what());
-                return false;
-            }
-            catch (...)
-            {
-                trace::Logger::Error("Unable to initialize selective sampling buffers.");
-                return false;
-            }
+            trace::Logger::Error("Unable to initialize selective sampling buffers: ", exception.what());
+            return false;
         }
-
-        const bool startThread                = !previous.HasThreadSampling() && candidate.HasThreadSampling();
-        const bool stopThread                 = previous.HasThreadSampling() && !candidate.HasThreadSampling();
-        const bool threadConfigurationChanged = previous.periodicThreadSamplingIntervalMilliseconds !=
-                                                    candidate.periodicThreadSamplingIntervalMilliseconds ||
-                                                previous.selectiveThreadSamplingIntervalMilliseconds !=
-                                                    candidate.selectiveThreadSamplingIntervalMilliseconds;
-
-        std::unique_ptr<std::thread> stagedThread;
-        if (startThread)
+        catch (...)
         {
-            if (stackWalker_ == nullptr || FAILED(stackWalker_->PrepareForStackWalking()))
-            {
-                trace::Logger::Error("Unable to prepare safe stack walking for continuous profiling.");
-                return false;
-            }
+            trace::Logger::Error("Unable to initialize selective sampling buffers.");
+            return false;
+        }
+    }
 
-            try
-            {
-                // The new thread blocks on sampling_state_mutex_ until the full
-                // producer transition commits below.
-                stagedThread = std::make_unique<std::thread>(&ContinuousProfiler::SamplingThreadMain, this);
-            }
-            catch (const std::exception& exception)
-            {
-                trace::Logger::Error("Unable to start continuous profiler sampling thread: ", exception.what());
-                return false;
-            }
-            catch (...)
-            {
-                trace::Logger::Error("Unable to start continuous profiler sampling thread.");
-                return false;
-            }
+    if (candidate.HasAllocationSampling() && info12 == nullptr && allocation_sampling_session_provider_ == nullptr)
+    {
+        trace::Logger::Warn("Allocation sampling is not supported for .NET Framework applications.");
+        return false;
+    }
+
+    if (candidate.HasThreadSampling() && thread_sampling_worker_exited_)
+    {
+        trace::Logger::Error("Continuous profiler sampling worker is unavailable after an unexpected exit.");
+        return false;
+    }
+
+    if (candidate.HasThreadSampling() && thread_sampling_thread_ == nullptr)
+    {
+        if (stackWalker_ == nullptr || FAILED(stackWalker_->PrepareForStackWalking()))
+        {
+            trace::Logger::Error("Unable to prepare safe stack walking for continuous profiling.");
+            return false;
         }
 
         try
         {
-            transitionSucceeded = ApplyAllocationConfiguration(previous.maxAllocationSamplesPerMinute,
-                                                               candidate.maxAllocationSamplesPerMinute);
+            // The worker cannot observe a partially applied candidate because
+            // it waits on sampling_state_mutex_ until publication below. Once
+            // created, it remains available in quiescence for the process
+            // lifetime and is joined only by terminal shutdown.
+            thread_sampling_thread_ = std::make_unique<std::thread>(&ContinuousProfiler::SamplingThreadMain, this);
         }
         catch (const std::exception& exception)
         {
-            trace::Logger::Error("Unable to apply allocation sampling configuration: ", exception.what());
-            transitionSucceeded = false;
+            trace::Logger::Error("Unable to start continuous profiler sampling thread: ", exception.what());
+            return false;
         }
         catch (...)
         {
-            trace::Logger::Error("Unable to apply allocation sampling configuration.");
-            transitionSucceeded = false;
-        }
-
-        if (!transitionSucceeded)
-        {
-            if (startThread)
-            {
-                threadToJoin = std::move(stagedThread);
-            }
-        }
-        else
-        {
-            // RuntimeSamplerConfiguration contains only optional integer values,
-            // so publication is a non-throwing final commit after all fallible
-            // resource transitions have succeeded.
-            configuration_ = candidate;
-            if (threadConfigurationChanged)
-            {
-                ++configuration_generation_;
-            }
-
-            if (startThread)
-            {
-                thread_sampling_stop_requested_ = false;
-                thread_sampling_thread_         = std::move(stagedThread);
-            }
-            else if (stopThread)
-            {
-                thread_sampling_stop_requested_ = true;
-                threadToJoin                    = std::move(thread_sampling_thread_);
-                stoppedActiveWorker             = true;
-            }
+            trace::Logger::Error("Unable to start continuous profiler sampling thread.");
+            return false;
         }
     }
 
-    if (threadToJoin != nullptr)
+    try
+    {
+        if (!ApplyAllocationConfiguration(previous.maxAllocationSamplesPerMinute,
+                                          candidate.maxAllocationSamplesPerMinute))
+        {
+            return false;
+        }
+    }
+    catch (const std::exception& exception)
+    {
+        trace::Logger::Error("Unable to apply allocation sampling configuration: ", exception.what());
+        return false;
+    }
+    catch (...)
+    {
+        trace::Logger::Error("Unable to apply allocation sampling configuration.");
+        return false;
+    }
+
+    const bool threadConfigurationChanged =
+        previous.periodicThreadSamplingIntervalMilliseconds != candidate.periodicThreadSamplingIntervalMilliseconds ||
+        previous.selectiveThreadSamplingIntervalMilliseconds != candidate.selectiveThreadSamplingIntervalMilliseconds;
+    const bool waitForQuiescence = previous.HasThreadSampling() && !candidate.HasThreadSampling();
+
+    // Publish only the state consumed by the retained thread worker. The
+    // RuntimeSamplerController remains the sole owner of the complete active
+    // configuration and its externally visible generation.
+    periodic_thread_sampling_interval_  = candidate.periodicThreadSamplingIntervalMilliseconds;
+    selective_thread_sampling_interval_ = candidate.selectiveThreadSamplingIntervalMilliseconds;
+    if (threadConfigurationChanged)
+    {
+        ++thread_configuration_generation_;
+    }
+    const auto committedThreadGeneration = thread_configuration_generation_;
+
+    stateLock.unlock();
+    if (threadConfigurationChanged)
     {
         sampling_state_cv_.notify_all();
-        if (threadToJoin->joinable())
-        {
-            threadToJoin->join();
-        }
-        if (stoppedActiveWorker)
-        {
-            LogProfilerInfoNoThrow("ContinuousProfiler sampling thread stopped.");
-        }
     }
 
-    if (transitionSucceeded && candidate.HasThreadSampling())
+    if (waitForQuiescence)
+    {
+        stateLock.lock();
+        sampling_state_cv_.wait(stateLock,
+                                [this, committedThreadGeneration]
+                                {
+                                    return acknowledged_thread_configuration_generation_ >= committedThreadGeneration ||
+                                           thread_sampling_worker_exited_;
+                                });
+        stateLock.unlock();
+    }
+
+    if (candidate.HasThreadSampling())
     {
         LogProfilerInfoNoThrow("ContinuousProfiler thread sampling configured.");
     }
 
-    return transitionSucceeded;
+    return true;
 }
 
-RuntimeSamplerConfiguration ContinuousProfiler::GetConfiguration() const
-{
-    std::lock_guard<std::mutex> guard(sampling_state_mutex_);
-    return configuration_;
-}
-
-bool ContinuousProfiler::IsThreadSamplingThreadRunning() const
+bool ContinuousProfiler::HasThreadSamplingWorker() const
 {
     std::lock_guard<std::mutex> guard(sampling_state_mutex_);
     return thread_sampling_thread_ != nullptr && thread_sampling_thread_->joinable();
 }
 
+bool ContinuousProfiler::IsThreadSamplingWorkerQuiescent() const
+{
+    std::lock_guard<std::mutex> guard(sampling_state_mutex_);
+    return thread_sampling_thread_ != nullptr && !thread_sampling_worker_exited_ &&
+           !periodic_thread_sampling_interval_.has_value() && !selective_thread_sampling_interval_.has_value() &&
+           acknowledged_thread_configuration_generation_ >= thread_configuration_generation_;
+}
+
 void ContinuousProfiler::Shutdown()
 {
-    std::unique_lock<std::mutex> transitionLock(configuration_transition_mutex_);
-    if (shutdown_requested_.exchange(true, std::memory_order_acq_rel))
-    {
-        return;
-    }
+    std::call_once(shutdown_once_,
+                   [this]
+                   {
+                       std::unique_ptr<std::thread> threadToJoin;
+                       {
+                           std::lock_guard<std::mutex> stateLock(sampling_state_mutex_);
+                           shutdown_requested_.store(true, std::memory_order_release);
+                           periodic_thread_sampling_interval_.reset();
+                           selective_thread_sampling_interval_.reset();
+                           ++thread_configuration_generation_;
+                           threadToJoin = std::move(thread_sampling_thread_);
+                       }
 
-    std::unique_ptr<std::thread> threadToJoin;
-    {
-        std::lock_guard<std::mutex> stateLock(sampling_state_mutex_);
-        configuration_ = RuntimeSamplerConfiguration{};
-        ++configuration_generation_;
-        thread_sampling_stop_requested_ = true;
-        threadToJoin                    = std::move(thread_sampling_thread_);
-    }
+                       sampling_state_cv_.notify_all();
+                       if (threadToJoin != nullptr && threadToJoin->joinable())
+                       {
+                           threadToJoin->join();
+                           LogProfilerInfoNoThrow("ContinuousProfiler sampling thread stopped.");
+                       }
 
-    sampling_state_cv_.notify_all();
-    if (threadToJoin != nullptr && threadToJoin->joinable())
-    {
-        threadToJoin->join();
-        LogProfilerInfoNoThrow("ContinuousProfiler sampling thread stopped.");
-    }
-
-    StopAllocationSamplingForShutdown();
-    ClearGlobalInfo();
+                       StopAllocationSamplingForShutdown();
+                       ClearGlobalInfo();
+                   });
 }
 
 bool ContinuousProfiler::IsShutdownRequested() const

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
@@ -7,6 +7,7 @@
 #include "stack_capture_types.h"
 #include "logger.h"
 #include <chrono>
+#include <deque>
 #include <map>
 #include <algorithm>
 #include <shared_mutex>
@@ -78,12 +79,23 @@ constexpr auto kVolatileFunctionIdentifierCacheSize = 2000;
     are fully processed before pausing the CLR for thread samples.
 */
 
-static std::mutex                  cpu_buffer_lock = std::mutex();
-static std::vector<unsigned char>* cpu_buffer_a;
-static std::vector<unsigned char>* cpu_buffer_b;
+struct ThreadSampleBatch
+{
+    std::unique_ptr<std::vector<unsigned char>> buffer;
+    std::uint32_t                               sampling_interval;
 
-static std::mutex                  allocation_buffer_lock = std::mutex();
-static std::vector<unsigned char>* allocation_buffer      = new std::vector<unsigned char>();
+    ThreadSampleBatch(std::unique_ptr<std::vector<unsigned char>> buffer, const std::uint32_t samplingInterval)
+        : buffer(std::move(buffer)), sampling_interval(samplingInterval)
+    {
+    }
+};
+
+static std::mutex                    cpu_buffer_lock = std::mutex();
+static std::deque<ThreadSampleBatch> cpu_buffers;
+
+static std::mutex                  allocation_buffer_lock      = std::mutex();
+static std::vector<unsigned char>* allocation_buffer           = new std::vector<unsigned char>();
+static bool                        allocation_buffer_saturated = false;
 
 static std::mutex                 selective_sampling_buffer_lock = std::mutex();
 static std::vector<unsigned char> selective_sampling_buffer;
@@ -101,61 +113,113 @@ static std::mutex name_cache_lock = std::mutex();
 
 static std::shared_mutex profiling_lock = std::shared_mutex();
 
-static ICorProfilerInfo7* profiler_info; // After feature sets settle down, perhaps this should be refactored and have
-                                         // a single static instance of ThreadSampler
+// After feature sets settle down, perhaps this should be refactored and have a single static instance of ThreadSampler.
+static std::atomic<ICorProfilerInfo7*> profiler_info{nullptr};
+static std::atomic_bool                profiler_callbacks_enabled{false};
+static std::shared_mutex               profiler_callback_lock;
+
+static void LogProfilerCallbackFailure(const char* callbackName) noexcept
+{
+    try
+    {
+        trace::Logger::Warn(callbackName, " failed; the error was contained by the native profiler.");
+    }
+    catch (...)
+    {
+    }
+}
+
+template <typename... Args>
+static void LogProfilerInfoNoThrow(const Args&... args) noexcept
+{
+    try
+    {
+        trace::Logger::Info(args...);
+    }
+    catch (...)
+    {
+    }
+}
 
 // Dirt-simple back pressure system to save overhead if managed code is not reading fast enough
 bool ThreadSamplingShouldProduceThreadSample()
 {
     std::lock_guard<std::mutex> guard(cpu_buffer_lock);
-    return cpu_buffer_a == nullptr || cpu_buffer_b == nullptr;
+    return cpu_buffers.size() < 2;
 }
-void ThreadSamplingRecordProducedThreadSample(std::vector<unsigned char>* buf)
+void ThreadSamplingRecordProducedThreadSample(std::vector<unsigned char>* buf, const std::uint32_t samplingInterval)
 {
-    std::lock_guard<std::mutex> guard(cpu_buffer_lock);
-    if (cpu_buffer_a == nullptr)
+    std::unique_ptr<std::vector<unsigned char>> ownedBuffer(buf);
+    if (ownedBuffer == nullptr)
     {
-        cpu_buffer_a = buf;
+        return;
     }
-    else if (cpu_buffer_b == nullptr)
+
+    std::lock_guard<std::mutex> guard(cpu_buffer_lock);
+    if (cpu_buffers.size() < 2)
     {
-        cpu_buffer_b = buf;
+        try
+        {
+            cpu_buffers.emplace_back(std::move(ownedBuffer), samplingInterval);
+        }
+        catch (const std::exception& exception)
+        {
+            trace::Logger::Warn("Could not buffer a completed thread sample batch: ", exception.what());
+        }
+        catch (...)
+        {
+            trace::Logger::Warn("Could not buffer a completed thread sample batch.");
+        }
     }
     else
     {
         trace::Logger::Warn("Unexpected buffer drop in ThreadSampling_RecordProducedThreadSample");
-        delete buf; // needs to be dropped now
     }
 }
 // Can return 0 if none are pending
-int32_t ThreadSamplingConsumeOneThreadSample(int32_t len, unsigned char* buf)
+int32_t ThreadSamplingConsumeOneThreadSample(int32_t len, unsigned char* buf, std::uint32_t* samplingInterval)
 {
+    if (samplingInterval == nullptr)
+    {
+        trace::Logger::Warn("Unexpected null sampling interval to ThreadSampling_ConsumeOneThreadSample");
+        return 0;
+    }
+
+    *samplingInterval = 0;
     if (len <= 0 || buf == nullptr)
     {
         trace::Logger::Warn("Unexpected 0/null buffer to ThreadSampling_ConsumeOneThreadSample");
         return 0;
     }
-    std::vector<unsigned char>* to_use = nullptr;
+    std::unique_ptr<std::vector<unsigned char>> to_use;
+    std::uint32_t                               to_use_sampling_interval = 0;
     {
         std::lock_guard<std::mutex> guard(cpu_buffer_lock);
-        if (cpu_buffer_a != nullptr)
+        if (!cpu_buffers.empty())
         {
-            to_use       = cpu_buffer_a;
-            cpu_buffer_a = nullptr;
-        }
-        else if (cpu_buffer_b != nullptr)
-        {
-            to_use       = cpu_buffer_b;
-            cpu_buffer_b = nullptr;
+            to_use_sampling_interval = cpu_buffers.front().sampling_interval;
+            to_use                   = std::move(cpu_buffers.front().buffer);
+            cpu_buffers.pop_front();
         }
     }
     if (to_use == nullptr)
     {
         return 0;
     }
-    const size_t to_use_len = static_cast<int>(std::min(to_use->size(), static_cast<size_t>(len)));
+    if (to_use->empty())
+    {
+        return 0;
+    }
+
+    if (to_use->size() > static_cast<size_t>(len))
+    {
+        trace::Logger::Warn("Discarding a thread sample batch because the destination buffer is too small.");
+        return 0;
+    }
+
+    const size_t to_use_len = to_use->size();
     memcpy(buf, to_use->data(), to_use_len);
-    delete to_use;
+    *samplingInterval = to_use_sampling_interval;
     return static_cast<int32_t>(to_use_len);
 }
 
@@ -215,12 +279,48 @@ void AllocationSamplingAppendToBuffer(int32_t appendLen, unsigned char* appendBu
     }
     std::lock_guard<std::mutex> guard(allocation_buffer_lock);
 
-    if (allocation_buffer->size() + appendLen >= kSamplesBufferMaximumSize)
+    if (allocation_buffer_saturated)
     {
+        return;
+    }
+
+    const auto appendSize  = static_cast<size_t>(appendLen);
+    const auto maximumSize = static_cast<size_t>(kSamplesBufferMaximumSize);
+    const auto currentSize = allocation_buffer->size();
+    if (currentSize > maximumSize || appendSize > maximumSize - currentSize)
+    {
+        allocation_buffer_saturated = true;
         trace::Logger::Warn("Discarding captured allocation sample. Allocation buffer is full.");
         return;
     }
-    allocation_buffer->insert(allocation_buffer->end(), appendBuf, &appendBuf[appendLen]);
+
+    try
+    {
+        allocation_buffer->insert(allocation_buffer->end(), appendBuf, appendBuf + appendSize);
+    }
+    catch (const std::exception& exception)
+    {
+        allocation_buffer_saturated = true;
+        trace::Logger::Warn("Could not buffer a completed allocation sample: ", exception.what());
+        return;
+    }
+    catch (...)
+    {
+        allocation_buffer_saturated = true;
+        trace::Logger::Warn("Could not buffer a completed allocation sample.");
+        return;
+    }
+
+    if (allocation_buffer->size() == maximumSize)
+    {
+        allocation_buffer_saturated = true;
+    }
+}
+
+bool AllocationSamplingShouldProduceSample()
+{
+    std::lock_guard<std::mutex> guard(allocation_buffer_lock);
+    return !allocation_buffer_saturated;
 }
 
 // Can return 0
@@ -231,20 +331,48 @@ static int32_t AllocationSamplingConsumeAndReplaceBuffer(int32_t len, unsigned c
         trace::Logger::Warn("Unexpected 0/null buffer to ContinuousProfilerReadAllocationSamples");
         return 0;
     }
-    std::vector<unsigned char>* to_use = nullptr;
+    std::unique_ptr<std::vector<unsigned char>> replacement;
+    try
+    {
+        replacement = std::make_unique<std::vector<unsigned char>>();
+        replacement->reserve(kSamplesBufferDefaultSize);
+    }
+    catch (const std::exception& exception)
+    {
+        trace::Logger::Warn("Could not allocate an allocation-sample read buffer: ", exception.what());
+        return 0;
+    }
+    catch (...)
+    {
+        trace::Logger::Warn("Could not allocate an allocation-sample read buffer.");
+        return 0;
+    }
+
+    std::unique_ptr<std::vector<unsigned char>> to_use;
     {
         std::lock_guard<std::mutex> guard(allocation_buffer_lock);
-        to_use            = allocation_buffer;
-        allocation_buffer = new std::vector<unsigned char>();
-        allocation_buffer->reserve(kSamplesBufferDefaultSize);
+        to_use.reset(allocation_buffer);
+        allocation_buffer           = replacement.release();
+        allocation_buffer_saturated = false;
     }
     if (to_use == nullptr)
     {
         return 0;
     }
-    const size_t to_use_len = static_cast<int>(std::min(to_use->size(), static_cast<size_t>(len)));
+
+    if (to_use->size() > static_cast<size_t>(len))
+    {
+        trace::Logger::Warn("Discarding allocation samples because the destination buffer is too small.");
+        return 0;
+    }
+
+    const size_t to_use_len = to_use->size();
+    if (to_use_len == 0)
+    {
+        return 0;
+    }
+
     memcpy(buf, to_use->data(), to_use_len);
-    delete to_use;
     return static_cast<int32_t>(to_use_len);
 }
 
@@ -257,7 +385,15 @@ static int32_t SelectiveSamplingConsumeAndClearBuffer(int32_t len, unsigned char
     }
 
     std::lock_guard<std::mutex> guard(selective_sampling_buffer_lock);
-    const size_t                to_use_len = std::min(selective_sampling_buffer.size(), static_cast<size_t>(len));
+    if (selective_sampling_buffer.size() > static_cast<size_t>(len))
+    {
+        selective_sampling_buffer.clear();
+        selective_sampling_buffer_saturated = false;
+        trace::Logger::Warn("Discarding selected-thread samples because the destination buffer is too small.");
+        return 0;
+    }
+
+    const size_t to_use_len = selective_sampling_buffer.size();
 
     if (to_use_len > 0)
     {
@@ -326,6 +462,7 @@ ThreadSamplesBuffer::~ThreadSamplesBuffer()
     {                                                                                                                  \
         if (buffer_->size() >= kSamplesBufferMaximumSize)                                                              \
         {                                                                                                              \
+            overflowed_ = true;                                                                                        \
             return;                                                                                                    \
         }                                                                                                              \
     }
@@ -424,6 +561,31 @@ void ThreadSamplesBuffer::WriteFinalStats(const SamplingStatistics& stats) const
     WriteInt(stats.name_cache_misses);
 }
 
+bool ThreadSamplesBuffer::IsOverflowed() const noexcept
+{
+    return overflowed_;
+}
+
+void ThreadSamplesBuffer::UpdateOverflowState() const noexcept
+{
+    if (buffer_->size() > static_cast<size_t>(kSamplesBufferMaximumSize))
+    {
+        overflowed_ = true;
+    }
+}
+
+template <typename... Args>
+static void LogProfilerErrorNoThrow(const Args&... args) noexcept
+{
+    try
+    {
+        trace::Logger::Error(args...);
+    }
+    catch (...)
+    {
+    }
+}
+
 void ThreadSamplesBuffer::WriteCodedFrameString(const FunctionIdentifier& fid, const trace::WSTRING& str)
 {
     const auto found = codes_.find(fid);
@@ -446,6 +608,7 @@ void ThreadSamplesBuffer::WriteShort(int16_t val) const
 {
     buffer_->push_back(((val >> 8) & 0xFF));
     buffer_->push_back(val & 0xFF);
+    UpdateOverflowState();
 }
 void ThreadSamplesBuffer::WriteInt(int32_t val) const
 {
@@ -453,6 +616,7 @@ void ThreadSamplesBuffer::WriteInt(int32_t val) const
     buffer_->push_back(((val >> 16) & 0xFF));
     buffer_->push_back(((val >> 8) & 0xFF));
     buffer_->push_back(val & 0xFF);
+    UpdateOverflowState();
 }
 
 void ThreadSamplesBuffer::WriteString(const WCHAR* s, size_t charLen) const
@@ -465,6 +629,7 @@ void ThreadSamplesBuffer::WriteString(const WCHAR* s, size_t charLen) const
     const auto str_begin = reinterpret_cast<const unsigned char*>(s);
     // possible endian-ness assumption here; unclear how the managed layer would decode on big endian platforms
     buffer_->insert(buffer_->end(), str_begin, str_begin + used_len * 2);
+    UpdateOverflowState();
 }
 
 void ThreadSamplesBuffer::WriteString(const trace::WSTRING& str) const
@@ -474,6 +639,7 @@ void ThreadSamplesBuffer::WriteString(const trace::WSTRING& str) const
 void ThreadSamplesBuffer::WriteByte(unsigned char b) const
 {
     buffer_->push_back(b);
+    UpdateOverflowState();
 }
 void ThreadSamplesBuffer::WriteUInt64(uint64_t val) const
 {
@@ -485,6 +651,7 @@ void ThreadSamplesBuffer::WriteUInt64(uint64_t val) const
     buffer_->push_back(((val >> 16) & 0xFF));
     buffer_->push_back(((val >> 8) & 0xFF));
     buffer_->push_back(val & 0xFF);
+    UpdateOverflowState();
 }
 
 void ThreadSamplesBuffer::WriteCurrentTimeMillis() const
@@ -512,6 +679,11 @@ void ThreadSpanContextMap::Remove(const thread_span_context& spanContext)
 void ThreadSpanContextMap::Remove(ThreadID threadId)
 {
     thread_span_context_map.erase(threadId);
+}
+
+void ThreadSpanContextMap::Clear()
+{
+    thread_span_context_map.clear();
 }
 
 std::unordered_map<ThreadID, thread_span_context>::const_iterator ThreadSpanContextMap::begin() const
@@ -547,17 +719,44 @@ NamingHelper::NamingHelper()
 
 void ContinuousProfiler::AllocateBuffer()
 {
-    auto bytes = new std::vector<unsigned char>();
+    DiscardBuffer();
+    auto bytes = std::make_unique<std::vector<unsigned char>>();
     bytes->reserve(kSamplesBufferDefaultSize);
-    cur_cpu_writer_ = new ThreadSamplesBuffer(bytes);
+    cur_cpu_writer_ = new ThreadSamplesBuffer(bytes.get());
+    bytes.release();
 }
 
-void ContinuousProfiler::PublishBuffer()
+void ContinuousProfiler::PublishBuffer(const std::uint32_t samplingInterval)
 {
-    ThreadSamplingRecordProducedThreadSample(cur_cpu_writer_->buffer_);
+    if (cur_cpu_writer_ == nullptr)
+    {
+        return;
+    }
+
+    if (cur_cpu_writer_->IsOverflowed())
+    {
+        trace::Logger::Warn("Discarding an overflowed thread sample batch.");
+        DiscardBuffer();
+        return;
+    }
+
+    auto* buffer             = cur_cpu_writer_->buffer_;
+    cur_cpu_writer_->buffer_ = nullptr;
     delete cur_cpu_writer_;
     cur_cpu_writer_ = nullptr;
     stats_          = SamplingStatistics();
+    ThreadSamplingRecordProducedThreadSample(buffer, samplingInterval);
+}
+
+void ContinuousProfiler::DiscardBuffer() noexcept
+{
+    if (cur_cpu_writer_ != nullptr)
+    {
+        delete cur_cpu_writer_->buffer_;
+        delete cur_cpu_writer_;
+        cur_cpu_writer_ = nullptr;
+    }
+    stats_ = SamplingStatistics();
 }
 
 void NamingHelper::ClearFunctionIdentifierCache()
@@ -761,7 +960,11 @@ struct DoStackSnapshotParams
 {
     ContinuousProfiler*              prof;
     std::vector<FunctionIdentifier>* buffer;
-    DoStackSnapshotParams(ContinuousProfiler* p, std::vector<FunctionIdentifier>* b) : prof(p), buffer(b) {}
+    SamplingStatistics*              stats;
+    DoStackSnapshotParams(ContinuousProfiler* p, std::vector<FunctionIdentifier>* b, SamplingStatistics* samplingStats)
+        : prof(p), buffer(b), stats(samplingStats)
+    {
+    }
 };
 
 static HRESULT __stdcall HandleStackFrame(_In_ FunctionID         func_id,
@@ -773,21 +976,22 @@ static HRESULT __stdcall HandleStackFrame(_In_ FunctionID         func_id,
 {
 
     const auto params = static_cast<DoStackSnapshotParams*>(client_data);
-    params->prof->stats_.total_frames++;
+    params->stats->total_frames++;
 
     const auto identifier = params->prof->helper.LookupManagedFunction(func_id, 0);
     params->buffer->push_back(identifier);
     return S_OK;
 }
 
-[[nodiscard]] static SamplingType GetNextSamplingType(const ContinuousProfiler* prof, const unsigned int iteration)
+[[nodiscard]] static SamplingType GetNextSamplingType(const RuntimeSamplerConfiguration& configuration,
+                                                      const unsigned int                 iteration)
 {
-    if (!prof->selectedThreadsSamplingInterval.has_value())
+    if (!configuration.selectiveThreadSamplingIntervalMilliseconds.has_value())
     {
         return SamplingType::Continuous;
     }
 
-    if (!prof->threadSamplingInterval.has_value())
+    if (!configuration.periodicThreadSamplingIntervalMilliseconds.has_value())
     {
         return SamplingType::SelectedThreads;
     }
@@ -797,7 +1001,8 @@ static HRESULT __stdcall HandleStackFrame(_In_ FunctionID         func_id,
     // N is a ratio of standard (continuos) sampling interval and selective sampling interval.
     // Selective sampling is expected to be much more frequent, e.g. every 20ms compared to 10s for continuous
     // profiling.
-    const unsigned ratio = prof->threadSamplingInterval.value() / prof->selectedThreadsSamplingInterval.value();
+    const unsigned ratio = configuration.periodicThreadSamplingIntervalMilliseconds.value() /
+                           configuration.selectiveThreadSamplingIntervalMilliseconds.value();
     if (iteration != ratio)
     {
         return SamplingType::SelectedThreads;
@@ -806,7 +1011,7 @@ static HRESULT __stdcall HandleStackFrame(_In_ FunctionID         func_id,
     return SamplingType::Continuous;
 }
 
-static void CaptureFunctionIdentifiersForThreads(
+static bool CaptureFunctionIdentifiersForThreads(
     ContinuousProfiler*                                            prof,
     ICorProfilerInfo7*                                             info7,
     const std::unordered_set<ThreadID>&                            selectedThreads,
@@ -819,7 +1024,7 @@ static void CaptureFunctionIdentifiersForThreads(
         auto frameProcessor = [&threadStacksBuffer, prof](continuous_profiler::CapturedFrame* frame) -> HRESULT
         {
             auto                  thread = frame->threadId;
-            DoStackSnapshotParams doStackSnapshotParams{prof, &threadStacksBuffer[thread]};
+            DoStackSnapshotParams doStackSnapshotParams{prof, &threadStacksBuffer[thread], &prof->stats_};
 
             if (frame->isUnmanagedFrame && frame->functionId == 0 && frame->instructionPointer != 0)
             {
@@ -835,8 +1040,19 @@ static void CaptureFunctionIdentifiersForThreads(
         };
 
         continuous_profiler::StackCaptureRequest request{frameProcessor};
-        stackWalker->CaptureStacks(selectedThreads, &request);
+        const HRESULT                            hr = stackWalker->CaptureStacks(selectedThreads, &request);
+        if (FAILED(hr))
+        {
+            trace::Logger::Debug("Stack capture failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);
+            threadStacksBuffer.clear();
+            return false;
+        }
+
+        return true;
     }
+
+    threadStacksBuffer.clear();
+    return false;
 }
 
 static std::unordered_set<ThreadID> EnumerateThreads(ICorProfilerInfo7* info7)
@@ -862,11 +1078,12 @@ static std::unordered_set<ThreadID> EnumerateThreads(ICorProfilerInfo7* info7)
 
 static void ResolveFrames(ContinuousProfiler*                    prof,
                           const std::vector<FunctionIdentifier>& threadStack,
-                          ThreadSamplesBuffer&                   buffer)
+                          ThreadSamplesBuffer&                   buffer,
+                          SamplingStatistics&                    stats)
 {
     for (const auto& functionIdentifier : threadStack)
     {
-        const trace::WSTRING* name = prof->helper.Lookup(functionIdentifier, prof->stats_);
+        const trace::WSTRING* name = prof->helper.Lookup(functionIdentifier, stats);
         // This is where line numbers could be calculated
         buffer.RecordFrame(functionIdentifier, *name);
     }
@@ -890,7 +1107,9 @@ static thread_span_context GetContext(ThreadID threadId)
 }
 
 static void ResolveSymbolsAndPublishBufferForAllThreads(
-    ContinuousProfiler* prof, const std::unordered_map<ThreadID, std::vector<FunctionIdentifier>>& threadStacks)
+    ContinuousProfiler*                                                  prof,
+    const std::unordered_map<ThreadID, std::vector<FunctionIdentifier>>& threadStacks,
+    const RuntimeSamplerConfiguration&                                   configuration)
 {
     prof->AllocateBuffer();
     prof->cur_cpu_writer_->StartBatch();
@@ -907,21 +1126,21 @@ static void ResolveSymbolsAndPublishBufferForAllThreads(
 
         prof->cur_cpu_writer_->StartSample(threadState, spanContext);
 
-        if (prof->selectedThreadsSamplingInterval.has_value())
+        if (configuration.selectiveThreadSamplingIntervalMilliseconds.has_value())
         {
             const auto threadSelectedForFrequentSampling =
                 selective_sampling_trace_map.find(spanContext.trace_context_) != selective_sampling_trace_map.end();
             prof->cur_cpu_writer_->MarkSelectedForFrequentSampling(threadSelectedForFrequentSampling);
         }
 
-        ResolveFrames(prof, threadStack, *prof->cur_cpu_writer_);
+        ResolveFrames(prof, threadStack, *prof->cur_cpu_writer_, prof->stats_);
         prof->cur_cpu_writer_->EndSample();
     }
     prof->cur_cpu_writer_->EndBatch();
 
     prof->cur_cpu_writer_->WriteFinalStats(prof->stats_);
 
-    prof->PublishBuffer();
+    prof->PublishBuffer(configuration.periodicThreadSamplingIntervalMilliseconds.value());
 }
 
 static void ResolveSymbolsAndPublishBufferForSelectedThreads(
@@ -942,10 +1161,16 @@ static void ResolveSymbolsAndPublishBufferForSelectedThreads(
         const auto          threadState = GetThreadState(prof->managed_tid_to_state_, threadId);
 
         localBuf.StartSampleForSelectedThread(threadState, spanContext);
-        ResolveFrames(prof, threadStack, localBuf);
+        ResolveFrames(prof, threadStack, localBuf, prof->stats_);
         localBuf.EndSample();
     }
     localBuf.EndSelectedThreadsBatch();
+
+    if (localBuf.IsOverflowed())
+    {
+        trace::Logger::Warn("Discarding an overflowed selected-thread sample batch.");
+        return;
+    }
 
     // TODO: write out stats
     SelectiveSamplingRecordProducedThreadSample(static_cast<int32_t>(localBytes.size()), localBytes.data());
@@ -1019,7 +1244,8 @@ bool TryPrepareSelectedThreadSampling(ContinuousProfiler* prof, const std::chron
 static void CaptureSamples(ContinuousProfiler*                                            prof,
                            ICorProfilerInfo7*                                             info7,
                            const SamplingType                                             samplingType,
-                           std::unordered_map<ThreadID, std::vector<FunctionIdentifier>>& threadStacksBuffer)
+                           std::unordered_map<ThreadID, std::vector<FunctionIdentifier>>& threadStacksBuffer,
+                           const RuntimeSamplerConfiguration&                             configuration)
 {
     if (samplingType == SamplingType::SelectedThreads &&
         !TryPrepareSelectedThreadSampling(prof, std::chrono::steady_clock::now()))
@@ -1089,20 +1315,31 @@ static void CaptureSamples(ContinuousProfiler*                                  
         if (samplingType == SamplingType::Continuous)
         {
             auto allThreads = EnumerateThreads(info7);
-            CaptureFunctionIdentifiersForThreads(prof, info7, allThreads, threadStacksBuffer);
+            if (!CaptureFunctionIdentifiersForThreads(prof, info7, allThreads, threadStacksBuffer))
+            {
+                return;
+            }
         }
         else if (samplingType == SamplingType::SelectedThreads)
         {
-            CaptureFunctionIdentifiersForThreads(prof, info7, selective_sampling_thread_buffer, threadStacksBuffer);
+            if (!CaptureFunctionIdentifiersForThreads(prof, info7, selective_sampling_thread_buffer,
+                                                      threadStacksBuffer))
+            {
+                return;
+            }
         }
     }
     catch (const std::exception& e)
     {
         trace::Logger::Warn("Could not capture thread samples: ", e.what());
+        threadStacksBuffer.clear();
+        return;
     }
     catch (...)
     {
         trace::Logger::Warn("Could not capture thread sample for unknown reasons");
+        threadStacksBuffer.clear();
+        return;
     }
 
     const auto end            = std::chrono::steady_clock::now();
@@ -1124,7 +1361,7 @@ static void CaptureSamples(ContinuousProfiler*                                  
 
     if (samplingType == SamplingType::Continuous)
     {
-        ResolveSymbolsAndPublishBufferForAllThreads(prof, threadStacksBuffer);
+        ResolveSymbolsAndPublishBufferForAllThreads(prof, threadStacksBuffer, configuration);
     }
     else if (samplingType == SamplingType::SelectedThreads)
     {
@@ -1132,17 +1369,17 @@ static void CaptureSamples(ContinuousProfiler*                                  
     }
 }
 
-static unsigned int GetSleepTime(const ContinuousProfiler* const prof)
+static unsigned int GetSleepTime(const RuntimeSamplerConfiguration& configuration)
 {
     // Assumption is continuous profiling interval is bigger and multiple of selective sampling interval.
     // If both are enabled, we need to wake every smaller interval.
-    if (prof->selectedThreadsSamplingInterval.has_value())
+    if (configuration.selectiveThreadSamplingIntervalMilliseconds.has_value())
     {
-        return prof->selectedThreadsSamplingInterval.value();
+        return configuration.selectiveThreadSamplingIntervalMilliseconds.value();
     }
-    if (prof->threadSamplingInterval.has_value())
+    if (configuration.periodicThreadSamplingIntervalMilliseconds.has_value())
     {
-        return prof->threadSamplingInterval.value();
+        return configuration.periodicThreadSamplingIntervalMilliseconds.value();
     }
     // Shouldn't ever happen.
     return 0;
@@ -1165,76 +1402,158 @@ static std::chrono::steady_clock::time_point GetNextRefreshTime(
     return now + std::chrono::minutes(5);
 }
 
-static bool ShouldTrackIterations(const ContinuousProfiler* const prof)
+static bool ShouldTrackIterations(const RuntimeSamplerConfiguration& configuration)
 {
-    return prof->selectedThreadsSamplingInterval.has_value() && prof->threadSamplingInterval.has_value();
+    return configuration.selectiveThreadSamplingIntervalMilliseconds.has_value() &&
+           configuration.periodicThreadSamplingIntervalMilliseconds.has_value();
 }
 
-static void SamplingThreadMain(ContinuousProfiler* prof)
+void ContinuousProfiler::SamplingThreadMain() noexcept
 {
-    ICorProfilerInfo7* info7 = prof->info7;
-
-    info7->InitializeCurrentThread();
-
-    std::unordered_map<ThreadID, std::vector<FunctionIdentifier>> threadStacksBuffer;
-    unsigned int                                                  iteration = 0;
-    ReserveCapacity(prof, threadStacksBuffer);
-
-    const auto startTime    = std::chrono::steady_clock::now();
-    auto       next_refresh = GetNextRefreshTime(startTime);
-
-    while (!prof->IsShutdownRequested())
+    try
     {
-        if (ShouldTrackIterations(prof))
+        ICorProfilerInfo7* currentInfo7 = info7;
+
+        if (currentInfo7 != nullptr)
         {
-            iteration++;
+            currentInfo7->InitializeCurrentThread();
         }
 
-        const unsigned int sleepTime = GetSleepTime(prof);
-        if (sleepTime == 0)
+        std::unordered_map<ThreadID, std::vector<FunctionIdentifier>> threadStacksBuffer;
+        unsigned int                                                  iteration = 0;
+        try
         {
-            trace::Logger::Warn("Unexpected sampling interval configured, exiting sampling thread.");
-            return;
+            ReserveCapacity(this, threadStacksBuffer);
+        }
+        catch (const std::exception& exception)
+        {
+            trace::Logger::Warn("Could not reserve thread-sampling buffers: ", exception.what());
+        }
+        catch (...)
+        {
+            trace::Logger::Warn("Could not reserve thread-sampling buffers.");
         }
 
+        const auto startTime    = std::chrono::steady_clock::now();
+        auto       next_refresh = GetNextRefreshTime(startTime);
+
+        std::uint64_t observedGeneration = 0;
+
+        while (true)
         {
-            std::unique_lock<std::mutex> lock(prof->shutdown_mutex_);
-            if (prof->shutdown_cv_.wait_for(lock, std::chrono::milliseconds(sleepTime),
-                                            [prof] { return prof->IsShutdownRequested(); }))
+            RuntimeSamplerConfiguration cycleConfiguration;
             {
-                return; // Shutdown signaled
+                std::unique_lock<std::mutex> lock(sampling_state_mutex_);
+                if (shutdown_requested_.load(std::memory_order_acquire) || thread_sampling_stop_requested_)
+                {
+                    return;
+                }
+
+                cycleConfiguration = configuration_;
+                if (!cycleConfiguration.HasThreadSampling())
+                {
+                    return;
+                }
+
+                if (observedGeneration != configuration_generation_)
+                {
+                    observedGeneration = configuration_generation_;
+                    iteration          = 0;
+                }
+
+                const unsigned int sleepTime = GetSleepTime(cycleConfiguration);
+                if (sleepTime == 0)
+                {
+                    trace::Logger::Warn("Unexpected sampling interval configured, exiting sampling thread.");
+                    return;
+                }
+
+                if (sampling_state_cv_.wait_for(lock, std::chrono::milliseconds(sleepTime),
+                                                [this] {
+                                                    return shutdown_requested_.load(std::memory_order_acquire) ||
+                                                           thread_sampling_stop_requested_;
+                                                }))
+                {
+                    return;
+                }
+            }
+
+            try
+            {
+                if (ShouldTrackIterations(cycleConfiguration))
+                {
+                    iteration++;
+                }
+
+                const auto samplingType = GetNextSamplingType(cycleConfiguration, iteration);
+
+                if (samplingType == SamplingType::Continuous && ShouldTrackIterations(cycleConfiguration))
+                {
+                    iteration = 0;
+                }
+
+                if (currentInfo7 != nullptr)
+                {
+                    CaptureSamples(this, currentInfo7, samplingType, threadStacksBuffer, cycleConfiguration);
+                }
+
+                if (IsShutdownRequested())
+                {
+                    return;
+                }
+
+                const auto now = std::chrono::steady_clock::now();
+                // In order to avoid the need to recreate the vectors each iteration,
+                // for the most of the iterations, instead of clearing the map, clear only the vectors.
+                if (now > next_refresh)
+                {
+                    threadStacksBuffer.clear();
+                    ReserveCapacity(this, threadStacksBuffer);
+                    next_refresh = GetNextRefreshTime(now);
+                }
+                else
+                {
+                    for (auto& [_, threadBuffer] : threadStacksBuffer)
+                    {
+                        threadBuffer.clear();
+                    }
+                }
+            }
+            catch (const std::exception& exception)
+            {
+                DiscardBuffer();
+                threadStacksBuffer.clear();
+                trace::Logger::Warn("Continuous profiler sampling cycle failed: ", exception.what());
+            }
+            catch (...)
+            {
+                DiscardBuffer();
+                threadStacksBuffer.clear();
+                trace::Logger::Warn("Continuous profiler sampling cycle failed.");
             }
         }
-
-        const auto samplingType = GetNextSamplingType(prof, iteration);
-
-        if (samplingType == SamplingType::Continuous && ShouldTrackIterations(prof))
+    }
+    catch (const std::exception& exception)
+    {
+        DiscardBuffer();
+        try
         {
-            iteration = 0;
+            trace::Logger::Error("Continuous profiler sampling thread stopped after an unexpected failure: ",
+                                 exception.what());
         }
-
-        CaptureSamples(prof, info7, samplingType, threadStacksBuffer);
-
-        if (prof->IsShutdownRequested())
+        catch (...)
         {
-            return;
         }
-
-        const auto now = std::chrono::steady_clock::now();
-        // In order to avoid the need to recreate the vectors each iteration,
-        // for the most of the iterations, instead of clearing the map, clear only the vectors.
-        if (now > next_refresh)
+    }
+    catch (...)
+    {
+        DiscardBuffer();
+        try
         {
-            threadStacksBuffer.clear();
-            ReserveCapacity(prof, threadStacksBuffer);
-            next_refresh = GetNextRefreshTime(now);
+            trace::Logger::Error("Continuous profiler sampling thread stopped after an unexpected failure.");
         }
-        else
+        catch (...)
         {
-            for (auto& [_, threadBuffer] : threadStacksBuffer)
-            {
-                threadBuffer.clear();
-            }
         }
     }
 }
@@ -1243,7 +1562,6 @@ void ContinuousProfiler::SetGlobalInfo7(ICorProfilerInfo7* cor_profiler_info7)
 {
     info7               = cor_profiler_info7;
     this->helper.info7_ = cor_profiler_info7;
-    profiler_info       = cor_profiler_info7;
 }
 
 void ContinuousProfiler::SetGlobalInfo12(ICorProfilerInfo12* cor_profiler_info12)
@@ -1251,6 +1569,34 @@ void ContinuousProfiler::SetGlobalInfo12(ICorProfilerInfo12* cor_profiler_info12
     // ICorProfilerInfo12 derives from ICorProfilerInfo7, so we can use it as ICorProfilerInfo7
     SetGlobalInfo7(cor_profiler_info12);
     info12 = cor_profiler_info12;
+}
+
+void ContinuousProfiler::PublishGlobalInfo() const
+{
+    profiler_info.store(info7, std::memory_order_release);
+    profiler_callbacks_enabled.store(true, std::memory_order_release);
+}
+
+void ContinuousProfiler::ClearGlobalInfo()
+{
+    profiler_callbacks_enabled.store(false, std::memory_order_release);
+    profiler_info.store(nullptr, std::memory_order_release);
+
+    // Wait for a callback that observed the old enabled value and may still
+    // be using profiler_info. Queued callbacks recheck the flag after taking
+    // the shared side of this gate and return without touching state.
+    std::unique_lock<std::shared_mutex> callbackLock(profiler_callback_lock);
+
+    {
+        std::lock_guard<std::mutex> guard(thread_span_context_lock);
+        thread_span_context_map.Clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> guard(selective_sampling_lock);
+        selective_sampling_trace_map.clear();
+        selective_sampling_thread_buffer.clear();
+    }
 }
 
 void ContinuousProfiler::SetStackWalker(IStackWalker* walker)
@@ -1266,30 +1612,210 @@ IStackWalker* ContinuousProfiler::GetStackWalker() const
 
 void ContinuousProfiler::InitSelectiveSamplingBuffer()
 {
-    selective_sampling_buffer.reserve(kSamplesBufferDefaultSize);
+    {
+        std::lock_guard<std::mutex> guard(selective_sampling_buffer_lock);
+        selective_sampling_buffer.reserve(kSamplesBufferDefaultSize);
+    }
     selective_sampling_thread_buffer.reserve(kSelectiveSamplingMaxTraces);
 }
 
-void ContinuousProfiler::StartThreadSampling()
+ContinuousProfiler::ContinuousProfiler(IAllocationSamplingSessionProvider* allocationSamplingSessionProvider) noexcept
+    : allocation_sampling_session_provider_(allocationSamplingSessionProvider)
 {
-    thread_sampling_thread_ = std::make_unique<std::thread>(SamplingThreadMain, this);
+}
+
+ContinuousProfiler::~ContinuousProfiler()
+{
+    Shutdown();
+    DiscardBuffer();
+
+    std::lock_guard<std::mutex> guard(thread_state_lock_);
+    for (const auto& threadStateEntry : managed_tid_to_state_)
+    {
+        delete threadStateEntry.second;
+    }
+    managed_tid_to_state_.clear();
+}
+
+bool ContinuousProfiler::ApplyConfiguration(const RuntimeSamplerConfiguration& candidate)
+{
+    std::unique_lock<std::mutex> transitionLock(configuration_transition_mutex_);
+    if (shutdown_requested_.load(std::memory_order_acquire))
+    {
+        return false;
+    }
+
+    std::unique_ptr<std::thread> threadToJoin;
+    bool                         transitionSucceeded = false;
+    bool                         stoppedActiveWorker = false;
+
+    {
+        std::unique_lock<std::mutex> stateLock(sampling_state_mutex_);
+        const auto                   previous = configuration_;
+        if (previous == candidate)
+        {
+            return true;
+        }
+
+        if (candidate.selectiveThreadSamplingIntervalMilliseconds.has_value())
+        {
+            try
+            {
+                std::call_once(selective_sampling_init_flag_, [] { InitSelectiveSamplingBuffer(); });
+            }
+            catch (const std::exception& exception)
+            {
+                trace::Logger::Error("Unable to initialize selective sampling buffers: ", exception.what());
+                return false;
+            }
+            catch (...)
+            {
+                trace::Logger::Error("Unable to initialize selective sampling buffers.");
+                return false;
+            }
+        }
+
+        const bool startThread                = !previous.HasThreadSampling() && candidate.HasThreadSampling();
+        const bool stopThread                 = previous.HasThreadSampling() && !candidate.HasThreadSampling();
+        const bool threadConfigurationChanged = previous.periodicThreadSamplingIntervalMilliseconds !=
+                                                    candidate.periodicThreadSamplingIntervalMilliseconds ||
+                                                previous.selectiveThreadSamplingIntervalMilliseconds !=
+                                                    candidate.selectiveThreadSamplingIntervalMilliseconds;
+
+        std::unique_ptr<std::thread> stagedThread;
+        if (startThread)
+        {
+            if (stackWalker_ == nullptr || FAILED(stackWalker_->PrepareForStackWalking()))
+            {
+                trace::Logger::Error("Unable to prepare safe stack walking for continuous profiling.");
+                return false;
+            }
+
+            try
+            {
+                // The new thread blocks on sampling_state_mutex_ until the full
+                // producer transition commits below.
+                stagedThread = std::make_unique<std::thread>(&ContinuousProfiler::SamplingThreadMain, this);
+            }
+            catch (const std::exception& exception)
+            {
+                trace::Logger::Error("Unable to start continuous profiler sampling thread: ", exception.what());
+                return false;
+            }
+            catch (...)
+            {
+                trace::Logger::Error("Unable to start continuous profiler sampling thread.");
+                return false;
+            }
+        }
+
+        try
+        {
+            transitionSucceeded = ApplyAllocationConfiguration(previous.maxAllocationSamplesPerMinute,
+                                                               candidate.maxAllocationSamplesPerMinute);
+        }
+        catch (const std::exception& exception)
+        {
+            trace::Logger::Error("Unable to apply allocation sampling configuration: ", exception.what());
+            transitionSucceeded = false;
+        }
+        catch (...)
+        {
+            trace::Logger::Error("Unable to apply allocation sampling configuration.");
+            transitionSucceeded = false;
+        }
+
+        if (!transitionSucceeded)
+        {
+            if (startThread)
+            {
+                threadToJoin = std::move(stagedThread);
+            }
+        }
+        else
+        {
+            // RuntimeSamplerConfiguration contains only optional integer values,
+            // so publication is a non-throwing final commit after all fallible
+            // resource transitions have succeeded.
+            configuration_ = candidate;
+            if (threadConfigurationChanged)
+            {
+                ++configuration_generation_;
+            }
+
+            if (startThread)
+            {
+                thread_sampling_stop_requested_ = false;
+                thread_sampling_thread_         = std::move(stagedThread);
+            }
+            else if (stopThread)
+            {
+                thread_sampling_stop_requested_ = true;
+                threadToJoin                    = std::move(thread_sampling_thread_);
+                stoppedActiveWorker             = true;
+            }
+        }
+    }
+
+    if (threadToJoin != nullptr)
+    {
+        sampling_state_cv_.notify_all();
+        if (threadToJoin->joinable())
+        {
+            threadToJoin->join();
+        }
+        if (stoppedActiveWorker)
+        {
+            LogProfilerInfoNoThrow("ContinuousProfiler sampling thread stopped.");
+        }
+    }
+
+    if (transitionSucceeded && candidate.HasThreadSampling())
+    {
+        LogProfilerInfoNoThrow("ContinuousProfiler thread sampling configured.");
+    }
+
+    return transitionSucceeded;
+}
+
+RuntimeSamplerConfiguration ContinuousProfiler::GetConfiguration() const
+{
+    std::lock_guard<std::mutex> guard(sampling_state_mutex_);
+    return configuration_;
+}
+
+bool ContinuousProfiler::IsThreadSamplingThreadRunning() const
+{
+    std::lock_guard<std::mutex> guard(sampling_state_mutex_);
+    return thread_sampling_thread_ != nullptr && thread_sampling_thread_->joinable();
 }
 
 void ContinuousProfiler::Shutdown()
 {
-    shutdown_requested_.store(true, std::memory_order_release);
-    shutdown_cv_.notify_all();
+    std::unique_lock<std::mutex> transitionLock(configuration_transition_mutex_);
+    if (shutdown_requested_.exchange(true, std::memory_order_acq_rel))
     {
-        std::unique_lock<std::shared_mutex> unique_lock(profiling_lock);
-        StopAllocationSampling();
+        return;
     }
 
-    if (thread_sampling_thread_ != nullptr && thread_sampling_thread_->joinable())
+    std::unique_ptr<std::thread> threadToJoin;
     {
-        thread_sampling_thread_->join();
-        thread_sampling_thread_.reset();
-        trace::Logger::Info("ContinuousProfiler sampling thread stopped.");
+        std::lock_guard<std::mutex> stateLock(sampling_state_mutex_);
+        configuration_ = RuntimeSamplerConfiguration{};
+        ++configuration_generation_;
+        thread_sampling_stop_requested_ = true;
+        threadToJoin                    = std::move(thread_sampling_thread_);
     }
+
+    sampling_state_cv_.notify_all();
+    if (threadToJoin != nullptr && threadToJoin->joinable())
+    {
+        threadToJoin->join();
+        LogProfilerInfoNoThrow("ContinuousProfiler sampling thread stopped.");
+    }
+
+    StopAllocationSamplingForShutdown();
+    ClearGlobalInfo();
 }
 
 bool ContinuousProfiler::IsShutdownRequested() const
@@ -1303,10 +1829,11 @@ static thread_span_context GetCurrentSpanContext(ThreadID tid)
     return GetContext(tid);
 }
 
-ThreadState* ContinuousProfiler::GetCurrentThreadState(ThreadID tid)
+ThreadState ContinuousProfiler::GetCurrentThreadState(ThreadID tid)
 {
     std::lock_guard<std::mutex> guard(thread_state_lock_);
-    return managed_tid_to_state_[tid];
+    const auto                  found = managed_tid_to_state_.find(tid);
+    return found != managed_tid_to_state_.end() && found->second != nullptr ? *found->second : ThreadState{};
 }
 
 // You can read about the ETW event format for AllocationTick at
@@ -1332,15 +1859,21 @@ constexpr auto EtwPointerSize                         = sizeof(void*);
 constexpr auto AllocationTickV4TypeNameStartByteIndex = 4 + 4 + 2 + 8 + EtwPointerSize;
 constexpr auto AllocationTickV4SizeWithoutTypeName    = 4 + 4 + 2 + 8 + EtwPointerSize + 4 + EtwPointerSize + 8;
 
-static void CaptureAllocationStack(ContinuousProfiler* prof, std::vector<FunctionIdentifier>& threadStack)
+static bool CaptureAllocationStack(ContinuousProfiler*              prof,
+                                   std::vector<FunctionIdentifier>& threadStack,
+                                   SamplingStatistics&              stats)
 {
-    DoStackSnapshotParams doStackSnapshotParams(prof, &threadStack);
+    DoStackSnapshotParams doStackSnapshotParams(prof, &threadStack, &stats);
     HRESULT               hr = prof->info7->DoStackSnapshot((ThreadID)NULL, &HandleStackFrame, COR_PRF_SNAPSHOT_DEFAULT,
                                                             &doStackSnapshotParams, nullptr, 0);
     if (FAILED(hr))
     {
         trace::Logger::Debug("DoStackSnapshot failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex, hr);
+        threadStack.clear();
+        return false;
     }
+
+    return true;
 }
 
 AllocationSubSampler::AllocationSubSampler(uint32_t targetPerCycle_, uint32_t secondsPerCycle_)
@@ -1425,36 +1958,45 @@ bool AllocationSubSampler::ShouldSample()
 
 void ContinuousProfiler::AllocationTick(ULONG dataLen, LPCBYTE data)
 {
+    // The event is a set of fixed-size fields followed by a UCS-2, null-terminated type name.
+    // Validate the payload before checking lifecycle state so malformed callbacks are always rejected at the boundary.
+    if (data == nullptr || dataLen < AllocationTickV4SizeWithoutTypeName + sizeof(WCHAR) ||
+        (dataLen - AllocationTickV4SizeWithoutTypeName) % sizeof(WCHAR) != 0)
+    {
+        trace::Logger::Debug("AllocationTick: event payload too small or malformed (", dataLen, " bytes), ignoring.");
+        return;
+    }
+
+    if (!allocation_sampling_enabled_.load(std::memory_order_acquire))
+    {
+        return;
+    }
+
+    if (!AllocationSamplingShouldProduceSample())
+    {
+        return;
+    }
+
     // try to acquire shared lock without blocking
     // and return early if attempt was unsuccessful -
     // CaptureSamples acquired exclusive lock
     // and it's not safe to proceed
-    std::shared_lock<std::shared_mutex> shared_lock(profiling_lock, std::try_to_lock);
-    if (!shared_lock.owns_lock())
+    std::shared_lock<std::shared_mutex> shared_lock(profiling_lock, std::defer_lock);
+    if (!shared_lock.try_lock())
     {
         // can't continue if suspension already started
         trace::Logger::Debug("Possible runtime suspension in progress, can't safely process allocation tick.");
         return;
     }
 
-    if (IsShutdownRequested())
+    if (IsShutdownRequested() || !allocation_sampling_enabled_.load(std::memory_order_acquire) ||
+        !AllocationSamplingShouldProduceSample())
     {
         return;
     }
 
     if (this->allocationSubSampler == nullptr || !this->allocationSubSampler->ShouldSample())
     {
-        return;
-    }
-
-    // The event is a set of fixed-size fields followed by a UCS-2, null-terminated type name.
-    // The type-name region must be present, hold at least the 2-byte null terminator, and be a
-    // whole number of UCS-2 code units. Otherwise the character-count computation below
-    // (typeNameCharLen) underflows and the type name would be read past the end of the event.
-    if (dataLen < AllocationTickV4SizeWithoutTypeName + sizeof(WCHAR) ||
-        (dataLen - AllocationTickV4SizeWithoutTypeName) % sizeof(WCHAR) != 0)
-    {
-        trace::Logger::Debug("AllocationTick: event payload too small or malformed (", dataLen, " bytes), ignoring.");
         return;
     }
 
@@ -1465,7 +2007,7 @@ void ContinuousProfiler::AllocationTick(ULONG dataLen, LPCBYTE data)
 
     // and its length can be derived without iterating it since there is only the one variable-length field
     // account for the null char
-    size_t typeNameCharLen = (dataLen - AllocationTickV4SizeWithoutTypeName) / 2 - 1;
+    size_t typeNameCharLen = (dataLen - AllocationTickV4SizeWithoutTypeName) / sizeof(WCHAR) - 1;
 
     ThreadID      threadId;
     const HRESULT hr = info7->GetCurrentThreadID(&threadId);
@@ -1475,16 +2017,10 @@ void ContinuousProfiler::AllocationTick(ULONG dataLen, LPCBYTE data)
         return;
     }
 
-    // TODO: not used at the moment, setting for consistency
-    this->stats_ = SamplingStatistics();
+    SamplingStatistics allocationStats;
 
-    auto unknownThreadState = ThreadState();
-    auto spanCtx            = GetCurrentSpanContext(threadId);
-    auto threadState        = GetCurrentThreadState(threadId);
-    if (threadState == nullptr)
-    {
-        threadState = &unknownThreadState;
-    }
+    auto spanCtx     = GetCurrentSpanContext(threadId);
+    auto threadState = GetCurrentThreadState(threadId);
     // Note that by using a local buffer that we will copy as a whole into the
     // "main" one later, we gain atomicity and improved concurrency, but lose out on a shared
     // string-coding dictionary for all the allocation samples in a cycle.  The tradeoffs here
@@ -1493,7 +2029,7 @@ void ContinuousProfiler::AllocationTick(ULONG dataLen, LPCBYTE data)
     // allocation sample are coded separately so if this changes, that code will need to change too.
     std::vector<unsigned char> localBytes;
     ThreadSamplesBuffer        localBuf = ThreadSamplesBuffer(&localBytes);
-    localBuf.AllocationSample(allocatedSize, typeName, typeNameCharLen, threadId, threadState, spanCtx);
+    localBuf.AllocationSample(allocatedSize, typeName, typeNameCharLen, threadId, &threadState, spanCtx);
 
     std::vector<FunctionIdentifier> threadStack;
 
@@ -1501,56 +2037,195 @@ void ContinuousProfiler::AllocationTick(ULONG dataLen, LPCBYTE data)
         std::lock_guard<std::mutex> guard(name_cache_lock);
         this->helper.ClearFunctionIdentifierCache();
 
-        CaptureAllocationStack(this, threadStack);
-        ResolveFrames(this, threadStack, localBuf);
+        if (!CaptureAllocationStack(this, threadStack, allocationStats))
+        {
+            return;
+        }
+        ResolveFrames(this, threadStack, localBuf, allocationStats);
     }
 
     localBuf.EndSample();
+    if (localBuf.IsOverflowed())
+    {
+        trace::Logger::Warn("Discarding an overflowed allocation sample.");
+        return;
+    }
+
     AllocationSamplingAppendToBuffer(static_cast<int32_t>(localBytes.size()), localBytes.data());
 }
 
-void ContinuousProfiler::StartAllocationSampling(const unsigned int maxMemorySamplesPerMinute)
+bool ContinuousProfiler::ApplyAllocationConfiguration(const std::optional<std::uint32_t>& previousRate,
+                                                      const std::optional<std::uint32_t>& candidateRate)
 {
-    if (!info12) // no info12 - we are on .Net Fx - ignore allocation sampling request
+    if (previousRate == candidateRate)
     {
-        trace::Logger::Warn("Ignore Allocation Sampling request, it is not supported for .Net Framework applications");
-        return;
+        return true;
     }
-    this->allocationSubSampler = std::make_unique<AllocationSubSampler>(maxMemorySamplesPerMinute, 60);
+
+    if (info12 == nullptr && allocation_sampling_session_provider_ == nullptr)
+    {
+        trace::Logger::Warn("Allocation sampling is not supported for .NET Framework applications.");
+        return !candidateRate.has_value();
+    }
+
+    std::unique_ptr<AllocationSubSampler> candidateSubSampler;
+    if (candidateRate.has_value())
+    {
+        try
+        {
+            candidateSubSampler = std::make_unique<AllocationSubSampler>(candidateRate.value(), 60);
+        }
+        catch (const std::exception& exception)
+        {
+            trace::Logger::Error("Could not configure allocation sampling: ", exception.what());
+            return false;
+        }
+        catch (...)
+        {
+            trace::Logger::Error("Could not configure allocation sampling.");
+            return false;
+        }
+    }
+
+    std::unique_lock<std::shared_mutex> profilingGuard(profiling_lock);
+    allocation_sampling_enabled_.store(false, std::memory_order_release);
+
+    if (!previousRate.has_value() && candidateRate.has_value())
+    {
+        if (!TryCleanupFailedAllocationSession())
+        {
+            return false;
+        }
+
+        EVENTPIPE_SESSION candidateSession = 0;
+        const HRESULT     hr               = StartAllocationSamplingSession(&candidateSession);
+        if (FAILED(hr))
+        {
+            if (candidateSession != 0)
+            {
+                const HRESULT cleanupResult = StopAllocationSamplingSession(candidateSession);
+                if (FAILED(cleanupResult))
+                {
+                    failed_allocation_session_cleanup_ = candidateSession;
+                    trace::Logger::Error("Could not clean up a failed allocation sampling session. HRESULT=0x",
+                                         std::setfill('0'), std::setw(8), std::hex, cleanupResult);
+                }
+            }
+            trace::Logger::Error("Could not enable allocation sampling: session pipe error. HRESULT=0x",
+                                 std::setfill('0'), std::setw(8), std::hex, hr);
+            return false;
+        }
+
+        if (candidateSession == 0)
+        {
+            trace::Logger::Error("Could not enable allocation sampling: EventPipe returned an invalid session.");
+            return false;
+        }
+
+        session_             = candidateSession;
+        allocationSubSampler = std::move(candidateSubSampler);
+        allocation_sampling_enabled_.store(true, std::memory_order_release);
+        LogProfilerInfoNoThrow("ContinuousProfiler allocation sampling session started.");
+        return true;
+    }
+
+    if (previousRate.has_value() && !candidateRate.has_value())
+    {
+        const HRESULT hr = session_ == 0 ? S_OK : StopAllocationSamplingSession(session_);
+        if (FAILED(hr))
+        {
+            allocation_sampling_enabled_.store(true, std::memory_order_release);
+            trace::Logger::Error("Could not disable allocation sampling: session pipe error. HRESULT=0x",
+                                 std::setfill('0'), std::setw(8), std::hex, hr);
+            return false;
+        }
+
+        session_ = 0;
+        allocationSubSampler.reset();
+        LogProfilerInfoNoThrow("ContinuousProfiler allocation sampling session stopped.");
+        return true;
+    }
+
+    // A rate change only replaces the sub-sampler. The existing EventPipe
+    // session remains active, so a configuration update cannot duplicate it.
+    allocationSubSampler = std::move(candidateSubSampler);
+    allocation_sampling_enabled_.store(true, std::memory_order_release);
+    LogProfilerInfoNoThrow("ContinuousProfiler allocation sampling rate updated.");
+    return true;
+}
+
+HRESULT ContinuousProfiler::StartAllocationSamplingSession(EVENTPIPE_SESSION* session) noexcept
+{
+    if (allocation_sampling_session_provider_ != nullptr)
+    {
+        return allocation_sampling_session_provider_->StartAllocationSamplingSession(session);
+    }
 
     COR_PRF_EVENTPIPE_PROVIDER_CONFIG sessionConfig[] = {{WStr("Microsoft-Windows-DotNETRuntime"),
                                                           0x1, // CLR_GC_KEYWORD
-                                                          // documentation says AllocationTick is at info but it lies
+                                                          // AllocationTick is emitted at verbose level.
                                                           COR_PRF_EVENTPIPE_VERBOSE, nullptr}};
-    HRESULT                           hr = this->info12->EventPipeStartSession(1, sessionConfig, false, &session_);
-    if (FAILED(hr))
-    {
-        trace::Logger::Error("Could not enable allocation sampling: session pipe error", hr);
-    }
-
-    trace::Logger::Info("ContinuousProfiler::MemoryProfiling started.");
+    return info12->EventPipeStartSession(1, sessionConfig, false, session);
 }
 
-void ContinuousProfiler::StopAllocationSampling()
+HRESULT ContinuousProfiler::StopAllocationSamplingSession(const EVENTPIPE_SESSION session) noexcept
 {
-    if (!info12) // no info12 - we are on .Net Fx - ignore allocation sampling stop request
+    if (allocation_sampling_session_provider_ != nullptr)
     {
-        return;
-    }
-    if (session_ == 0)
-    {
-        return;
+        return allocation_sampling_session_provider_->StopAllocationSamplingSession(session);
     }
 
-    HRESULT hr = this->info12->EventPipeStopSession(session_);
+    return info12->EventPipeStopSession(session);
+}
+
+bool ContinuousProfiler::TryCleanupFailedAllocationSession()
+{
+    if (failed_allocation_session_cleanup_ == 0)
+    {
+        return true;
+    }
+
+    if (info12 == nullptr && allocation_sampling_session_provider_ == nullptr)
+    {
+        LogProfilerErrorNoThrow("Could not clean up a failed allocation sampling session: EventPipe is unavailable.");
+        return false;
+    }
+
+    const HRESULT hr = StopAllocationSamplingSession(failed_allocation_session_cleanup_);
     if (FAILED(hr))
     {
-        trace::Logger::Error("Could not disable allocation sampling: session pipe error. HRESULT=0x", std::setfill('0'),
-                             std::setw(8), std::hex, hr);
+        LogProfilerErrorNoThrow("Could not clean up a failed allocation sampling session. HRESULT=0x",
+                                std::setfill('0'), std::setw(8), std::hex, hr);
+        return false;
     }
-    session_ = 0;
 
-    trace::Logger::Info("ContinuousProfiler allocation sampling session stopped.");
+    failed_allocation_session_cleanup_ = 0;
+    LogProfilerInfoNoThrow("Cleaned up failed allocation sampling session.");
+    return true;
+}
+
+void ContinuousProfiler::StopAllocationSamplingForShutdown()
+{
+    std::unique_lock<std::shared_mutex> profilingGuard(profiling_lock);
+    allocation_sampling_enabled_.store(false, std::memory_order_release);
+
+    TryCleanupFailedAllocationSession();
+
+    if ((info12 != nullptr || allocation_sampling_session_provider_ != nullptr) && session_ != 0)
+    {
+        const HRESULT hr = StopAllocationSamplingSession(session_);
+        if (FAILED(hr))
+        {
+            LogProfilerErrorNoThrow("Could not stop allocation sampling during shutdown. HRESULT=0x", std::setfill('0'),
+                                    std::setw(8), std::hex, hr);
+        }
+        else
+        {
+            session_ = 0;
+        }
+    }
+
+    allocationSubSampler.reset();
 }
 
 void ContinuousProfiler::ThreadCreated(ThreadID thread_id)
@@ -1643,82 +2318,217 @@ extern "C"
 {
     EXPORTTHIS int32_t ContinuousProfilerReadThreadSamples(int32_t len, unsigned char* buf)
     {
-        return ThreadSamplingConsumeOneThreadSample(len, buf);
+        try
+        {
+            std::uint32_t samplingInterval = 0;
+            return ThreadSamplingConsumeOneThreadSample(len, buf, &samplingInterval);
+        }
+        catch (...)
+        {
+            LogProfilerCallbackFailure("ContinuousProfilerReadThreadSamples");
+            return 0;
+        }
+    }
+    EXPORTTHIS std::int32_t STDAPICALLTYPE ContinuousProfilerReadThreadSamplesV2(std::int32_t   len,
+                                                                                 unsigned char* buf,
+                                                                                 std::uint32_t* samplingInterval)
+    {
+        if (samplingInterval != nullptr)
+        {
+            *samplingInterval = 0;
+        }
+
+        try
+        {
+            return ThreadSamplingConsumeOneThreadSample(len, buf, samplingInterval);
+        }
+        catch (...)
+        {
+            LogProfilerCallbackFailure("ContinuousProfilerReadThreadSamplesV2");
+            return 0;
+        }
     }
     EXPORTTHIS int32_t ContinuousProfilerReadAllocationSamples(int32_t len, unsigned char* buf)
     {
-        return AllocationSamplingConsumeAndReplaceBuffer(len, buf);
+        try
+        {
+            return AllocationSamplingConsumeAndReplaceBuffer(len, buf);
+        }
+        catch (...)
+        {
+            LogProfilerCallbackFailure("ContinuousProfilerReadAllocationSamples");
+            return 0;
+        }
     }
     EXPORTTHIS int32_t SelectiveSamplerReadThreadSamples(int32_t len, unsigned char* buf)
     {
-        return SelectiveSamplingConsumeAndClearBuffer(len, buf);
+        try
+        {
+            return SelectiveSamplingConsumeAndClearBuffer(len, buf);
+        }
+        catch (...)
+        {
+            LogProfilerCallbackFailure("SelectiveSamplerReadThreadSamples");
+            return 0;
+        }
     }
     EXPORTTHIS void ContinuousProfilerNotifySpanStopped(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId)
     {
-        std::lock_guard<std::mutex>                    guard(thread_span_context_lock);
-        const continuous_profiler::thread_span_context spanContext = {traceIdHigh, traceIdLow, spanId};
-        thread_span_context_map.Remove(spanContext);
+        try
+        {
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
+
+            std::shared_lock<std::shared_mutex> callbackLock(profiler_callback_lock);
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
+
+            std::lock_guard<std::mutex>                    guard(thread_span_context_lock);
+            const continuous_profiler::thread_span_context spanContext = {traceIdHigh, traceIdLow, spanId};
+            thread_span_context_map.Remove(spanContext);
+        }
+        catch (...)
+        {
+            LogProfilerCallbackFailure("ContinuousProfilerNotifySpanStopped");
+        }
     }
     EXPORTTHIS void ContinuousProfilerSetNativeContext(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId)
     {
-        // This method is called anytime thread-span association changes, e.g. when activity is started/stopped or
-        // when suspension/resumption occurs.
-
-        if (profiler_info == nullptr)
+        try
         {
-            trace::Logger::Debug("ContinuousProfilerSetNativeContext skipped: profiler_info is null.");
-            return;
-        }
+            // This method is called anytime thread-span association changes, e.g. when activity is started/stopped or
+            // when suspension/resumption occurs.
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
 
-        ThreadID      threadId;
-        const HRESULT hr = profiler_info->GetCurrentThreadID(&threadId);
-        if (FAILED(hr))
+            std::shared_lock<std::shared_mutex> callbackLock(profiler_callback_lock);
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
+
+            auto currentProfilerInfo = profiler_info.load(std::memory_order_acquire);
+            if (currentProfilerInfo == nullptr)
+            {
+                trace::Logger::Debug("ContinuousProfilerSetNativeContext skipped: profiler_info is null.");
+                return;
+            }
+
+            ThreadID      threadId;
+            const HRESULT hr = currentProfilerInfo->GetCurrentThreadID(&threadId);
+            if (FAILED(hr))
+            {
+                trace::Logger::Debug("GetCurrentThreadID failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex,
+                                     hr);
+                return;
+            }
+
+            std::lock_guard<std::mutex> guard(thread_span_context_lock);
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire) ||
+                profiler_info.load(std::memory_order_acquire) != currentProfilerInfo)
+            {
+                return;
+            }
+
+            const continuous_profiler::thread_span_context newSpanContext = {traceIdHigh, traceIdLow, spanId};
+            thread_span_context_map.Put(threadId, newSpanContext);
+        }
+        catch (...)
         {
-            trace::Logger::Debug("GetCurrentThreadID failed. HRESULT=0x", std::setfill('0'), std::setw(8), std::hex,
-                                 hr);
-            return;
+            LogProfilerCallbackFailure("ContinuousProfilerSetNativeContext");
         }
-        std::lock_guard<std::mutex> guard(thread_span_context_lock);
-
-        const continuous_profiler::thread_span_context newSpanContext = {traceIdHigh, traceIdLow, spanId};
-        thread_span_context_map.Put(threadId, newSpanContext);
     }
     EXPORTTHIS void SelectiveSamplingStart(uint64_t traceIdHigh, uint64_t traceIdLow)
     {
-        if (profiler_info == nullptr)
+        try
         {
-            return;
-        }
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
 
-        const continuous_profiler::trace_context context = {traceIdHigh, traceIdLow};
-        if (context.IsDefault())
+            std::shared_lock<std::shared_mutex> callbackLock(profiler_callback_lock);
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
+
+            const continuous_profiler::trace_context context = {traceIdHigh, traceIdLow};
+            if (context.IsDefault())
+            {
+                return;
+            }
+
+            bool added = false;
+            {
+                std::lock_guard<std::mutex> guard(selective_sampling_lock);
+                if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+                {
+                    return;
+                }
+
+                if (selective_sampling_trace_map.size() < kSelectiveSamplingMaxTraces)
+                {
+                    const auto deadline =
+                        std::chrono::steady_clock::now() + std::chrono::minutes(kSelectiveSamplingMaxAgeMinutes);
+                    selective_sampling_trace_map[context] =
+                        std::chrono::duration_cast<std::chrono::milliseconds>(deadline.time_since_epoch()).count();
+                    added = true;
+                }
+            }
+
+            if (added)
+            {
+                return;
+            }
+
+            trace::Logger::Warn("SelectiveSamplingStart: ignoring request to start sampling for trace {",
+                                "traceIdHigh: ", traceIdHigh, ", traceIdLow: ", traceIdLow,
+                                "} because maximum number of traces is already being sampled.");
+        }
+        catch (...)
         {
-            return;
+            LogProfilerCallbackFailure("SelectiveSamplingStart");
         }
-
-        // Don't allow for too many samples at once
-        if (continuous_profiler::TryAddSelectiveSamplingTrace(context, std::chrono::steady_clock::now()))
-        {
-            return;
-        }
-
-        trace::Logger::Warn("SelectiveSamplingStart: ignoring request to start sampling for trace {",
-                            "traceIdHigh: ", traceIdHigh, ", traceIdLow: ", traceIdLow,
-                            "} because maximum number of traces is already being sampled.");
     }
 
     EXPORTTHIS void SelectiveSamplingStop(uint64_t traceIdHigh, uint64_t traceIdLow)
     {
-        if (profiler_info == nullptr)
+        try
         {
-            return;
-        }
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
 
-        const continuous_profiler::trace_context context = {traceIdHigh, traceIdLow};
-        if (context.IsDefault())
-        {
-            return;
+            std::shared_lock<std::shared_mutex> callbackLock(profiler_callback_lock);
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
+
+            const continuous_profiler::trace_context context = {traceIdHigh, traceIdLow};
+            if (context.IsDefault())
+            {
+                return;
+            }
+
+            std::lock_guard<std::mutex> guard(selective_sampling_lock);
+            if (!profiler_callbacks_enabled.load(std::memory_order_acquire))
+            {
+                return;
+            }
+            selective_sampling_trace_map.erase(context);
         }
-        continuous_profiler::RemoveSelectiveSamplingTrace(context);
+        catch (...)
+        {
+            LogProfilerCallbackFailure("SelectiveSamplingStop");
+        }
     }
 }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
@@ -1841,7 +1841,7 @@ void ContinuousProfiler::Shutdown()
                    });
 }
 
-bool ContinuousProfiler::IsShutdownRequested() const
+bool ContinuousProfiler::IsShutdownRequested() const noexcept
 {
     return shutdown_requested_.load(std::memory_order_acquire);
 }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
@@ -361,7 +361,7 @@ public:
     bool                HasThreadSamplingWorker() const;
     bool                IsThreadSamplingWorkerQuiescent() const;
     void                Shutdown();
-    bool                IsShutdownRequested() const;
+    bool                IsShutdownRequested() const noexcept;
     static void         InitSelectiveSamplingBuffer();
     void                AllocationTick(ULONG dataLen, LPCBYTE data);
     ICorProfilerInfo12* info12 = nullptr;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
@@ -356,18 +356,19 @@ public:
     explicit ContinuousProfiler(
         IAllocationSamplingSessionProvider* allocationSamplingSessionProvider = nullptr) noexcept;
     ~ContinuousProfiler();
-    bool                        ApplyConfiguration(const RuntimeSamplerConfiguration& configuration);
-    RuntimeSamplerConfiguration GetConfiguration() const;
-    bool                        IsThreadSamplingThreadRunning() const;
-    void                        Shutdown();
-    bool                        IsShutdownRequested() const;
-    static void                 InitSelectiveSamplingBuffer();
-    void                        AllocationTick(ULONG dataLen, LPCBYTE data);
-    ICorProfilerInfo12*         info12 = nullptr;
-    ICorProfilerInfo7*          info7  = nullptr;
-    static void                 ThreadCreated(ThreadID thread_id);
-    void                        ThreadDestroyed(ThreadID thread_id);
-    void                        ThreadNameChanged(ThreadID thread_id, ULONG cch_name, WCHAR name[]);
+    bool                ApplyConfiguration(const RuntimeSamplerConfiguration& previousConfiguration,
+                                           const RuntimeSamplerConfiguration& configuration);
+    bool                HasThreadSamplingWorker() const;
+    bool                IsThreadSamplingWorkerQuiescent() const;
+    void                Shutdown();
+    bool                IsShutdownRequested() const;
+    static void         InitSelectiveSamplingBuffer();
+    void                AllocationTick(ULONG dataLen, LPCBYTE data);
+    ICorProfilerInfo12* info12 = nullptr;
+    ICorProfilerInfo7*  info7  = nullptr;
+    static void         ThreadCreated(ThreadID thread_id);
+    void                ThreadDestroyed(ThreadID thread_id);
+    void                ThreadNameChanged(ThreadID thread_id, ULONG cch_name, WCHAR name[]);
 
     void          SetGlobalInfo12(ICorProfilerInfo12* info12);
     void          SetGlobalInfo7(ICorProfilerInfo7* cor_profiler_info7);
@@ -398,13 +399,15 @@ private:
     bool    TryCleanupFailedAllocationSession();
     void    StopAllocationSamplingForShutdown();
 
-    mutable std::mutex           configuration_transition_mutex_;
     mutable std::mutex           sampling_state_mutex_;
     std::condition_variable      sampling_state_cv_;
-    RuntimeSamplerConfiguration  configuration_;
-    std::uint64_t                configuration_generation_       = 0;
-    bool                         thread_sampling_stop_requested_ = false;
+    std::optional<std::uint32_t> periodic_thread_sampling_interval_;
+    std::optional<std::uint32_t> selective_thread_sampling_interval_;
+    std::uint64_t                thread_configuration_generation_              = 0;
+    std::uint64_t                acknowledged_thread_configuration_generation_ = 0;
+    bool                         thread_sampling_worker_exited_                = false;
     std::once_flag               selective_sampling_init_flag_;
+    std::once_flag               shutdown_once_;
     std::atomic_bool             shutdown_requested_{false};
     std::atomic_bool             allocation_sampling_enabled_{false};
     std::unique_ptr<std::thread> thread_sampling_thread_;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h
@@ -7,7 +7,10 @@
 #define OTEL_CONTINUOUS_PROFILER_H_
 
 #include "continuous_profiler_clr_helpers.h"
+#include "runtime_sampler_configuration.h"
 #include "stack_walker.h"
+#include <atomic>
+#include <condition_variable>
 #include <mutex>
 #include <cinttypes>
 #include <future>
@@ -17,6 +20,7 @@
 #include <utility>
 #include <unordered_map>
 #include <random>
+#include <thread>
 #include <unordered_set>
 
 #ifdef _WIN32
@@ -28,8 +32,11 @@
 extern "C"
 {
     EXPORTTHIS int32_t ContinuousProfilerReadThreadSamples(int32_t len, unsigned char* buf);
-    EXPORTTHIS int32_t ContinuousProfilerReadAllocationSamples(int32_t len, unsigned char* buf);
-    EXPORTTHIS int32_t SelectiveSamplerReadThreadSamples(int32_t len, unsigned char* buf);
+    EXPORTTHIS std::int32_t STDAPICALLTYPE ContinuousProfilerReadThreadSamplesV2(std::int32_t   len,
+                                                                                 unsigned char* buf,
+                                                                                 std::uint32_t* samplingInterval);
+    EXPORTTHIS int32_t                     ContinuousProfilerReadAllocationSamples(int32_t len, unsigned char* buf);
+    EXPORTTHIS int32_t                     SelectiveSamplerReadThreadSamples(int32_t len, unsigned char* buf);
     // ReSharper disable CppInconsistentNaming
     EXPORTTHIS void ContinuousProfilerSetNativeContext(uint64_t traceIdHigh, uint64_t traceIdLow, uint64_t spanId);
     EXPORTTHIS void SelectiveSamplingStart(uint64_t traceIdHigh, uint64_t traceIdLow);
@@ -73,13 +80,10 @@ struct FunctionIdentifier
 
 struct FunctionIdentifierResolveArgs
 {
-    FunctionID  function_id;
+    FunctionID function_id;
 
     FunctionIdentifierResolveArgs() = delete;
-    FunctionIdentifierResolveArgs(const FunctionID func_id)
-        : function_id(func_id)
-    {
-    }
+    FunctionIdentifierResolveArgs(const FunctionID func_id) : function_id(func_id) {}
     bool operator==(const FunctionIdentifierResolveArgs& p) const
     {
         return function_id == p.function_id;
@@ -95,12 +99,9 @@ struct trace_context
     uint64_t trace_id_high_;
     uint64_t trace_id_low_;
 
-    trace_context(): trace_id_high_(0), trace_id_low_(0)
-    {
-    }
+    trace_context() : trace_id_high_(0), trace_id_low_(0) {}
     trace_context(const uint64_t trace_id_high, const uint64_t trace_id_low)
-        : trace_id_high_(trace_id_high)
-        , trace_id_low_(trace_id_low)
+        : trace_id_high_(trace_id_high), trace_id_low_(trace_id_low)
     {
     }
 
@@ -119,13 +120,11 @@ class thread_span_context
 {
 public:
     trace_context trace_context_;
-    uint64_t span_id_;
+    uint64_t      span_id_;
 
-    thread_span_context() : span_id_(0)
-    {
-    }
-    thread_span_context(uint64_t _traceIdHigh, uint64_t _traceIdLow, uint64_t _spanId) :
-        trace_context_(_traceIdHigh, _traceIdLow), span_id_(_spanId)
+    thread_span_context() : span_id_(0) {}
+    thread_span_context(uint64_t _traceIdHigh, uint64_t _traceIdLow, uint64_t _spanId)
+        : trace_context_(_traceIdHigh, _traceIdLow), span_id_(_spanId)
     {
     }
 
@@ -140,13 +139,14 @@ public:
 
     [[nodiscard]] bool IsDefault() const;
 };
-}
+} // namespace continuous_profiler
 
 template <typename... Args>
-std::size_t hash_combine(const Args&... args) {
+std::size_t hash_combine(const Args&... args)
+{
     std::size_t seed = 0;
 
-    (..., (seed ^= std::hash<Args>{}(args)+0x9e3779b9 + (seed << 6) + (seed >> 2)));
+    (..., (seed ^= std::hash<Args>{}(args) + 0x9e3779b9 + (seed << 6) + (seed >> 2)));
     return seed;
 }
 
@@ -194,14 +194,12 @@ struct SamplingStatistics
     int num_threads;
     int total_frames;
     int name_cache_misses;
-    SamplingStatistics() : micros_suspended(0), num_threads(0), total_frames(0), name_cache_misses(0)
-    {
-    }
-    SamplingStatistics(SamplingStatistics const& other) :
-        micros_suspended(other.micros_suspended),
-        num_threads(other.num_threads),
-        total_frames(other.total_frames),
-        name_cache_misses(other.name_cache_misses)
+    SamplingStatistics() : micros_suspended(0), num_threads(0), total_frames(0), name_cache_misses(0) {}
+    SamplingStatistics(SamplingStatistics const& other)
+        : micros_suspended(other.micros_suspended)
+        , num_threads(other.num_threads)
+        , total_frames(other.total_frames)
+        , name_cache_misses(other.name_cache_misses)
     {
     }
 };
@@ -210,19 +208,15 @@ class ThreadState
 {
 public:
     trace::WSTRING thread_name_;
-    ThreadState()
-    {
-    }
-    ThreadState(ThreadState const& other) : thread_name_(other.thread_name_)
-    {
-    }
+    ThreadState() {}
+    ThreadState(ThreadState const& other) : thread_name_(other.thread_name_) {}
 };
 
 class ThreadSamplesBuffer
 {
 public:
     std::unordered_map<FunctionIdentifier, int> codes_;
-    std::vector<unsigned char>* buffer_;
+    std::vector<unsigned char>*                 buffer_;
 
     explicit ThreadSamplesBuffer(std::vector<unsigned char>* buf);
     ~ThreadSamplesBuffer();
@@ -231,16 +225,24 @@ public:
     void EndSelectedThreadsBatch() const;
     void WriteSpanContext(const thread_span_context& span_context) const;
     void StartSample(const ThreadState* state, const thread_span_context& span_context) const;
-    void StartSampleForSelectedThread(const ThreadState*         state,
-                                      const thread_span_context& span_context) const;
+    void StartSampleForSelectedThread(const ThreadState* state, const thread_span_context& span_context) const;
     void MarkSelectedForFrequentSampling(bool value) const;
     void RecordFrame(const FunctionIdentifier& fid, const trace::WSTRING& frame);
     void EndSample() const;
     void EndBatch() const;
     void WriteFinalStats(const SamplingStatistics& stats) const;
-    void AllocationSample(uint64_t allocSize, const WCHAR* allocType, size_t allocTypeCharLen, ThreadID id, const ThreadState* state, const thread_span_context& span_context) const;
+    [[nodiscard]] bool IsOverflowed() const noexcept;
+    void               AllocationSample(uint64_t                   allocSize,
+                                        const WCHAR*               allocType,
+                                        size_t                     allocTypeCharLen,
+                                        ThreadID                   id,
+                                        const ThreadState*         state,
+                                        const thread_span_context& span_context) const;
 
 private:
+    mutable bool overflowed_ = false;
+
+    void UpdateOverflowState() const noexcept;
     void WriteCurrentTimeMillis() const;
     void WriteCodedFrameString(const FunctionIdentifier& fid, const trace::WSTRING& str);
     void WriteShort(int16_t val) const;
@@ -258,10 +260,11 @@ namespace continuous_profiler
 class ThreadSpanContextMap
 {
 public:
-    void                                                              Put(ThreadID threadId, const thread_span_context& currentSpanContext);
-    std::optional<thread_span_context>                                GetContext(ThreadID threadId);
-    void                                                              Remove(const thread_span_context& spanContext);
-    void                                                              Remove(ThreadID threadId);
+    void                               Put(ThreadID threadId, const thread_span_context& currentSpanContext);
+    std::optional<thread_span_context> GetContext(ThreadID threadId);
+    void                               Remove(const thread_span_context& spanContext);
+    void                               Remove(ThreadID threadId);
+    void                               Clear();
     std::unordered_map<ThreadID, thread_span_context>::const_iterator begin() const;
     std::unordered_map<ThreadID, thread_span_context>::const_iterator end() const;
 
@@ -271,19 +274,19 @@ private:
 template <typename TKey, typename TValue>
 class NameCache
 {
-// ModuleID is volatile but it is unlikely to have exactly same pair of Function Token and ModuleId after changes.
-// If fails we should end up we Unknown(unknown) as a result
+    // ModuleID is volatile but it is unlikely to have exactly same pair of Function Token and ModuleId after changes.
+    // If fails we should end up we Unknown(unknown) as a result
 public:
     explicit NameCache(size_t maximum_size, TValue default_value);
     TValue Get(TKey key);
-// if max cache size is exceeded it return value which should be disposed
+    // if max cache size is exceeded it return value which should be disposed
     TValue Put(TKey key, TValue val);
-    void Clear();
+    void   Clear();
 
 private:
-    TValue default_value_;
-    size_t max_size_;
-    std::list<std::pair<TKey, TValue>> list_;
+    TValue                                                                          default_value_;
+    size_t                                                                          max_size_;
+    std::list<std::pair<TKey, TValue>>                                              list_;
     std::unordered_map<TKey, typename std::list<std::pair<TKey, TValue>>::iterator> map_;
 };
 
@@ -291,20 +294,20 @@ class NamingHelper
 {
 public:
     // These are permanent parts of the helper object
-    ICorProfilerInfo7* info7_ = nullptr;
+    ICorProfilerInfo7* info7_       = nullptr;
     IStackWalker*      stackWalker_ = nullptr;
     NamingHelper();
-    void ClearFunctionIdentifierCache();
-    trace::WSTRING* Lookup(const FunctionIdentifier& function_identifier, SamplingStatistics & stats);
+    void               ClearFunctionIdentifierCache();
+    trace::WSTRING*    Lookup(const FunctionIdentifier& function_identifier, SamplingStatistics& stats);
     FunctionIdentifier LookupManagedFunction(FunctionID functionId, COR_PRF_FRAME_INFO frameInfo);
 
-    [[nodiscard]] FunctionIdentifier ResolveManagedFunctionIdentifier(FunctionID func_id,
-                                                                     COR_PRF_FRAME_INFO frame_info) const;
+    [[nodiscard]] FunctionIdentifier ResolveManagedFunctionIdentifier(FunctionID         func_id,
+                                                                      COR_PRF_FRAME_INFO frame_info) const;
+
 private:
-    NameCache<FunctionIdentifier, trace::WSTRING*> function_name_cache_;
+    NameCache<FunctionIdentifier, trace::WSTRING*>               function_name_cache_;
     NameCache<FunctionIdentifierResolveArgs, FunctionIdentifier> function_identifier_cache_;
     void GetFunctionName(FunctionIdentifier function_identifier, trace::WSTRING& result) const;
-
 };
 
 // We can get more AllocationTick events than we reasonably want to push to the cloud; this
@@ -319,83 +322,114 @@ public:
     void AdvanceCycle(std::chrono::milliseconds now);
 
 private:
-    uint32_t targetPerCycle;
-    uint32_t secondsPerCycle;
-    uint32_t seenThisCycle;
-    uint32_t sampledThisCycle;
-    uint32_t seenLastCycle;
-    uint32_t                   startupCyclesRemaining;
-    std::chrono::milliseconds  startupMinSampleSpacingMillis;
+    uint32_t                              targetPerCycle;
+    uint32_t                              secondsPerCycle;
+    uint32_t                              seenThisCycle;
+    uint32_t                              sampledThisCycle;
+    uint32_t                              seenLastCycle;
+    uint32_t                              startupCyclesRemaining;
+    std::chrono::milliseconds             startupMinSampleSpacingMillis;
     std::chrono::steady_clock::time_point startupNextSampleAllowedAt;
-    std::chrono::milliseconds nextCycleStartMillis;
-    std::mutex sampleLock;
-    std::default_random_engine rand;
+    std::chrono::milliseconds             nextCycleStartMillis;
+    std::mutex                            sampleLock;
+    std::default_random_engine            rand;
 };
 
-enum class SamplingType : int32_t { Continuous = 1, SelectedThreads = 2 };
+enum class SamplingType : int32_t
+{
+    Continuous      = 1,
+    SelectedThreads = 2
+};
+
+class IAllocationSamplingSessionProvider
+{
+public:
+    virtual ~IAllocationSamplingSessionProvider()                                       = default;
+    virtual HRESULT StartAllocationSamplingSession(EVENTPIPE_SESSION* session) noexcept = 0;
+    virtual HRESULT StopAllocationSamplingSession(EVENTPIPE_SESSION session) noexcept   = 0;
+};
 
 class ContinuousProfiler
 {
 public:
-    std::optional<unsigned int> threadSamplingInterval;
-    std::optional<unsigned int> selectedThreadsSamplingInterval;
     std::chrono::time_point<std::chrono::steady_clock> nextOutdatedEntriesScan;
-    void                        StartThreadSampling();
+    explicit ContinuousProfiler(
+        IAllocationSamplingSessionProvider* allocationSamplingSessionProvider = nullptr) noexcept;
+    ~ContinuousProfiler();
+    bool                        ApplyConfiguration(const RuntimeSamplerConfiguration& configuration);
+    RuntimeSamplerConfiguration GetConfiguration() const;
+    bool                        IsThreadSamplingThreadRunning() const;
     void                        Shutdown();
     bool                        IsShutdownRequested() const;
     static void                 InitSelectiveSamplingBuffer();
-    unsigned int                maxMemorySamplesPerMinute;
-    void                        StartAllocationSampling(unsigned int maxMemorySamplesPerMinute);
-    void                        StopAllocationSampling();
     void                        AllocationTick(ULONG dataLen, LPCBYTE data);
     ICorProfilerInfo12*         info12 = nullptr;
-    ICorProfilerInfo7*          info7 = nullptr;
+    ICorProfilerInfo7*          info7  = nullptr;
     static void                 ThreadCreated(ThreadID thread_id);
     void                        ThreadDestroyed(ThreadID thread_id);
     void                        ThreadNameChanged(ThreadID thread_id, ULONG cch_name, WCHAR name[]);
 
-    void SetGlobalInfo12(ICorProfilerInfo12* info12);
-    void SetGlobalInfo7(ICorProfilerInfo7* cor_profiler_info7);
-    void                   SetStackWalker(IStackWalker* walker);
+    void          SetGlobalInfo12(ICorProfilerInfo12* info12);
+    void          SetGlobalInfo7(ICorProfilerInfo7* cor_profiler_info7);
+    void          PublishGlobalInfo() const;
+    static void   ClearGlobalInfo();
+    void          SetStackWalker(IStackWalker* walker);
     IStackWalker* GetStackWalker() const;
-    ThreadState* GetCurrentThreadState(ThreadID tid);
+    ThreadState   GetCurrentThreadState(ThreadID tid);
 
     std::unordered_map<ThreadID, ThreadState*> managed_tid_to_state_;
-    std::mutex thread_state_lock_;
-    NamingHelper helper;
-    std::unique_ptr<AllocationSubSampler> allocationSubSampler = nullptr;
+    std::mutex                                 thread_state_lock_;
+    NamingHelper                               helper;
+    std::unique_ptr<AllocationSubSampler>      allocationSubSampler = nullptr;
 
     // These cycle every sample and/or are owned externally
     ThreadSamplesBuffer* cur_cpu_writer_ = nullptr;
-    SamplingStatistics stats_;
-    void AllocateBuffer();
-    void PublishBuffer();
-    mutable std::mutex      shutdown_mutex_;
-    std::condition_variable shutdown_cv_;
+    SamplingStatistics   stats_;
+    void                 AllocateBuffer();
+    void                 PublishBuffer(std::uint32_t samplingInterval);
+    void                 DiscardBuffer() noexcept;
 
 private:
-    std::atomic_bool             shutdown_requested_{ false };
+    void    SamplingThreadMain() noexcept;
+    bool    ApplyAllocationConfiguration(const std::optional<std::uint32_t>& previousRate,
+                                         const std::optional<std::uint32_t>& candidateRate);
+    HRESULT StartAllocationSamplingSession(EVENTPIPE_SESSION* session) noexcept;
+    HRESULT StopAllocationSamplingSession(EVENTPIPE_SESSION session) noexcept;
+    bool    TryCleanupFailedAllocationSession();
+    void    StopAllocationSamplingForShutdown();
+
+    mutable std::mutex           configuration_transition_mutex_;
+    mutable std::mutex           sampling_state_mutex_;
+    std::condition_variable      sampling_state_cv_;
+    RuntimeSamplerConfiguration  configuration_;
+    std::uint64_t                configuration_generation_       = 0;
+    bool                         thread_sampling_stop_requested_ = false;
+    std::once_flag               selective_sampling_init_flag_;
+    std::atomic_bool             shutdown_requested_{false};
+    std::atomic_bool             allocation_sampling_enabled_{false};
     std::unique_ptr<std::thread> thread_sampling_thread_;
-    EVENTPIPE_SESSION            session_ = 0;
-    IStackWalker*                stackWalker_ = nullptr;
+    EVENTPIPE_SESSION            session_                           = 0;
+    EVENTPIPE_SESSION            failed_allocation_session_cleanup_ = 0;
+    // Non-owning testable boundary around the EventPipe operations. The provider must outlive this profiler.
+    IAllocationSamplingSessionProvider* allocation_sampling_session_provider_ = nullptr;
+    IStackWalker*                       stackWalker_                          = nullptr;
 };
 
 // Internal selective-sampling state operations, public for unit testing.
-bool TryAddSelectiveSamplingTrace(const trace_context&                             context,
-                                  const std::chrono::steady_clock::time_point now);
+bool TryAddSelectiveSamplingTrace(const trace_context& context, const std::chrono::steady_clock::time_point now);
 void RemoveSelectiveSamplingTrace(const trace_context& context);
 
-bool TryPrepareSelectedThreadSampling(ContinuousProfiler*                         prof,
-                                      const std::chrono::steady_clock::time_point now);
+bool TryPrepareSelectedThreadSampling(ContinuousProfiler* prof, const std::chrono::steady_clock::time_point now);
 
 } // namespace continuous_profiler
 
 void AllocationSamplingAppendToBuffer(int32_t appendLen, unsigned char* appendBuf);
+bool AllocationSamplingShouldProduceSample();
 
 bool ThreadSamplingShouldProduceThreadSample();
-void ThreadSamplingRecordProducedThreadSample(std::vector<unsigned char>* buf);
+void ThreadSamplingRecordProducedThreadSample(std::vector<unsigned char>* buf, std::uint32_t samplingInterval);
 // Can return 0 if none are pending
-int32_t ThreadSamplingConsumeOneThreadSample(int32_t len, unsigned char* buf);
+int32_t ThreadSamplingConsumeOneThreadSample(int32_t len, unsigned char* buf, std::uint32_t* samplingInterval);
 
 bool SelectiveSamplingShouldProduceThreadSample();
 void SelectiveSamplingRecordProducedThreadSample(int32_t appendLen, unsigned char* appendBuf);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -56,15 +56,40 @@ using namespace std::chrono_literals;
 namespace trace
 {
 
+template <typename... Args>
+static void LogContinuousProfilerErrorNoThrow(const Args&... args) noexcept
+{
+    try
+    {
+        Logger::Error(args...);
+    }
+    catch (...)
+    {
+    }
+}
+
+template <typename... Args>
+static void LogContinuousProfilerWarningNoThrow(const Args&... args) noexcept
+{
+    try
+    {
+        Logger::Warn(args...);
+    }
+    catch (...)
+    {
+    }
+}
+
 CorProfiler* profiler = nullptr;
+
+CorProfiler::CorProfiler() : runtime_sampler_controller_(*this) {}
 
 //
 // ICorProfilerCallback methods
 //
 HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown)
 {
-    auto _                   = trace::Stats::Instance()->InitializeMeasure();
-    this->continuousProfiler = nullptr;
+    auto _ = trace::Stats::Instance()->InitializeMeasure();
 
     CorProfilerBase::Initialize(cor_profiler_info_unknown);
 
@@ -208,7 +233,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     tracer_integration_preprocessor = std::make_unique<TracerRejitPreprocessor>(rejit_handler, work_offloader);
 
     DWORD event_mask = COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST | COR_PRF_MONITOR_MODULE_LOADS |
-                       COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS | COR_PRF_ENABLE_REJIT;
+                       COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS | COR_PRF_ENABLE_REJIT |
+                       COR_PRF_MONITOR_THREADS | COR_PRF_ENABLE_STACK_SNAPSHOT;
 
 #ifdef _WIN32
     if (runtime_information_.is_desktop())
@@ -282,6 +308,14 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     this->info_->AddRef();
     is_attached_.store(true);
     profiler = this;
+
+    // Prepare stack walking and the process-wide sampler foundation before any
+    // managed configuration arrives. Sampling producers are started only by a
+    // later successful configuration apply.
+    if (!runtime_sampler_controller_.Prepare())
+    {
+        LogContinuousProfilerWarningNoThrow("ContinuousProfiler: sampler foundation is unavailable.");
+    }
 
     return S_OK;
 }
@@ -918,10 +952,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
 
 HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
 {
-    if (continuousProfiler != nullptr)
-    {
-        continuousProfiler->Shutdown();
-    }
+    runtime_sampler_controller_.Shutdown();
 
     is_attached_.store(false);
 
@@ -954,6 +985,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ProfilerDetachSucceeded()
         return S_OK;
     }
 
+    runtime_sampler_controller_.Shutdown();
     CorProfilerBase::ProfilerDetachSucceeded();
 
     // keep this lock until we are done using the module,
@@ -1180,50 +1212,191 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
 
 bool CorProfiler::InitThreadSampler()
 {
-#if defined(_WIN32)
-    // for net fx, the native thread ID is needed by stack capture
-    // the profiler callback, ThreadAssignedToOSThread is not invoked for main thread
-    // for the following machinery to work,
-    // 1 The thread needs to have executed managed code first
-    // 2. InitThreadSampler must must be executing in context of main thread
-    // InitThreadSampler is called from managed code
-    // And more importantly, the main thread calls InitThreadSampler
-    ThreadID mainThreadId = 0;
-    if (auto hr = info_->GetCurrentThreadID(&mainThreadId); SUCCEEDED(hr))
+    if (continuous_profiler_callbacks_.load(std::memory_order_acquire) != nullptr)
     {
-        ThreadAssignedToOSThread(mainThreadId, ::GetCurrentThreadId());
+        return true;
+    }
+
+    auto sampler = std::make_unique<continuous_profiler::ContinuousProfiler>();
+    if (this->info12_ != nullptr)
+    {
+        sampler->SetGlobalInfo12(this->info12_);
+    }
+    else
+    {
+        sampler->SetGlobalInfo7(this->info_);
+    }
+
+    using continuous_profiler::RuntimeType;
+    RuntimeType runtime     = runtime_information_.is_desktop() ? RuntimeType::DotNetFramework
+                              : runtime_information_.is_core()  ? RuntimeType::DotNetCore
+                                                                : RuntimeType::Unknown;
+    auto        stackWalker = std::make_shared<continuous_profiler::StackWalkerImpl>(this->info_, runtime);
+
+    sampler->SetStackWalker(stackWalker.get());
+    sampler->PublishGlobalInfo();
+
+    continuous_profiler_ = std::move(sampler);
+    std::atomic_store_explicit(&stack_walker_impl_, stackWalker, std::memory_order_release);
+    continuous_profiler_callbacks_.store(continuous_profiler_.get(), std::memory_order_release);
+    continuous_profiler_callbacks_enabled_.store(true, std::memory_order_release);
+    RecordCurrentThreadAssignmentForContinuousProfiler();
+    Logger::Info("ContinuousProfiler: process-wide sampler initialized.");
+    return true;
+}
+
+void CorProfiler::RecordCurrentThreadAssignmentForContinuousProfiler() noexcept
+{
+#if defined(_WIN32)
+    if (!runtime_information_.is_desktop())
+    {
+        return;
+    }
+
+    try
+    {
+        std::shared_lock<std::shared_mutex> callbackLock;
+        if (!TryEnterContinuousProfilerCallback(callbackLock))
+        {
+            return;
+        }
+
+        const auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
+        if (stackWalker == nullptr)
+        {
+            return;
+        }
+
+        // The CLR does not report ThreadAssignedToOSThread for the .NET
+        // Framework main thread. The legacy configuration call is made from
+        // managed code on that thread, so refresh the mapping there as well as
+        // during early preparation.
+        ThreadID currentThreadId = 0;
+        if (const auto hr = info_->GetCurrentThreadID(&currentThreadId); SUCCEEDED(hr))
+        {
+            stackWalker->OnThreadAssignedToOSThread(currentThreadId, ::GetCurrentThreadId());
+        }
+    }
+    catch (...)
+    {
+        try
+        {
+            Logger::Warn("ContinuousProfiler: could not record the current .NET Framework thread assignment.");
+        }
+        catch (...)
+        {
+        }
     }
 #endif
+}
 
-    DWORD pdvEventsLow;
-    DWORD pdvEventsHigh;
-    auto  hr = this->info_->GetEventMask2(&pdvEventsLow, &pdvEventsHigh);
-    if (FAILED(hr))
+bool CorProfiler::TryEnterContinuousProfilerCallback(std::shared_lock<std::shared_mutex>& callbackLock) noexcept
+{
+    if (!continuous_profiler_callbacks_enabled_.load(std::memory_order_acquire))
     {
-        Logger::Warn("ConfigureContinuousProfiler: Failed to take event masks for continuous profiler.");
         return false;
     }
 
-    pdvEventsLow |= COR_PRF_MONITOR_THREADS | COR_PRF_ENABLE_STACK_SNAPSHOT;
-
-    hr = this->info_->SetEventMask2(pdvEventsLow, pdvEventsHigh);
-    if (FAILED(hr))
+    try
     {
-        Logger::Warn("ConfigureContinuousProfiler: Failed to set event masks for continuous profiler.");
+        callbackLock = std::shared_lock<std::shared_mutex>(continuous_profiler_callback_lock_);
+    }
+    catch (...)
+    {
         return false;
     }
 
-    this->continuousProfiler = new continuous_profiler::ContinuousProfiler();
-    this->continuousProfiler->SetGlobalInfo12(this->info12_);
-    this->continuousProfiler->SetGlobalInfo7(this->info_);
-    using continuous_profiler::RuntimeType;
-    RuntimeType runtime = runtime_information_.is_desktop() ? RuntimeType::DotNetFramework
-                          : runtime_information_.is_core()  ? RuntimeType::DotNetCore
-                                                            : RuntimeType::Unknown;
-    stack_walker_impl_  = std::make_unique<continuous_profiler::StackWalkerImpl>(this->info_, runtime);
-    this->continuousProfiler->SetStackWalker(stack_walker_impl_.get());
-    Logger::Info("ConfigureContinuousProfiler: Events masks configured for continuous profiler");
-    return true;
+    return continuous_profiler_callbacks_enabled_.load(std::memory_order_acquire);
+}
+
+bool CorProfiler::IsAllocationSamplingSupported() const noexcept
+{
+    return info12_ != nullptr;
+}
+
+bool CorProfiler::Bootstrap() noexcept
+{
+    try
+    {
+        return InitThreadSampler();
+    }
+    catch (const std::exception& exception)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: unable to initialize sampler: ", exception.what());
+    }
+    catch (...)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: unable to initialize sampler.");
+    }
+    return false;
+}
+
+bool CorProfiler::ApplyConfiguration(const continuous_profiler::RuntimeSamplerConfiguration& configuration) noexcept
+{
+    try
+    {
+        // RuntimeSamplerController serializes ApplyConfiguration with
+        // ShutdownSampling, so the sampler cannot be destroyed during this
+        // call. Avoid holding the CLR-callback gate while starting or stopping
+        // EventPipe because those APIs may deliver callbacks synchronously.
+        if (!continuous_profiler_callbacks_enabled_.load(std::memory_order_acquire))
+        {
+            return false;
+        }
+
+        auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+        return sampler != nullptr && sampler->ApplyConfiguration(configuration);
+    }
+    catch (const std::exception& exception)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: configuration transition failed: ", exception.what());
+    }
+    catch (...)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: configuration transition failed.");
+    }
+    return false;
+}
+
+void CorProfiler::ShutdownSampling() noexcept
+{
+    continuous_profiler_callbacks_enabled_.store(false, std::memory_order_release);
+    auto sampler = continuous_profiler_callbacks_.exchange(nullptr, std::memory_order_acq_rel);
+
+    // A callback can observe the enabled flag immediately before it is
+    // cleared. Briefly taking the exclusive lock waits for callbacks that
+    // already entered, while the second flag check makes queued callbacks
+    // return without loading the sampler. Do not hold this lock while stopping
+    // EventPipe: the runtime may synchronously wait for a callback that also
+    // passes through this gate.
+    {
+        std::unique_lock<std::shared_mutex> callbackLock(continuous_profiler_callback_lock_);
+    }
+
+    if (sampler != nullptr)
+    {
+        try
+        {
+            sampler->Shutdown();
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: shutdown failed: ", exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: shutdown failed.");
+        }
+    }
+
+    if (continuous_profiler_ != nullptr)
+    {
+        continuous_profiler_->SetStackWalker(nullptr);
+        continuous_profiler_.reset();
+    }
+
+    std::atomic_store_explicit(&stack_walker_impl_, std::shared_ptr<continuous_profiler::StackWalkerImpl>{},
+                               std::memory_order_release);
 }
 
 void CorProfiler::ConfigureContinuousProfiler(bool         threadSamplingEnabled,
@@ -1232,57 +1405,79 @@ void CorProfiler::ConfigureContinuousProfiler(bool         threadSamplingEnabled
                                               unsigned int maxMemorySamplesPerMinute,
                                               unsigned int selectedThreadsSamplingInterval)
 {
-    ContinuousProfilerParams params{threadSamplingEnabled, threadSamplingInterval, allocationSamplingEnabled,
-                                    maxMemorySamplesPerMinute, selectedThreadsSamplingInterval};
-    // Guard against multiple initialization: In .NET Framework, this method may be called
-    // once per AppDomain, but the continuous profiler is a process-level singleton.
-    // std::call_once ensures thread-safe one-time initialization across all AppDomains.
-    std::call_once(sampling_init_flag_, [this, &params]() { ConfigureContinuousProfilerInternal(params); });
+    Logger::Info("ConfigureContinuousProfiler: thread sampling enabled: ", threadSamplingEnabled,
+                 ", thread sampling interval: ", threadSamplingInterval,
+                 ", allocationSamplingEnabled: ", allocationSamplingEnabled,
+                 ", max memory samples per minute: ", maxMemorySamplesPerMinute,
+                 ", selected threads sampling interval: ", selectedThreadsSamplingInterval);
+
+    // The legacy entry point is an initial process-wide seed. Repeated calls
+    // from additional .NET Framework AppDomains cannot replace that seed.
+    continuous_profiler::RuntimeSamplerConfigurationV1
+        wireConfiguration{sizeof(continuous_profiler::RuntimeSamplerConfigurationV1),
+                          continuous_profiler::kRuntimeSamplerSchemaVersionV1,
+                          threadSamplingEnabled ? threadSamplingInterval : 0,
+                          selectedThreadsSamplingInterval,
+                          allocationSamplingEnabled && IsAllocationSamplingSupported() ? maxMemorySamplesPerMinute : 0,
+                          0,
+                          0,
+                          0};
+
+    continuous_profiler::RuntimeSamplerConfiguration configuration;
+    const auto decodeResult = continuous_profiler::DecodeRuntimeSamplerConfigurationV1(
+        &wireConfiguration,
+        IsAllocationSamplingSupported() ? continuous_profiler::RuntimeSamplerAllocationSupport::Supported
+                                        : continuous_profiler::RuntimeSamplerAllocationSupport::Unsupported,
+        configuration);
+    if (decodeResult != continuous_profiler::RuntimeSamplerApplyResult::Applied)
+    {
+        Logger::Warn("ConfigureContinuousProfiler: invalid configuration rejected with result ",
+                     static_cast<std::int32_t>(decodeResult), ".");
+        return;
+    }
+
+    if (configuration.HasThreadSampling())
+    {
+        RecordCurrentThreadAssignmentForContinuousProfiler();
+    }
+
+    const auto result = runtime_sampler_controller_.ApplyInitialConfiguration(configuration);
+    if (result != continuous_profiler::RuntimeSamplerApplyResult::Applied &&
+        result != continuous_profiler::RuntimeSamplerApplyResult::NoChange &&
+        result != continuous_profiler::RuntimeSamplerApplyResult::IgnoredInitialConfiguration)
+    {
+        Logger::Warn("ConfigureContinuousProfiler: configuration was not applied. Result: ",
+                     static_cast<std::int32_t>(result), ".");
+    }
 }
 
-void CorProfiler::ConfigureContinuousProfilerInternal(const ContinuousProfilerParams& params)
+continuous_profiler::RuntimeSamplerApplyResult CorProfiler::ApplyContinuousProfilerConfigurationV1(
+    const continuous_profiler::RuntimeSamplerConfigurationV1* configuration) noexcept
 {
-    Logger::Info("ConfigureContinuousProfiler: thread sampling enabled: ", params.threadSamplingEnabled,
-                 ", thread sampling interval: ", params.threadSamplingInterval,
-                 ", allocationSamplingEnabled: ", params.allocationSamplingEnabled,
-                 ", max memory samples per minute: ", params.maxMemorySamplesPerMinute,
-                 ", selected threads sampling interval: ", params.selectedThreadsSamplingInterval);
-
-    const bool selectiveSamplingConfigured = params.selectedThreadsSamplingInterval != 0;
-
-    if (!params.threadSamplingEnabled && !params.allocationSamplingEnabled && !selectiveSamplingConfigured)
+    continuous_profiler::RuntimeSamplerConfiguration decodedConfiguration;
+    const auto decodeResult = continuous_profiler::DecodeRuntimeSamplerConfigurationV1(
+        configuration,
+        IsAllocationSamplingSupported() ? continuous_profiler::RuntimeSamplerAllocationSupport::Supported
+                                        : continuous_profiler::RuntimeSamplerAllocationSupport::Unsupported,
+        decodedConfiguration);
+    if (decodeResult != continuous_profiler::RuntimeSamplerApplyResult::Applied)
     {
-        Logger::Debug("ConfigureContinuousProfiler: no sampling type configured.");
-        return;
+        return decodeResult;
     }
 
-    if (!InitThreadSampler())
+    if (decodedConfiguration.HasThreadSampling())
     {
-        Logger::Warn("ContinuousProfiler: unable to init sampler.");
-        return;
+        RecordCurrentThreadAssignmentForContinuousProfiler();
     }
 
-    if (params.threadSamplingEnabled)
-    {
-        this->continuousProfiler->threadSamplingInterval = params.threadSamplingInterval;
-    }
-    if (selectiveSamplingConfigured)
-    {
-        this->continuousProfiler->selectedThreadsSamplingInterval = params.selectedThreadsSamplingInterval;
-        this->continuousProfiler->nextOutdatedEntriesScan         = std::chrono::steady_clock::now();
-        continuous_profiler::ContinuousProfiler::InitSelectiveSamplingBuffer();
-    }
+    return runtime_sampler_controller_.ApplyConfiguration(decodedConfiguration);
+}
 
-    if (params.threadSamplingEnabled || selectiveSamplingConfigured)
-    {
-        Logger::Info("ContinuousProfiler::StartThreadSampling");
-        this->continuousProfiler->StartThreadSampling();
-    }
-
-    if (params.allocationSamplingEnabled)
-    {
-        this->continuousProfiler->StartAllocationSampling(params.maxMemorySamplesPerMinute);
-    }
+continuous_profiler::RuntimeSamplerStateQueryResult CorProfiler::GetContinuousProfilerStateV1(
+    continuous_profiler::RuntimeSamplerStateV1* state) const noexcept
+{
+    const auto currentState = runtime_sampler_controller_.GetState();
+    return continuous_profiler::EncodeRuntimeSamplerStateV1(currentState.configuration, currentState.generation, state);
 }
 
 void CorProfiler::InitializeTraceMethods(WCHAR* id,
@@ -3796,51 +3991,166 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
 
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadCreated(ThreadID threadId)
 {
-    if (continuousProfiler != nullptr)
+    std::shared_lock<std::shared_mutex> callbackLock;
+    if (!TryEnterContinuousProfilerCallback(callbackLock))
     {
-        continuousProfiler->ThreadCreated(threadId);
+        return S_OK;
     }
 
-    if (stack_walker_impl_)
+    if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire); sampler != nullptr)
     {
-        stack_walker_impl_->OnThreadCreated(threadId);
+        try
+        {
+            sampler->ThreadCreated(threadId);
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated sampler callback failed: ",
+                                              exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated sampler callback failed.");
+        }
     }
+
+    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
+        stackWalker != nullptr)
+    {
+        try
+        {
+            stackWalker->OnThreadCreated(threadId);
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated stack-walker callback failed: ",
+                                              exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated stack-walker callback failed.");
+        }
+    }
+
     return S_OK;
 }
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadDestroyed(ThreadID threadId)
 {
-    if (continuousProfiler != nullptr)
+    std::shared_lock<std::shared_mutex> callbackLock;
+    if (!TryEnterContinuousProfilerCallback(callbackLock))
     {
-        continuousProfiler->ThreadDestroyed(threadId);
+        return S_OK;
     }
 
-    if (stack_walker_impl_)
+    if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire); sampler != nullptr)
     {
-        stack_walker_impl_->OnThreadDestroyed(threadId);
+        try
+        {
+            sampler->ThreadDestroyed(threadId);
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed sampler callback failed: ",
+                                              exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed sampler callback failed.");
+        }
+    }
+
+    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
+        stackWalker != nullptr)
+    {
+        try
+        {
+            stackWalker->OnThreadDestroyed(threadId);
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed stack-walker callback failed: ",
+                                              exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed stack-walker callback failed.");
+        }
     }
 
     return S_OK;
 }
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[])
 {
-    if (continuousProfiler != nullptr)
+    std::shared_lock<std::shared_mutex> callbackLock;
+    if (!TryEnterContinuousProfilerCallback(callbackLock))
     {
-        continuousProfiler->ThreadNameChanged(threadId, cchName, name);
+        return S_OK;
     }
 
-    if (stack_walker_impl_)
+    if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire); sampler != nullptr)
     {
-        stack_walker_impl_->OnThreadNameChanged(threadId, cchName, name);
+        try
+        {
+            sampler->ThreadNameChanged(threadId, cchName, name);
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged sampler callback failed: ",
+                                              exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged sampler callback failed.");
+        }
+    }
+
+    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
+        stackWalker != nullptr)
+    {
+        try
+        {
+            stackWalker->OnThreadNameChanged(threadId, cchName, name);
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged stack-walker callback failed: ",
+                                              exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged stack-walker callback failed.");
+        }
     }
 
     return S_OK;
 }
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId)
 {
-    if (stack_walker_impl_)
+    std::shared_lock<std::shared_mutex> callbackLock;
+    if (!TryEnterContinuousProfilerCallback(callbackLock))
     {
-        stack_walker_impl_->OnThreadAssignedToOSThread(managedThreadId, osThreadId);
+        return S_OK;
     }
+
+    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
+        stackWalker != nullptr)
+    {
+        try
+        {
+            stackWalker->OnThreadAssignedToOSThread(managedThreadId, osThreadId);
+        }
+        catch (const std::exception& exception)
+        {
+            LogContinuousProfilerErrorNoThrow(
+                "ContinuousProfiler: ThreadAssignedToOSThread stack-walker callback failed: ", exception.what());
+        }
+        catch (...)
+        {
+            LogContinuousProfilerErrorNoThrow(
+                "ContinuousProfiler: ThreadAssignedToOSThread stack-walker callback failed.");
+        }
+    }
+
     return S_OK;
 }
 
@@ -3857,10 +4167,30 @@ HRESULT STDMETHODCALLTYPE CorProfiler::EventPipeEventDelivered(EVENTPIPE_PROVIDE
                                                                ULONG              numStackFrames,
                                                                UINT_PTR           stackFrames[])
 {
-    if (continuousProfiler != nullptr && eventId == 10 && eventVersion == 4)
+    std::shared_lock<std::shared_mutex> callbackLock;
+    if (!TryEnterContinuousProfilerCallback(callbackLock))
     {
-        continuousProfiler->AllocationTick(cbEventData, eventData);
+        return S_OK;
     }
+
+    try
+    {
+        if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+            sampler != nullptr && eventId == 10 && eventVersion == 4)
+        {
+            sampler->AllocationTick(cbEventData, eventData);
+        }
+    }
+    catch (const std::exception& exception)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: EventPipeEventDelivered callback failed: ",
+                                          exception.what());
+    }
+    catch (...)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: EventPipeEventDelivered callback failed.");
+    }
+
     return S_OK;
 }
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -1191,11 +1191,6 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
 
 bool CorProfiler::InitThreadSampler()
 {
-    if (continuous_profiler_callbacks_.load(std::memory_order_acquire) != nullptr)
-    {
-        return true;
-    }
-
     DWORD eventMaskLow;
     DWORD eventMaskHigh;
     auto  hr = this->info_->GetEventMask2(&eventMaskLow, &eventMaskHigh);
@@ -1206,13 +1201,6 @@ bool CorProfiler::InitThreadSampler()
     }
 
     eventMaskLow |= COR_PRF_MONITOR_THREADS | COR_PRF_ENABLE_STACK_SNAPSHOT;
-
-    hr = this->info_->SetEventMask2(eventMaskLow, eventMaskHigh);
-    if (FAILED(hr))
-    {
-        Logger::Warn("ConfigureContinuousProfiler: Failed to set event masks for continuous profiler.");
-        return false;
-    }
 
     auto sampler = std::make_unique<continuous_profiler::ContinuousProfiler>();
     if (this->info12_ != nullptr)
@@ -1228,15 +1216,27 @@ bool CorProfiler::InitThreadSampler()
     RuntimeType runtime     = runtime_information_.is_desktop() ? RuntimeType::DotNetFramework
                               : runtime_information_.is_core()  ? RuntimeType::DotNetCore
                                                                 : RuntimeType::Unknown;
-    auto        stackWalker = std::make_shared<continuous_profiler::StackWalkerImpl>(this->info_, runtime);
+    auto        stackWalker = std::make_unique<continuous_profiler::StackWalkerImpl>(this->info_, runtime);
 
     sampler->SetStackWalker(stackWalker.get());
-    sampler->PublishGlobalInfo();
 
+    stack_walker_impl_   = std::move(stackWalker);
     continuous_profiler_ = std::move(sampler);
-    std::atomic_store_explicit(&stack_walker_impl_, stackWalker, std::memory_order_release);
+
+    // Publish the fully initialized callback facade before enabling CLR
+    // callbacks. The facade and its walker remain at stable addresses until
+    // the CorProfiler itself is destroyed; terminal shutdown only stops their
+    // internal producers.
     continuous_profiler_callbacks_.store(continuous_profiler_.get(), std::memory_order_release);
-    continuous_profiler_callbacks_enabled_.store(true, std::memory_order_release);
+
+    hr = this->info_->SetEventMask2(eventMaskLow, eventMaskHigh);
+    if (FAILED(hr))
+    {
+        Logger::Warn("ConfigureContinuousProfiler: Failed to set event masks for continuous profiler.");
+        return false;
+    }
+
+    continuous_profiler_->PublishGlobalInfo();
     RecordCurrentThreadAssignmentForContinuousProfiler();
     Logger::Info("ContinuousProfiler: process-wide sampler initialized.");
     return true;
@@ -1252,22 +1252,16 @@ void CorProfiler::RecordCurrentThreadAssignmentForContinuousProfiler() noexcept
 
     try
     {
-        std::shared_lock<std::shared_mutex> callbackLock;
-        if (!TryEnterContinuousProfilerCallback(callbackLock))
-        {
-            return;
-        }
-
-        const auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
-        if (stackWalker == nullptr)
+        const auto sampler     = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+        const auto stackWalker = stack_walker_impl_.get();
+        if (sampler == nullptr || sampler->IsShutdownRequested() || stackWalker == nullptr)
         {
             return;
         }
 
         // The CLR does not report ThreadAssignedToOSThread for the .NET
-        // Framework main thread. The legacy configuration call is made from
-        // managed code on that thread, so refresh the mapping there as well as
-        // during lazy sampler initialization.
+        // Framework main thread. Managed configuration is invoked on that
+        // thread, so refresh its mapping before applying the configuration.
         ThreadID currentThreadId = 0;
         if (const auto hr = info_->GetCurrentThreadID(&currentThreadId); SUCCEEDED(hr))
         {
@@ -1285,25 +1279,6 @@ void CorProfiler::RecordCurrentThreadAssignmentForContinuousProfiler() noexcept
         }
     }
 #endif
-}
-
-bool CorProfiler::TryEnterContinuousProfilerCallback(std::shared_lock<std::shared_mutex>& callbackLock) noexcept
-{
-    if (!continuous_profiler_callbacks_enabled_.load(std::memory_order_acquire))
-    {
-        return false;
-    }
-
-    try
-    {
-        callbackLock = std::shared_lock<std::shared_mutex>(continuous_profiler_callback_lock_);
-    }
-    catch (...)
-    {
-        return false;
-    }
-
-    return continuous_profiler_callbacks_enabled_.load(std::memory_order_acquire);
 }
 
 bool CorProfiler::IsAllocationSamplingSupported() const noexcept
@@ -1334,15 +1309,9 @@ bool CorProfiler::ApplyConfiguration(const continuous_profiler::RuntimeSamplerCo
     try
     {
         // RuntimeSamplerController serializes ApplyConfiguration with
-        // ShutdownSampling, so the sampler cannot be destroyed during this
-        // call. Avoid holding the CLR-callback gate while starting or stopping
-        // EventPipe because those APIs may deliver callbacks synchronously.
-        if (!continuous_profiler_callbacks_enabled_.load(std::memory_order_acquire))
-        {
-            return false;
-        }
-
-        auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+        // ShutdownSampling. The published facade remains alive after shutdown;
+        // the controller prevents configuration from reaching it once terminal.
+        const auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
         return sampler != nullptr && sampler->ApplyConfiguration(previousConfiguration, configuration);
     }
     catch (const std::exception& exception)
@@ -1358,19 +1327,7 @@ bool CorProfiler::ApplyConfiguration(const continuous_profiler::RuntimeSamplerCo
 
 void CorProfiler::ShutdownSampling() noexcept
 {
-    continuous_profiler_callbacks_enabled_.store(false, std::memory_order_release);
-    auto sampler = continuous_profiler_callbacks_.exchange(nullptr, std::memory_order_acq_rel);
-
-    // A callback can observe the enabled flag immediately before it is
-    // cleared. Briefly taking the exclusive lock waits for callbacks that
-    // already entered, while the second flag check makes queued callbacks
-    // return without loading the sampler. Do not hold this lock while stopping
-    // EventPipe: the runtime may synchronously wait for a callback that also
-    // passes through this gate.
-    {
-        std::unique_lock<std::shared_mutex> callbackLock(continuous_profiler_callback_lock_);
-    }
-
+    const auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
     if (sampler != nullptr)
     {
         try
@@ -1387,14 +1344,10 @@ void CorProfiler::ShutdownSampling() noexcept
         }
     }
 
-    if (continuous_profiler_ != nullptr)
+    if (stack_walker_impl_ != nullptr)
     {
-        continuous_profiler_->SetStackWalker(nullptr);
-        continuous_profiler_.reset();
+        stack_walker_impl_->Stop();
     }
-
-    std::atomic_store_explicit(&stack_walker_impl_, std::shared_ptr<continuous_profiler::StackWalkerImpl>{},
-                               std::memory_order_release);
 }
 
 void CorProfiler::ConfigureContinuousProfiler(bool         threadSamplingEnabled,
@@ -3989,31 +3942,27 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
 
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadCreated(ThreadID threadId)
 {
-    std::shared_lock<std::shared_mutex> callbackLock;
-    if (!TryEnterContinuousProfilerCallback(callbackLock))
+    const auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+    if (sampler == nullptr || sampler->IsShutdownRequested())
     {
         return S_OK;
     }
 
-    if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire); sampler != nullptr)
+    try
     {
-        try
-        {
-            sampler->ThreadCreated(threadId);
-        }
-        catch (const std::exception& exception)
-        {
-            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated sampler callback failed: ",
-                                              exception.what());
-        }
-        catch (...)
-        {
-            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated sampler callback failed.");
-        }
+        sampler->ThreadCreated(threadId);
+    }
+    catch (const std::exception& exception)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated sampler callback failed: ",
+                                          exception.what());
+    }
+    catch (...)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadCreated sampler callback failed.");
     }
 
-    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
-        stackWalker != nullptr)
+    if (const auto stackWalker = stack_walker_impl_.get(); stackWalker != nullptr)
     {
         try
         {
@@ -4034,31 +3983,27 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ThreadCreated(ThreadID threadId)
 }
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadDestroyed(ThreadID threadId)
 {
-    std::shared_lock<std::shared_mutex> callbackLock;
-    if (!TryEnterContinuousProfilerCallback(callbackLock))
+    const auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+    if (sampler == nullptr || sampler->IsShutdownRequested())
     {
         return S_OK;
     }
 
-    if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire); sampler != nullptr)
+    try
     {
-        try
-        {
-            sampler->ThreadDestroyed(threadId);
-        }
-        catch (const std::exception& exception)
-        {
-            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed sampler callback failed: ",
-                                              exception.what());
-        }
-        catch (...)
-        {
-            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed sampler callback failed.");
-        }
+        sampler->ThreadDestroyed(threadId);
+    }
+    catch (const std::exception& exception)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed sampler callback failed: ",
+                                          exception.what());
+    }
+    catch (...)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadDestroyed sampler callback failed.");
     }
 
-    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
-        stackWalker != nullptr)
+    if (const auto stackWalker = stack_walker_impl_.get(); stackWalker != nullptr)
     {
         try
         {
@@ -4079,31 +4024,27 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ThreadDestroyed(ThreadID threadId)
 }
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[])
 {
-    std::shared_lock<std::shared_mutex> callbackLock;
-    if (!TryEnterContinuousProfilerCallback(callbackLock))
+    const auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+    if (sampler == nullptr || sampler->IsShutdownRequested())
     {
         return S_OK;
     }
 
-    if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire); sampler != nullptr)
+    try
     {
-        try
-        {
-            sampler->ThreadNameChanged(threadId, cchName, name);
-        }
-        catch (const std::exception& exception)
-        {
-            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged sampler callback failed: ",
-                                              exception.what());
-        }
-        catch (...)
-        {
-            LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged sampler callback failed.");
-        }
+        sampler->ThreadNameChanged(threadId, cchName, name);
+    }
+    catch (const std::exception& exception)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged sampler callback failed: ",
+                                          exception.what());
+    }
+    catch (...)
+    {
+        LogContinuousProfilerErrorNoThrow("ContinuousProfiler: ThreadNameChanged sampler callback failed.");
     }
 
-    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
-        stackWalker != nullptr)
+    if (const auto stackWalker = stack_walker_impl_.get(); stackWalker != nullptr)
     {
         try
         {
@@ -4124,14 +4065,14 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ThreadNameChanged(ThreadID threadId, ULON
 }
 HRESULT STDMETHODCALLTYPE CorProfiler::ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId)
 {
-    std::shared_lock<std::shared_mutex> callbackLock;
-    if (!TryEnterContinuousProfilerCallback(callbackLock))
+    // The acquire-load publishes stack_walker_impl_ as well as the sampler.
+    const auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+    if (sampler == nullptr || sampler->IsShutdownRequested())
     {
         return S_OK;
     }
 
-    if (auto stackWalker = std::atomic_load_explicit(&stack_walker_impl_, std::memory_order_acquire);
-        stackWalker != nullptr)
+    if (const auto stackWalker = stack_walker_impl_.get(); stackWalker != nullptr)
     {
         try
         {
@@ -4165,16 +4106,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::EventPipeEventDelivered(EVENTPIPE_PROVIDE
                                                                ULONG              numStackFrames,
                                                                UINT_PTR           stackFrames[])
 {
-    std::shared_lock<std::shared_mutex> callbackLock;
-    if (!TryEnterContinuousProfilerCallback(callbackLock))
+    const auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
+    if (sampler == nullptr || sampler->IsShutdownRequested())
     {
         return S_OK;
     }
 
     try
     {
-        if (auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
-            sampler != nullptr && eventId == 10 && eventVersion == 4)
+        if (eventId == 10 && eventVersion == 4)
         {
             sampler->AllocationTick(cbEventData, eventData);
         }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -68,18 +68,6 @@ static void LogContinuousProfilerErrorNoThrow(const Args&... args) noexcept
     }
 }
 
-template <typename... Args>
-static void LogContinuousProfilerWarningNoThrow(const Args&... args) noexcept
-{
-    try
-    {
-        Logger::Warn(args...);
-    }
-    catch (...)
-    {
-    }
-}
-
 CorProfiler* profiler = nullptr;
 
 CorProfiler::CorProfiler() : runtime_sampler_controller_(*this) {}
@@ -233,8 +221,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     tracer_integration_preprocessor = std::make_unique<TracerRejitPreprocessor>(rejit_handler, work_offloader);
 
     DWORD event_mask = COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST | COR_PRF_MONITOR_MODULE_LOADS |
-                       COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS | COR_PRF_ENABLE_REJIT |
-                       COR_PRF_MONITOR_THREADS | COR_PRF_ENABLE_STACK_SNAPSHOT;
+                       COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS | COR_PRF_ENABLE_REJIT;
 
 #ifdef _WIN32
     if (runtime_information_.is_desktop())
@@ -308,14 +295,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     this->info_->AddRef();
     is_attached_.store(true);
     profiler = this;
-
-    // Prepare stack walking and the process-wide sampler foundation before any
-    // managed configuration arrives. Sampling producers are started only by a
-    // later successful configuration apply.
-    if (!runtime_sampler_controller_.Prepare())
-    {
-        LogContinuousProfilerWarningNoThrow("ContinuousProfiler: sampler foundation is unavailable.");
-    }
 
     return S_OK;
 }
@@ -1217,6 +1196,24 @@ bool CorProfiler::InitThreadSampler()
         return true;
     }
 
+    DWORD eventMaskLow;
+    DWORD eventMaskHigh;
+    auto  hr = this->info_->GetEventMask2(&eventMaskLow, &eventMaskHigh);
+    if (FAILED(hr))
+    {
+        Logger::Warn("ConfigureContinuousProfiler: Failed to take event masks for continuous profiler.");
+        return false;
+    }
+
+    eventMaskLow |= COR_PRF_MONITOR_THREADS | COR_PRF_ENABLE_STACK_SNAPSHOT;
+
+    hr = this->info_->SetEventMask2(eventMaskLow, eventMaskHigh);
+    if (FAILED(hr))
+    {
+        Logger::Warn("ConfigureContinuousProfiler: Failed to set event masks for continuous profiler.");
+        return false;
+    }
+
     auto sampler = std::make_unique<continuous_profiler::ContinuousProfiler>();
     if (this->info12_ != nullptr)
     {
@@ -1270,7 +1267,7 @@ void CorProfiler::RecordCurrentThreadAssignmentForContinuousProfiler() noexcept
         // The CLR does not report ThreadAssignedToOSThread for the .NET
         // Framework main thread. The legacy configuration call is made from
         // managed code on that thread, so refresh the mapping there as well as
-        // during early preparation.
+        // during lazy sampler initialization.
         ThreadID currentThreadId = 0;
         if (const auto hr = info_->GetCurrentThreadID(&currentThreadId); SUCCEEDED(hr))
         {
@@ -1331,7 +1328,8 @@ bool CorProfiler::Bootstrap() noexcept
     return false;
 }
 
-bool CorProfiler::ApplyConfiguration(const continuous_profiler::RuntimeSamplerConfiguration& configuration) noexcept
+bool CorProfiler::ApplyConfiguration(const continuous_profiler::RuntimeSamplerConfiguration& previousConfiguration,
+                                     const continuous_profiler::RuntimeSamplerConfiguration& configuration) noexcept
 {
     try
     {
@@ -1345,7 +1343,7 @@ bool CorProfiler::ApplyConfiguration(const continuous_profiler::RuntimeSamplerCo
         }
 
         auto sampler = continuous_profiler_callbacks_.load(std::memory_order_acquire);
-        return sampler != nullptr && sampler->ApplyConfiguration(configuration);
+        return sampler != nullptr && sampler->ApplyConfiguration(previousConfiguration, configuration);
     }
     catch (const std::exception& exception)
     {

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -150,7 +150,8 @@ private:
     bool TryEnterContinuousProfilerCallback(std::shared_lock<std::shared_mutex>& callbackLock) noexcept;
     bool IsAllocationSamplingSupported() const noexcept override;
     bool Bootstrap() noexcept override;
-    bool ApplyConfiguration(const continuous_profiler::RuntimeSamplerConfiguration& configuration) noexcept override;
+    bool ApplyConfiguration(const continuous_profiler::RuntimeSamplerConfiguration& previousConfiguration,
+                            const continuous_profiler::RuntimeSamplerConfiguration& configuration) noexcept override;
     void ShutdownSampling() noexcept override;
 
 public:

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -11,7 +11,6 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -59,12 +58,11 @@ private:
     bool                            in_azure_app_services = false;
     bool                            is_desktop_iis        = false;
 
-    std::shared_ptr<continuous_profiler::StackWalkerImpl>    stack_walker_impl_;
+    std::unique_ptr<continuous_profiler::StackWalkerImpl>    stack_walker_impl_;
     std::unique_ptr<continuous_profiler::ContinuousProfiler> continuous_profiler_;
-    std::atomic<continuous_profiler::ContinuousProfiler*>    continuous_profiler_callbacks_{nullptr};
-    std::atomic_bool                                         continuous_profiler_callbacks_enabled_{false};
-    std::shared_mutex                                        continuous_profiler_callback_lock_;
-    continuous_profiler::RuntimeSamplerController            runtime_sampler_controller_;
+    // Published once after both owners are initialized and never cleared.
+    std::atomic<continuous_profiler::ContinuousProfiler*> continuous_profiler_callbacks_{nullptr};
+    continuous_profiler::RuntimeSamplerController         runtime_sampler_controller_;
     HRESULT STDMETHODCALLTYPE ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId) override;
 
     //
@@ -147,7 +145,6 @@ private:
     void InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* items, int size, bool isDerived);
     bool InitThreadSampler();
     void RecordCurrentThreadAssignmentForContinuousProfiler() noexcept;
-    bool TryEnterContinuousProfilerCallback(std::shared_lock<std::shared_mutex>& callbackLock) noexcept;
     bool IsAllocationSamplingSupported() const noexcept override;
     bool Bootstrap() noexcept override;
     bool ApplyConfiguration(const continuous_profiler::RuntimeSamplerConfiguration& previousConfiguration,
@@ -278,6 +275,7 @@ public:
     //
     HRESULT RewriteILSystemDataCommandText(const ModuleID module_id);
 
+    friend class CorProfilerContinuousProfilerTestAccess;
     friend class TracerMethodRewriter;
 };
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h
@@ -9,7 +9,9 @@
 #include "cor.h"
 #include "corprof.h"
 #include <atomic>
+#include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -21,6 +23,7 @@
 #include "pal.h"
 #include "rejit_preprocessor.h"
 #include "rejit_handler.h"
+#include "runtime_sampler_controller.h"
 #include <unordered_set>
 #include "clr_helpers.h"
 #include "stack_walker_impl.h"
@@ -32,44 +35,37 @@ class ContinuousProfiler;
 
 namespace trace
 {
-struct ContinuousProfilerParams
-{
-    bool         threadSamplingEnabled;
-    unsigned int threadSamplingInterval;
-    bool         allocationSamplingEnabled;
-    unsigned int maxMemorySamplesPerMinute;
-    unsigned int selectedThreadsSamplingInterval;
-};
-
-class CorProfiler : public CorProfilerBase
+class CorProfiler : public CorProfilerBase, private continuous_profiler::IRuntimeSamplerLifecycle
 {
 private:
-    std::atomic_bool is_attached_ = {false};
-    RuntimeInformation runtime_information_;
+    std::atomic_bool                   is_attached_ = {false};
+    RuntimeInformation                 runtime_information_;
     std::vector<IntegrationDefinition> integration_definitions_;
 
     std::unordered_set<WSTRING> definitions_ids_;
-    std::mutex definitions_ids_lock_;
+    std::mutex                  definitions_ids_lock_;
 
     // Startup helper variables
     WSTRING home_path;
-    bool assembly_redirection_enabled_ = false;
-    bool first_jit_compilation_completed = false;
-    bool startup_fix_required = false;
+    bool    assembly_redirection_enabled_   = false;
+    bool    first_jit_compilation_completed = false;
+    bool    startup_fix_required            = false;
 
-    bool corlib_module_loaded = false;
-    AppDomainID corlib_app_domain_id = 0;
-    bool managed_profiler_loaded_domain_neutral = false;
+    bool                            corlib_module_loaded                   = false;
+    AppDomainID                     corlib_app_domain_id                   = 0;
+    bool                            managed_profiler_loaded_domain_neutral = false;
     std::unordered_set<AppDomainID> managed_profiler_loaded_app_domains;
     std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
-    bool in_azure_app_services = false;
-    bool is_desktop_iis = false;
+    bool                            in_azure_app_services = false;
+    bool                            is_desktop_iis        = false;
 
-    continuous_profiler::ContinuousProfiler* continuousProfiler;
-    std::unique_ptr<continuous_profiler::StackWalkerImpl>       stack_walker_impl_;
-    std::once_flag sampling_init_flag_;
+    std::shared_ptr<continuous_profiler::StackWalkerImpl>    stack_walker_impl_;
+    std::unique_ptr<continuous_profiler::ContinuousProfiler> continuous_profiler_;
+    std::atomic<continuous_profiler::ContinuousProfiler*>    continuous_profiler_callbacks_{nullptr};
+    std::atomic_bool                                         continuous_profiler_callbacks_enabled_{false};
+    std::shared_mutex                                        continuous_profiler_callback_lock_;
+    continuous_profiler::RuntimeSamplerController            runtime_sampler_controller_;
     HRESULT STDMETHODCALLTYPE ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId) override;
-
 
     //
     // CallTarget Members
@@ -77,13 +73,13 @@ private:
     // The variables 'enable_by_ref_instrumentation' and 'enable_calltarget_state_by_ref' will always be true,
     // but instead of removing them and the conditional branches they affect, we will keep the variables to make
     // future upstream pulls easier.
-    std::shared_ptr<RejitHandler> rejit_handler = nullptr;
-    bool enable_by_ref_instrumentation = true;
-    bool enable_calltarget_state_by_ref = true;
+    std::shared_ptr<RejitHandler>            rejit_handler                   = nullptr;
+    bool                                     enable_by_ref_instrumentation   = true;
+    bool                                     enable_calltarget_state_by_ref  = true;
     std::unique_ptr<TracerRejitPreprocessor> tracer_integration_preprocessor = nullptr;
 
     // Cor assembly properties
-    AssemblyProperty corAssemblyProperty{};
+    AssemblyProperty   corAssemblyProperty{};
     AssemblyReference* managed_profiler_assembly_reference;
 
     //
@@ -94,7 +90,7 @@ private:
     //
     // Module helper variables
     //
-    std::mutex module_ids_lock_;
+    std::mutex            module_ids_lock_;
     std::vector<ModuleID> module_ids_;
 
     //
@@ -109,7 +105,11 @@ private:
     //
     // Loader methods. These are only used on the .NET Framework.
     //
-    HRESULT RunAutoInstrumentationLoader(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token, const FunctionInfo& caller, const ModuleMetadata& module_metadata);
+    HRESULT RunAutoInstrumentationLoader(const ComPtr<IMetaDataEmit2>&,
+                                         const ModuleID        module_id,
+                                         const mdToken         function_token,
+                                         const FunctionInfo&   caller,
+                                         const ModuleMetadata& module_metadata);
     HRESULT GenerateLoaderMethod(const ModuleID module_id, mdMethodDef* ret_method_token);
     HRESULT GenerateLoaderType(const ModuleID module_id,
                                mdTypeDef*     loader_type,
@@ -135,8 +135,10 @@ private:
     // Helper methods
     //
     void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const WSTRING& nativemethods_type_name);
-    bool GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleID module_id,
-                               const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
+    bool GetIntegrationTypeRef(ModuleMetadata&              module_metadata,
+                               ModuleID                     module_id,
+                               const IntegrationDefinition& integration_definition,
+                               mdTypeRef&                   integration_type_ref);
     bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
 
     //
@@ -144,10 +146,15 @@ private:
     //
     void InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* items, int size, bool isDerived);
     bool InitThreadSampler();
-    void ConfigureContinuousProfilerInternal(const ContinuousProfilerParams& params);
+    void RecordCurrentThreadAssignmentForContinuousProfiler() noexcept;
+    bool TryEnterContinuousProfilerCallback(std::shared_lock<std::shared_mutex>& callbackLock) noexcept;
+    bool IsAllocationSamplingSupported() const noexcept override;
+    bool Bootstrap() noexcept override;
+    bool ApplyConfiguration(const continuous_profiler::RuntimeSamplerConfiguration& configuration) noexcept override;
+    void ShutdownSampling() noexcept override;
 
 public:
-    CorProfiler() = default;
+    CorProfiler();
 
     bool IsAttached() const;
 
@@ -155,13 +162,15 @@ public:
 
 #ifdef _WIN32
     // GetAssemblyAndSymbolsBytes is used when injecting the Loader into a .NET Framework application.
-    void GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assemblySize, BYTE** pSymbolsArray,
-                                    int* symbolsSize) const;
+    void GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray,
+                                    int*   assemblySize,
+                                    BYTE** pSymbolsArray,
+                                    int*   symbolsSize) const;
 
     // Return redirection table used in runtime
     // that will match TFM folder to load assemblies.
     // It may not be actual .NET Framework version.
-    int  GetNetFrameworkRedirectionVersion() const;
+    int GetNetFrameworkRedirectionVersion() const;
 #endif
 
     std::string GetILCodes(const std::string&              title,
@@ -196,17 +205,23 @@ public:
     // ReJIT Methods
     //
 
-    HRESULT STDMETHODCALLTYPE ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId,
-                                                      BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE ReJITCompilationStarted(FunctionID functionId,
+                                                      ReJITID    rejitId,
+                                                      BOOL       fIsSafeToBlock) override;
 
-    HRESULT STDMETHODCALLTYPE GetReJITParameters(ModuleID moduleId, mdMethodDef methodId,
+    HRESULT STDMETHODCALLTYPE GetReJITParameters(ModuleID                     moduleId,
+                                                 mdMethodDef                  methodId,
                                                  ICorProfilerFunctionControl* pFunctionControl) override;
 
-    HRESULT STDMETHODCALLTYPE ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus,
-                                                       BOOL fIsSafeToBlock) override;
+    HRESULT STDMETHODCALLTYPE ReJITCompilationFinished(FunctionID functionId,
+                                                       ReJITID    rejitId,
+                                                       HRESULT    hrStatus,
+                                                       BOOL       fIsSafeToBlock) override;
 
-    HRESULT STDMETHODCALLTYPE ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId,
-                                         HRESULT hrStatus) override;
+    HRESULT STDMETHODCALLTYPE ReJITError(ModuleID    moduleId,
+                                         mdMethodDef methodId,
+                                         FunctionID  functionId,
+                                         HRESULT     hrStatus) override;
 
     HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchStarted(FunctionID functionId, BOOL* pbUseCachedFunction) override;
 
@@ -232,7 +247,7 @@ public:
     //
     // ICorProfilerCallback6 methods
     //
-    HRESULT STDMETHODCALLTYPE GetAssemblyReferences(const WCHAR* wszAssemblyPath,
+    HRESULT STDMETHODCALLTYPE GetAssemblyReferences(const WCHAR*                           wszAssemblyPath,
                                                     ICorProfilerAssemblyReferenceProvider* pAsmRefProvider) override;
 
     //
@@ -247,8 +262,15 @@ public:
     //
     // Continuous Profiler methods
     //
-    void ConfigureContinuousProfiler(bool threadSamplingEnabled, unsigned int threadSamplingInterval, bool allocationSamplingEnabled, unsigned int maxMemorySamplesPerMinute, 
-        unsigned int selectedThreadsSamplingInterval);
+    void                                           ConfigureContinuousProfiler(bool         threadSamplingEnabled,
+                                                                               unsigned int threadSamplingInterval,
+                                                                               bool         allocationSamplingEnabled,
+                                                                               unsigned int maxMemorySamplesPerMinute,
+                                                                               unsigned int selectedThreadsSamplingInterval);
+    continuous_profiler::RuntimeSamplerApplyResult ApplyContinuousProfilerConfigurationV1(
+        const continuous_profiler::RuntimeSamplerConfigurationV1* configuration) noexcept;
+    continuous_profiler::RuntimeSamplerStateQueryResult GetContinuousProfilerStateV1(
+        continuous_profiler::RuntimeSamplerStateV1* state) const noexcept;
 
     //
     // IL Rewriting methods

--- a/src/OpenTelemetry.AutoInstrumentation.Native/interop.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/interop.cpp
@@ -58,6 +58,27 @@ EXTERN_C VOID STDAPICALLTYPE ConfigureContinuousProfiler(bool         threadSamp
                                                         selectedThreadSamplingInterval);
 }
 
+EXTERN_C INT32 STDAPICALLTYPE
+ApplyContinuousProfilerConfigurationV1(const continuous_profiler::RuntimeSamplerConfigurationV1* configuration)
+{
+    if (trace::profiler == nullptr)
+    {
+        return static_cast<INT32>(continuous_profiler::RuntimeSamplerApplyResult::ShuttingDown);
+    }
+
+    return static_cast<INT32>(trace::profiler->ApplyContinuousProfilerConfigurationV1(configuration));
+}
+
+EXTERN_C INT32 STDAPICALLTYPE GetContinuousProfilerStateV1(continuous_profiler::RuntimeSamplerStateV1* state)
+{
+    if (trace::profiler == nullptr)
+    {
+        return static_cast<INT32>(continuous_profiler::RuntimeSamplerStateQueryResult::InvalidArgument);
+    }
+
+    return static_cast<INT32>(trace::profiler->GetContinuousProfilerStateV1(state));
+}
+
 EXTERN_C VOID STDAPICALLTYPE InitializeTraceMethods(WCHAR* id,
                                                     WCHAR* integration_assembly_name_ptr,
                                                     WCHAR* integration_type_name_ptr,

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.cpp
@@ -22,6 +22,11 @@ NetFxRuntimeCapture::NetFxRuntimeCapture(IProfilerApi* profilerApi, const NetFxC
     trace::Logger::Info(L"[NetFxRuntimeCapture] Initialized with canary prefix: ", options_.canaryNamePrefix);
 }
 
+HRESULT NetFxRuntimeCapture::PrepareForStackWalking() noexcept
+{
+    return stackWalkGuard_ != nullptr && stackWalkGuard_->Start() ? S_OK : E_FAIL;
+}
+
 CanarySnapshot NetFxRuntimeCapture::SnapshotCanary() const
 {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.cpp
@@ -27,6 +27,14 @@ HRESULT NetFxRuntimeCapture::PrepareForStackWalking() noexcept
     return stackWalkGuard_ != nullptr && stackWalkGuard_->Start() ? S_OK : E_FAIL;
 }
 
+void NetFxRuntimeCapture::Stop() noexcept
+{
+    if (stackWalkGuard_ != nullptr)
+    {
+        stackWalkGuard_->Stop();
+    }
+}
+
 CanarySnapshot NetFxRuntimeCapture::SnapshotCanary() const
 {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.h
@@ -84,6 +84,7 @@ public:
     NetFxRuntimeCapture& operator=(const NetFxRuntimeCapture&) = delete;
 
     HRESULT PrepareForStackWalking() noexcept override;
+    void    Stop() noexcept override;
     HRESULT SuspendRuntime() override
     {
         return S_OK;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/netfx_runtime_capture.h
@@ -65,7 +65,7 @@ struct CanarySnapshot
 
 struct NetFxCaptureOptions
 {
-    std::chrono::milliseconds probeTimeout    = std::chrono::milliseconds(250);
+    std::chrono::milliseconds probeTimeout     = std::chrono::milliseconds(250);
     const wchar_t*            canaryNamePrefix = L"OpenTelemetry Profiler Canary Thread";
 
     bool IsCanaryThreadName(const std::wstring& threadName) const
@@ -77,31 +77,32 @@ struct NetFxCaptureOptions
 class NetFxRuntimeCapture final : public IRuntimeCapture
 {
 public:
-    explicit NetFxRuntimeCapture(IProfilerApi*              profilerApi,
-                                 const NetFxCaptureOptions& options = {});
+    explicit NetFxRuntimeCapture(IProfilerApi* profilerApi, const NetFxCaptureOptions& options = {});
     ~NetFxRuntimeCapture() = default;
 
     NetFxRuntimeCapture(const NetFxRuntimeCapture&)            = delete;
     NetFxRuntimeCapture& operator=(const NetFxRuntimeCapture&) = delete;
 
-    HRESULT SuspendRuntime() override { return S_OK; }
-    void    ResumeRuntime() noexcept override {}
+    HRESULT PrepareForStackWalking() noexcept override;
+    HRESULT SuspendRuntime() override
+    {
+        return S_OK;
+    }
+    void ResumeRuntime() noexcept override {}
 
-    HRESULT CaptureStack(ThreadID                      managedThreadId,
-                         StackSnapshotCallbackContext* clientData) override;
+    HRESULT CaptureStack(ThreadID managedThreadId, StackSnapshotCallbackContext* clientData) override;
 
     void OnThreadDestroyed(ThreadID threadId) override;
     void OnThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[]) override;
     void OnThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId) override;
 
-
 private:
     CanarySnapshot SnapshotCanary() const;
     void           ReelectCanaryLocked();
 
-    IProfilerApi*                          profilerApi_;
-    NetFxCaptureOptions                    options_;
-    std::unique_ptr<StackWalkGuard>        stackWalkGuard_;
+    IProfilerApi*                   profilerApi_;
+    NetFxCaptureOptions             options_;
+    std::unique_ptr<StackWalkGuard> stackWalkGuard_;
 #if defined(_M_AMD64)
     std::unique_ptr<SafeNativeWalkService> nativeWalk_;
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_capture.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_capture.h
@@ -28,6 +28,12 @@ public:
     virtual ~IRuntimeCapture() = default;
 
     /// <summary>
+    /// Starts any helper needed for safe stack walking. This must run before
+    /// SuspendRuntime or per-thread suspension begins.
+    /// </summary>
+    virtual HRESULT PrepareForStackWalking() noexcept = 0;
+
+    /// <summary>
     /// Bring the runtime to a state where one or more stacks can be walked.
     /// ClrRuntimeCapture: profiler-API SuspendRuntime (seedless DSS is safe
     ///   under runtime suspension; probes only run in the native-walk fallback).
@@ -46,8 +52,7 @@ public:
     /// thread resolution, per-thread suspension, safety checks, and the
     /// DSS (or future native-walk fallback) internally.
     /// </summary>
-    virtual HRESULT CaptureStack(ThreadID                       managedThreadId,
-                                 StackSnapshotCallbackContext*  clientData) = 0;
+    virtual HRESULT CaptureStack(ThreadID managedThreadId, StackSnapshotCallbackContext* clientData) = 0;
 
     // Lifecycle notifications routed from ICorProfilerCallback.
     // Default no-op; NetFxRuntimeCapture overrides for canary tracking.

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_capture.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_capture.h
@@ -64,7 +64,7 @@ public:
     /// <summary>
     /// Shutdown signal (release waiters, e.g. canary wait).  Default no-op.
     /// </summary>
-    virtual void Stop() {}
+    virtual void Stop() noexcept {}
 };
 
 } // namespace ProfilerStackCapture

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_configuration.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_configuration.cpp
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "runtime_sampler_configuration.h"
+
+namespace continuous_profiler
+{
+namespace
+{
+
+std::optional<std::uint32_t> Normalize(const std::uint32_t value) noexcept
+{
+    return value == 0 ? std::nullopt : std::optional<std::uint32_t>{value};
+}
+
+bool HasNonZeroReservedField(const RuntimeSamplerConfigurationV1& configuration) noexcept
+{
+    return configuration.reserved0 != 0 || configuration.reserved1 != 0 || configuration.reserved2 != 0;
+}
+
+RuntimeSamplerApplyResult ValidateConfiguration(const RuntimeSamplerConfiguration&    configuration,
+                                                const RuntimeSamplerAllocationSupport allocationSupport) noexcept
+{
+    const auto& periodicInterval  = configuration.periodicThreadSamplingIntervalMilliseconds;
+    const auto& selectiveInterval = configuration.selectiveThreadSamplingIntervalMilliseconds;
+
+    if (periodicInterval.has_value() && selectiveInterval.has_value() &&
+        (periodicInterval.value() <= selectiveInterval.value() ||
+         periodicInterval.value() % selectiveInterval.value() != 0))
+    {
+        return RuntimeSamplerApplyResult::RejectedInvalidConfiguration;
+    }
+
+    if (configuration.maxAllocationSamplesPerMinute.has_value() &&
+        allocationSupport != RuntimeSamplerAllocationSupport::Supported)
+    {
+        return RuntimeSamplerApplyResult::RejectedUnsupportedRuntime;
+    }
+
+    return RuntimeSamplerApplyResult::Applied;
+}
+
+RuntimeSamplerConfigurationV1 EncodeRuntimeSamplerConfigurationV1(
+    const RuntimeSamplerConfiguration& configuration) noexcept
+{
+    return {sizeof(RuntimeSamplerConfigurationV1),
+            kRuntimeSamplerSchemaVersionV1,
+            configuration.periodicThreadSamplingIntervalMilliseconds.value_or(0),
+            configuration.selectiveThreadSamplingIntervalMilliseconds.value_or(0),
+            configuration.maxAllocationSamplesPerMinute.value_or(0),
+            0,
+            0,
+            0};
+}
+
+} // namespace
+
+bool RuntimeSamplerConfiguration::HasThreadSampling() const noexcept
+{
+    return periodicThreadSamplingIntervalMilliseconds.has_value() ||
+           selectiveThreadSamplingIntervalMilliseconds.has_value();
+}
+
+bool RuntimeSamplerConfiguration::HasAllocationSampling() const noexcept
+{
+    return maxAllocationSamplesPerMinute.has_value();
+}
+
+bool RuntimeSamplerConfiguration::operator==(const RuntimeSamplerConfiguration& other) const noexcept
+{
+    return periodicThreadSamplingIntervalMilliseconds == other.periodicThreadSamplingIntervalMilliseconds &&
+           selectiveThreadSamplingIntervalMilliseconds == other.selectiveThreadSamplingIntervalMilliseconds &&
+           maxAllocationSamplesPerMinute == other.maxAllocationSamplesPerMinute;
+}
+
+bool RuntimeSamplerConfiguration::operator!=(const RuntimeSamplerConfiguration& other) const noexcept
+{
+    return !(*this == other);
+}
+
+RuntimeSamplerApplyResult DecodeRuntimeSamplerConfigurationV1(
+    const RuntimeSamplerConfigurationV1*  configuration,
+    const RuntimeSamplerAllocationSupport allocationSupport,
+    RuntimeSamplerConfiguration&          decodedConfiguration) noexcept
+{
+    if (configuration == nullptr)
+    {
+        return RuntimeSamplerApplyResult::RejectedInvalidArgument;
+    }
+
+    // structureSize is the only field read until the caller has declared the
+    // complete V1 payload. This prevents an undersized payload from being decoded.
+    if (configuration->structureSize != sizeof(RuntimeSamplerConfigurationV1))
+    {
+        return RuntimeSamplerApplyResult::RejectedUnsupportedSchema;
+    }
+
+    if (configuration->schemaVersion != kRuntimeSamplerSchemaVersionV1)
+    {
+        return RuntimeSamplerApplyResult::RejectedUnsupportedSchema;
+    }
+
+    if (HasNonZeroReservedField(*configuration))
+    {
+        return RuntimeSamplerApplyResult::RejectedReservedField;
+    }
+
+    RuntimeSamplerConfiguration candidate{Normalize(configuration->periodicThreadSamplingIntervalMilliseconds),
+                                          Normalize(configuration->selectiveThreadSamplingIntervalMilliseconds),
+                                          Normalize(configuration->maxAllocationSamplesPerMinute)};
+
+    const auto validationResult = ValidateConfiguration(candidate, allocationSupport);
+    if (validationResult != RuntimeSamplerApplyResult::Applied)
+    {
+        return validationResult;
+    }
+
+    decodedConfiguration = candidate;
+    return RuntimeSamplerApplyResult::Applied;
+}
+
+RuntimeSamplerStateQueryResult EncodeRuntimeSamplerStateV1(const RuntimeSamplerConfiguration& configuration,
+                                                           const std::uint64_t                generation,
+                                                           RuntimeSamplerStateV1*             state) noexcept
+{
+    if (state == nullptr)
+    {
+        return RuntimeSamplerStateQueryResult::InvalidArgument;
+    }
+
+    if (state->structureSize != sizeof(RuntimeSamplerStateV1))
+    {
+        return RuntimeSamplerStateQueryResult::UnsupportedSchema;
+    }
+
+    if (state->schemaVersion != kRuntimeSamplerSchemaVersionV1)
+    {
+        return RuntimeSamplerStateQueryResult::UnsupportedSchema;
+    }
+
+    if (HasNonZeroReservedField(state->activeConfiguration))
+    {
+        return RuntimeSamplerStateQueryResult::ReservedFieldNonZero;
+    }
+
+    RuntimeSamplerStateV1 encodedState{sizeof(RuntimeSamplerStateV1), kRuntimeSamplerSchemaVersionV1, generation,
+                                       EncodeRuntimeSamplerConfigurationV1(configuration)};
+
+    *state = encodedState;
+    return RuntimeSamplerStateQueryResult::Succeeded;
+}
+
+} // namespace continuous_profiler

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_configuration.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_configuration.h
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OTEL_RUNTIME_SAMPLER_CONFIGURATION_H_
+#define OTEL_RUNTIME_SAMPLER_CONFIGURATION_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+
+namespace continuous_profiler
+{
+
+constexpr std::uint32_t kRuntimeSamplerSchemaVersionV1 = 1;
+
+// Versioned request payload for the runtime sampler configuration ABI. Numeric
+// zero disables the corresponding producer. Reserved fields must be zero.
+struct RuntimeSamplerConfigurationV1
+{
+    std::uint32_t structureSize;
+    std::uint32_t schemaVersion;
+    std::uint32_t periodicThreadSamplingIntervalMilliseconds;
+    std::uint32_t selectiveThreadSamplingIntervalMilliseconds;
+    std::uint32_t maxAllocationSamplesPerMinute;
+    std::uint32_t reserved0;
+    std::uint32_t reserved1;
+    std::uint32_t reserved2;
+};
+
+// Versioned output payload used by a state-query export. The active
+// configuration is one complete normalized snapshot.
+struct RuntimeSamplerStateV1
+{
+    std::uint32_t                 structureSize;
+    std::uint32_t                 schemaVersion;
+    std::uint64_t                 generation;
+    RuntimeSamplerConfigurationV1 activeConfiguration;
+};
+
+// These values are part of the exported ABI contract. Do not reorder them.
+enum class RuntimeSamplerApplyResult : std::int32_t
+{
+    Applied                      = 0,
+    NoChange                     = 1,
+    IgnoredInitialConfiguration  = 2,
+    RejectedInvalidArgument      = 3,
+    RejectedUnsupportedSchema    = 4,
+    RejectedReservedField        = 5,
+    RejectedInvalidConfiguration = 6,
+    RejectedUnsupportedRuntime   = 7,
+    BootstrapFailed              = 8,
+    ActivationFailed             = 9,
+    ShuttingDown                 = 10
+};
+
+// These values are part of the exported ABI contract. Do not reorder them.
+enum class RuntimeSamplerStateQueryResult : std::int32_t
+{
+    Succeeded            = 0,
+    InvalidArgument      = 1,
+    UnsupportedSchema    = 2,
+    ReservedFieldNonZero = 3
+};
+
+enum class RuntimeSamplerAllocationSupport : std::uint8_t
+{
+    Unsupported = 0,
+    Supported   = 1
+};
+
+// Canonical native value. An empty optional means that the corresponding
+// sampling mode is disabled.
+struct RuntimeSamplerConfiguration
+{
+    std::optional<std::uint32_t> periodicThreadSamplingIntervalMilliseconds;
+    std::optional<std::uint32_t> selectiveThreadSamplingIntervalMilliseconds;
+    std::optional<std::uint32_t> maxAllocationSamplesPerMinute;
+
+    bool HasThreadSampling() const noexcept;
+    bool HasAllocationSampling() const noexcept;
+    bool operator==(const RuntimeSamplerConfiguration& other) const noexcept;
+    bool operator!=(const RuntimeSamplerConfiguration& other) const noexcept;
+};
+
+// Decodes and validates one complete candidate without performing any producer
+// lifecycle work. The output remains unchanged when the candidate is rejected.
+RuntimeSamplerApplyResult DecodeRuntimeSamplerConfigurationV1(
+    const RuntimeSamplerConfigurationV1* configuration,
+    RuntimeSamplerAllocationSupport      allocationSupport,
+    RuntimeSamplerConfiguration&         decodedConfiguration) noexcept;
+
+// Encodes the authoritative native value for a state-query response. The caller
+// initializes structureSize and schemaVersion and zeroes all reserved fields in
+// activeConfiguration before calling this function.
+RuntimeSamplerStateQueryResult EncodeRuntimeSamplerStateV1(const RuntimeSamplerConfiguration& configuration,
+                                                           std::uint64_t                      generation,
+                                                           RuntimeSamplerStateV1*             state) noexcept;
+
+static_assert(sizeof(std::uint32_t) == 4, "Runtime sampler ABI requires 32-bit uint32_t.");
+static_assert(sizeof(std::uint64_t) == 8, "Runtime sampler ABI requires 64-bit uint64_t.");
+
+static_assert(std::is_standard_layout<RuntimeSamplerConfigurationV1>::value,
+              "RuntimeSamplerConfigurationV1 must have a stable ABI layout.");
+static_assert(std::is_trivially_copyable<RuntimeSamplerConfigurationV1>::value,
+              "RuntimeSamplerConfigurationV1 must be trivially copyable.");
+static_assert(sizeof(RuntimeSamplerConfigurationV1) == 32, "RuntimeSamplerConfigurationV1 ABI size changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, structureSize) == 0,
+              "RuntimeSamplerConfigurationV1.structureSize ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, schemaVersion) == 4,
+              "RuntimeSamplerConfigurationV1.schemaVersion ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, periodicThreadSamplingIntervalMilliseconds) == 8,
+              "RuntimeSamplerConfigurationV1.periodicThreadSamplingIntervalMilliseconds ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, selectiveThreadSamplingIntervalMilliseconds) == 12,
+              "RuntimeSamplerConfigurationV1.selectiveThreadSamplingIntervalMilliseconds ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, maxAllocationSamplesPerMinute) == 16,
+              "RuntimeSamplerConfigurationV1.maxAllocationSamplesPerMinute ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, reserved0) == 20,
+              "RuntimeSamplerConfigurationV1.reserved0 ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, reserved1) == 24,
+              "RuntimeSamplerConfigurationV1.reserved1 ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerConfigurationV1, reserved2) == 28,
+              "RuntimeSamplerConfigurationV1.reserved2 ABI offset changed.");
+
+static_assert(std::is_standard_layout<RuntimeSamplerStateV1>::value,
+              "RuntimeSamplerStateV1 must have a stable ABI layout.");
+static_assert(std::is_trivially_copyable<RuntimeSamplerStateV1>::value,
+              "RuntimeSamplerStateV1 must be trivially copyable.");
+static_assert(sizeof(RuntimeSamplerStateV1) == 48, "RuntimeSamplerStateV1 ABI size changed.");
+static_assert(offsetof(RuntimeSamplerStateV1, structureSize) == 0,
+              "RuntimeSamplerStateV1.structureSize ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerStateV1, schemaVersion) == 4,
+              "RuntimeSamplerStateV1.schemaVersion ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerStateV1, generation) == 8, "RuntimeSamplerStateV1.generation ABI offset changed.");
+static_assert(offsetof(RuntimeSamplerStateV1, activeConfiguration) == 16,
+              "RuntimeSamplerStateV1.activeConfiguration ABI offset changed.");
+
+static_assert(sizeof(RuntimeSamplerApplyResult) == 4, "RuntimeSamplerApplyResult ABI size changed.");
+static_assert(sizeof(RuntimeSamplerStateQueryResult) == 4, "RuntimeSamplerStateQueryResult ABI size changed.");
+
+} // namespace continuous_profiler
+
+#endif // OTEL_RUNTIME_SAMPLER_CONFIGURATION_H_

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.cpp
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "runtime_sampler_controller.h"
+
+namespace continuous_profiler
+{
+
+RuntimeSamplerController::RuntimeSamplerController(IRuntimeSamplerLifecycle& lifecycle) noexcept : lifecycle_(lifecycle)
+{
+}
+
+RuntimeSamplerController::~RuntimeSamplerController()
+{
+    Shutdown();
+}
+
+bool RuntimeSamplerController::Prepare() noexcept
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+    return !shutdown_requested_ && EnsureBootstrappedLocked();
+}
+
+RuntimeSamplerApplyResult RuntimeSamplerController::ApplyConfiguration(
+    const RuntimeSamplerConfiguration& configuration) noexcept
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+    return ApplyConfigurationLocked(configuration, false);
+}
+
+RuntimeSamplerApplyResult RuntimeSamplerController::ApplyInitialConfiguration(
+    const RuntimeSamplerConfiguration& configuration) noexcept
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+    return ApplyConfigurationLocked(configuration, true);
+}
+
+RuntimeSamplerControllerState RuntimeSamplerController::GetState() const noexcept
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+    return {active_configuration_, generation_};
+}
+
+void RuntimeSamplerController::Shutdown() noexcept
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (shutdown_requested_)
+    {
+        return;
+    }
+
+    shutdown_requested_ = true;
+    if (bootstrap_attempted_)
+    {
+        lifecycle_.ShutdownSampling();
+    }
+}
+
+RuntimeSamplerApplyResult RuntimeSamplerController::ApplyConfigurationLocked(
+    const RuntimeSamplerConfiguration& configuration, const bool establishInitialConfiguration) noexcept
+{
+    if (shutdown_requested_)
+    {
+        return RuntimeSamplerApplyResult::ShuttingDown;
+    }
+
+    if (establishInitialConfiguration && configuration_established_)
+    {
+        return RuntimeSamplerApplyResult::IgnoredInitialConfiguration;
+    }
+
+    // A first, explicitly supplied all-disabled initial configuration is an
+    // established state even though it equals the controller's zero state.
+    const bool establishesExplicitAllDisabledConfiguration =
+        !configuration_established_ && !configuration.HasThreadSampling() && !configuration.HasAllocationSampling();
+
+    if (!establishesExplicitAllDisabledConfiguration && configuration == active_configuration_)
+    {
+        return RuntimeSamplerApplyResult::NoChange;
+    }
+
+    if (configuration.HasAllocationSampling() && !lifecycle_.IsAllocationSamplingSupported())
+    {
+        return RuntimeSamplerApplyResult::RejectedUnsupportedRuntime;
+    }
+
+    const bool requiresBootstrap = configuration.HasThreadSampling() || configuration.HasAllocationSampling();
+    if (requiresBootstrap && !EnsureBootstrappedLocked())
+    {
+        return RuntimeSamplerApplyResult::BootstrapFailed;
+    }
+
+    // Once bootstrap has succeeded, even an all-disabled candidate must reach
+    // the lifecycle so that already-created producers are quiesced.
+    if (bootstrap_succeeded_ && !lifecycle_.ApplyConfiguration(configuration))
+    {
+        return RuntimeSamplerApplyResult::ActivationFailed;
+    }
+
+    active_configuration_      = configuration;
+    configuration_established_ = true;
+    generation_++;
+    return RuntimeSamplerApplyResult::Applied;
+}
+
+bool RuntimeSamplerController::EnsureBootstrappedLocked() noexcept
+{
+    if (!bootstrap_attempted_)
+    {
+        bootstrap_attempted_ = true;
+        bootstrap_succeeded_ = lifecycle_.Bootstrap();
+    }
+
+    return bootstrap_succeeded_;
+}
+
+} // namespace continuous_profiler

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.cpp
@@ -15,12 +15,6 @@ RuntimeSamplerController::~RuntimeSamplerController()
     Shutdown();
 }
 
-bool RuntimeSamplerController::Prepare() noexcept
-{
-    std::lock_guard<std::mutex> guard(mutex_);
-    return !shutdown_requested_ && EnsureBootstrappedLocked();
-}
-
 RuntimeSamplerApplyResult RuntimeSamplerController::ApplyConfiguration(
     const RuntimeSamplerConfiguration& configuration) noexcept
 {
@@ -90,9 +84,10 @@ RuntimeSamplerApplyResult RuntimeSamplerController::ApplyConfigurationLocked(
         return RuntimeSamplerApplyResult::BootstrapFailed;
     }
 
-    // Once bootstrap has succeeded, even an all-disabled candidate must reach
-    // the lifecycle so that already-created producers are quiesced.
-    if (bootstrap_succeeded_ && !lifecycle_.ApplyConfiguration(configuration))
+    // Once bootstrap has succeeded, even an all-disabled candidate reaches the
+    // lifecycle so that any producer resources left by a failed transition can
+    // be quiesced before controller state is established.
+    if (bootstrap_succeeded_ && !lifecycle_.ApplyConfiguration(active_configuration_, configuration))
     {
         return RuntimeSamplerApplyResult::ActivationFailed;
     }

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.h
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OTEL_RUNTIME_SAMPLER_CONTROLLER_H_
+#define OTEL_RUNTIME_SAMPLER_CONTROLLER_H_
+
+#include "runtime_sampler_configuration.h"
+
+#include <cstdint>
+#include <mutex>
+
+namespace continuous_profiler
+{
+
+// Separates configuration ownership from the CLR-specific producer lifecycle.
+// Implementations must either apply the complete configuration or return false
+// while retaining their previous effective producer state.
+class IRuntimeSamplerLifecycle
+{
+public:
+    virtual ~IRuntimeSamplerLifecycle() = default;
+
+    virtual bool IsAllocationSamplingSupported() const noexcept                                = 0;
+    virtual bool Bootstrap() noexcept                                                          = 0;
+    virtual bool ApplyConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept = 0;
+    virtual void ShutdownSampling() noexcept                                                   = 0;
+};
+
+struct RuntimeSamplerControllerState
+{
+    RuntimeSamplerConfiguration configuration;
+    std::uint64_t               generation;
+};
+
+// Owns the authoritative runtime sampler configuration. All transitions are
+// serialized, and state is published only after the lifecycle accepts the
+// complete candidate.
+class RuntimeSamplerController
+{
+public:
+    explicit RuntimeSamplerController(IRuntimeSamplerLifecycle& lifecycle) noexcept;
+    ~RuntimeSamplerController();
+
+    RuntimeSamplerController(const RuntimeSamplerController&)            = delete;
+    RuntimeSamplerController& operator=(const RuntimeSamplerController&) = delete;
+
+    // Initializes the sampler foundation without applying a configuration or
+    // starting any sampling producer. A failed preparation is sticky, just as
+    // a bootstrap requested by an apply is.
+    bool                          Prepare() noexcept;
+    RuntimeSamplerApplyResult     ApplyConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept;
+    RuntimeSamplerApplyResult     ApplyInitialConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept;
+    RuntimeSamplerControllerState GetState() const noexcept;
+    void                          Shutdown() noexcept;
+
+private:
+    RuntimeSamplerApplyResult ApplyConfigurationLocked(const RuntimeSamplerConfiguration& configuration,
+                                                       bool establishInitialConfiguration) noexcept;
+    bool                      EnsureBootstrappedLocked() noexcept;
+
+    IRuntimeSamplerLifecycle&   lifecycle_;
+    mutable std::mutex          mutex_;
+    RuntimeSamplerConfiguration active_configuration_;
+    std::uint64_t               generation_                = 0;
+    bool                        configuration_established_ = false;
+    bool                        bootstrap_attempted_       = false;
+    bool                        bootstrap_succeeded_       = false;
+    bool                        shutdown_requested_        = false;
+};
+
+} // namespace continuous_profiler
+
+#endif // OTEL_RUNTIME_SAMPLER_CONTROLLER_H_

--- a/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.h
@@ -22,7 +22,8 @@ public:
 
     virtual bool IsAllocationSamplingSupported() const noexcept                                = 0;
     virtual bool Bootstrap() noexcept                                                          = 0;
-    virtual bool ApplyConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept = 0;
+    virtual bool ApplyConfiguration(const RuntimeSamplerConfiguration& previousConfiguration,
+                                    const RuntimeSamplerConfiguration& configuration) noexcept = 0;
     virtual void ShutdownSampling() noexcept                                                   = 0;
 };
 
@@ -44,10 +45,6 @@ public:
     RuntimeSamplerController(const RuntimeSamplerController&)            = delete;
     RuntimeSamplerController& operator=(const RuntimeSamplerController&) = delete;
 
-    // Initializes the sampler foundation without applying a configuration or
-    // starting any sampling producer. A failed preparation is sticky, just as
-    // a bootstrap requested by an apply is.
-    bool                          Prepare() noexcept;
     RuntimeSamplerApplyResult     ApplyConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept;
     RuntimeSamplerApplyResult     ApplyInitialConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept;
     RuntimeSamplerControllerState GetState() const noexcept;

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.cpp
@@ -54,6 +54,11 @@ public:
 
     ~StackCaptureImpl() override = default;
 
+    HRESULT PrepareForStackWalking() noexcept override
+    {
+        return runtime_ != nullptr ? runtime_->PrepareForStackWalking() : E_FAIL;
+    }
+
     HRESULT CaptureStacks(const std::unordered_set<ThreadID>& threads, void* clientData) override
     {
         if (threads.empty())

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.cpp
@@ -25,9 +25,10 @@ namespace ProfilerStackCapture
 /// All probe and walk machinery is owned by each IRuntimeCapture instance;
 /// this class only orchestrates the batch lifecycle and dispatch.
 ///
-/// Shutdown: implicit via member destruction order. runtime_ is declared
-/// after profilerApi_ so it is destroyed first - joining its StackWalkGuard
-/// worker thread before the IProfilerApi it references is destroyed.
+/// Shutdown: Stop() terminates runtime helpers without destroying this
+/// callback-visible facade. Member destruction remains a fallback: runtime_
+/// is declared after profilerApi_ so it is destroyed first, joining its
+/// StackWalkGuard worker before the IProfilerApi it references is destroyed.
 ///
 /// Destructor chain:
 ///
@@ -57,6 +58,14 @@ public:
     HRESULT PrepareForStackWalking() noexcept override
     {
         return runtime_ != nullptr ? runtime_->PrepareForStackWalking() : E_FAIL;
+    }
+
+    void Stop() noexcept override
+    {
+        if (runtime_ != nullptr)
+        {
+            runtime_->Stop();
+        }
     }
 
     HRESULT CaptureStacks(const std::unordered_set<ThreadID>& threads, void* clientData) override

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.h
@@ -28,6 +28,11 @@ public:
     virtual ~IStackCapturer() = default;
 
     /// <summary>
+    /// Starts stack-walking helpers before any runtime or thread suspension.
+    /// </summary>
+    virtual HRESULT PrepareForStackWalking() noexcept = 0;
+
+    /// <summary>
     /// Captures stacks for specified threads via seedless DoStackSnapshot.
     /// And uses RTL based native walk fallback on Windows x64 when DSS fails (e.g. thread in native code with no
     /// managed frames on top).
@@ -35,7 +40,7 @@ public:
     /// <param name="threads">Set of managed thread IDs to capture</param>
     /// <param name="clientData">Callback context passed to DoStackSnapshotUnseeded</param>
     /// <returns>S_OK on success, error HRESULT otherwise</returns>
-    /// 
+    ///
     /// THREAD SAFETY CONTRACT:
     /// - Caller MUST NOT hold locks that sampled threads might acquire
     /// - Implementation handles ALL suspension/resume logic
@@ -49,7 +54,7 @@ public:
     {
         (void)instructionPointer;
         (void)outName;
-        return S_FALSE;  // Not available in seedless phase
+        return S_FALSE; // Not available in seedless phase
     }
 
     // Thread lifecycle notifications (for future NetFx canary coordination)
@@ -66,9 +71,8 @@ public:
 /// <param name="profilerInfo">CLR profiler API</param>
 /// <param name="runtimeType">Runtime being profiled (.NET Core or .NET Framework)</param>
 /// <returns>Heap-allocated capturer (caller owns), or nullptr on error</returns>
-std::unique_ptr<IStackCapturer> CreateStackCapturer(
-    ICorProfilerInfo2*  profilerInfo,
-    continuous_profiler::RuntimeType runtimeType);
+std::unique_ptr<IStackCapturer> CreateStackCapturer(ICorProfilerInfo2*               profilerInfo,
+                                                    continuous_profiler::RuntimeType runtimeType);
 
 } // namespace ProfilerStackCapture
 

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_capturer.h
@@ -33,6 +33,11 @@ public:
     virtual HRESULT PrepareForStackWalking() noexcept = 0;
 
     /// <summary>
+    /// Stops stack-walking helpers while retaining this callback-visible facade.
+    /// </summary>
+    virtual void Stop() noexcept = 0;
+
+    /// <summary>
     /// Captures stacks for specified threads via seedless DoStackSnapshot.
     /// And uses RTL based native walk fallback on Windows x64 when DSS fails (e.g. thread in native code with no
     /// managed frames on top).

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.cpp
@@ -74,7 +74,6 @@ StackWalkGuard::StackWalkGuard(IProfilerApi*             profilerApi,
                                std::chrono::milliseconds probe_timeout)
     : api_(profilerApi), park_timeout_(park_timeout), probe_timeout_(probe_timeout)
 {
-    worker_ = std::make_unique<std::thread>([this]() { WorkerLoop(); });
 }
 
 StackWalkGuard::~StackWalkGuard()
@@ -89,15 +88,53 @@ StackWalkGuard::~StackWalkGuard()
     worker_.reset();
 }
 
+bool StackWalkGuard::Start() noexcept
+{
+    std::lock_guard<std::mutex> lk(mutex_);
+    if (state_ == State::Stopping)
+    {
+        return false;
+    }
+
+    if (worker_ != nullptr)
+    {
+        return true;
+    }
+
+    try
+    {
+        worker_ = std::make_unique<std::thread>([this]() { WorkerLoop(); });
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
 bool StackWalkGuard::IsIdle() const noexcept
 {
     std::lock_guard<std::mutex> lk(mutex_);
     return state_ == State::Idle;
 }
 
+bool StackWalkGuard::IsStarted() const noexcept
+{
+    std::lock_guard<std::mutex> lk(mutex_);
+    return worker_ != nullptr;
+}
+
 bool StackWalkGuard::Schedule(const ProbeRequest& req)
 {
     std::unique_lock<std::mutex> lk(mutex_);
+
+    // Starting a thread here is unsafe: callers schedule probes only after
+    // suspending the runtime or an application thread. The worker must have
+    // been prepared before sampling begins.
+    if (worker_ == nullptr)
+    {
+        return false;
+    }
 
     // Wait for the worker to be Idle. Idle covers both "fresh" and
     // "previous verdict published but not yet consumed" - either way the

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.cpp
@@ -78,14 +78,23 @@ StackWalkGuard::StackWalkGuard(IProfilerApi*             profilerApi,
 
 StackWalkGuard::~StackWalkGuard()
 {
+    Stop();
+}
+
+void StackWalkGuard::Stop() noexcept
+{
+    std::unique_ptr<std::thread> worker;
     {
         std::lock_guard<std::mutex> lk(mutex_);
-        state_ = State::Stopping;
+        abandon_ = true;
+        state_   = State::Stopping;
+        worker   = std::move(worker_);
     }
     cv_.notify_all();
-    if (worker_ && worker_->joinable())
-        worker_->join();
-    worker_.reset();
+    if (worker != nullptr && worker->joinable())
+    {
+        worker->join();
+    }
 }
 
 bool StackWalkGuard::Start() noexcept
@@ -273,6 +282,10 @@ void StackWalkGuard::WorkerLoop()
         {
             {
                 std::lock_guard<std::mutex> lk(mutex_);
+                if (state_ == State::Stopping)
+                {
+                    break;
+                }
                 result_ = ProbeResult::Failed;
                 state_  = State::Idle;
                 SetStage(ProbeStage::None);

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.h
@@ -112,6 +112,10 @@ public:
     // profiler does not create a helper thread.
     bool Start() noexcept;
 
+    // Stops and joins the safety worker. Call from outside the safety worker.
+    // Idempotent and terminal: Start() rejects attempts to restart afterwards.
+    void Stop() noexcept;
+
     // CanaryDss: STL gate + (if canary != 0) DSS on a coast-clear thread.
     // canary == 0 reduces to STL-only.
     // Available on all Windows architectures.

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.h
@@ -107,6 +107,11 @@ public:
     StackWalkGuard(const StackWalkGuard&)            = delete;
     StackWalkGuard& operator=(const StackWalkGuard&) = delete;
 
+    // Starts the safety worker before any sampled thread or runtime is
+    // suspended. Construction is intentionally dormant so an all-disabled
+    // profiler does not create a helper thread.
+    bool Start() noexcept;
+
     // CanaryDss: STL gate + (if canary != 0) DSS on a coast-clear thread.
     // canary == 0 reduces to STL-only.
     // Available on all Windows architectures.
@@ -119,6 +124,9 @@ public:
 
     // True if the worker is Idle (diagnostic).
     bool IsIdle() const noexcept;
+
+    // True after the safety worker has been started (diagnostic).
+    bool IsStarted() const noexcept;
 
 #if defined(_M_AMD64)
     // RtlFrame0 probe (x64 only).
@@ -206,8 +214,8 @@ private:
     bool Schedule(const ProbeRequest& req);
 
     void WorkerLoop();
-    bool RunChecks(ProbeRequest& req) noexcept;          // dispatch on req.kind; may stage outputs
-    bool RunCanaryChecks(ThreadID canary) noexcept;      // heap envelope + optional canary DSS
+    bool RunChecks(ProbeRequest& req) noexcept;     // dispatch on req.kind; may stage outputs
+    bool RunCanaryChecks(ThreadID canary) noexcept; // heap envelope + optional canary DSS
 #if defined(_M_AMD64)
     bool RunRtlFrame0Checks(ProbeRequest& req) noexcept; // cooperative RTL frame-0 (x64 only)
 #endif

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_walker.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_walker.h
@@ -10,7 +10,6 @@
 #include <unordered_set>
 #include "string_utils.h"
 
-
 namespace continuous_profiler
 {
 /// @brief Forward declaration of per-frame data contract delivered to the consumer during stack capture.
@@ -34,14 +33,16 @@ class IStackWalker
 public:
     virtual ~IStackWalker() = default;
 
+    /// @brief Starts stack-walking helpers before sampling can suspend the
+    /// runtime or an application thread.
+    virtual HRESULT PrepareForStackWalking() noexcept = 0;
+
     /// @brief Capture stacks for the given threads.
     /// Implementation owns all suspension/resume logic.
-    virtual HRESULT CaptureStacks(const std::unordered_set<ThreadID>& threads,
-                                  StackCaptureRequest*                request) = 0;
+    virtual HRESULT CaptureStacks(const std::unordered_set<ThreadID>& threads, StackCaptureRequest* request) = 0;
 
     /// @brief Resolve a native IP to a human-readable symbol name.
-    virtual HRESULT ResolveNativeSymbolName(UINT_PTR        instructionPointer,
-                                            trace::WSTRING& outName) = 0;
+    virtual HRESULT ResolveNativeSymbolName(UINT_PTR instructionPointer, trace::WSTRING& outName) = 0;
 };
 
 /// @brief Lifecycle events forwarded from CLR callbacks.

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_walker_impl.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_walker_impl.h
@@ -32,6 +32,15 @@ public:
         return capturer_ != nullptr ? capturer_->PrepareForStackWalking() : E_FAIL;
     }
 
+    /// @brief Stops helper threads while retaining this callback-visible facade.
+    void Stop() noexcept
+    {
+        if (capturer_ != nullptr)
+        {
+            capturer_->Stop();
+        }
+    }
+
     HRESULT CaptureStacks(const std::unordered_set<ThreadID>& threads, StackCaptureRequest* request) override
     {
         if (capturer_ == nullptr)

--- a/src/OpenTelemetry.AutoInstrumentation.Native/stack_walker_impl.h
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/stack_walker_impl.h
@@ -20,16 +20,19 @@ namespace continuous_profiler
 class StackWalkerImpl : public IStackWalker, public IThreadLifecycleListener
 {
 public:
-    explicit StackWalkerImpl(ICorProfilerInfo2* profilerInfo,
-                             RuntimeType        runtimeType)
+    explicit StackWalkerImpl(ICorProfilerInfo2* profilerInfo, RuntimeType runtimeType)
         : capturer_(ProfilerStackCapture::CreateStackCapturer(profilerInfo, runtimeType))
-        
+
     {
     }
 
     // -- IStackWalker (consumed by ContinuousProfiler) --
-    HRESULT CaptureStacks(const std::unordered_set<ThreadID>& threads,
-                          StackCaptureRequest*                request) override
+    HRESULT PrepareForStackWalking() noexcept override
+    {
+        return capturer_ != nullptr ? capturer_->PrepareForStackWalking() : E_FAIL;
+    }
+
+    HRESULT CaptureStacks(const std::unordered_set<ThreadID>& threads, StackCaptureRequest* request) override
     {
         if (capturer_ == nullptr)
         {
@@ -41,18 +44,14 @@ public:
         }
 
         // Zero-copy bridge: forward the embedded CapturedFrame to the consumer.
-        auto bridgeCallback =
-            [request](ProfilerStackCapture::StackSnapshotCallbackContext* ctx) -> HRESULT
-        {
-            return request->onFrame(&ctx->frame);
-        };
+        auto bridgeCallback = [request](ProfilerStackCapture::StackSnapshotCallbackContext* ctx) -> HRESULT
+        { return request->onFrame(&ctx->frame); };
 
         ProfilerStackCapture::StackSnapshotCallbackContext context{bridgeCallback};
         return capturer_->CaptureStacks(threads, &context);
     }
 
-    HRESULT ResolveNativeSymbolName(UINT_PTR        instructionPointer,
-                                    trace::WSTRING& outName) override
+    HRESULT ResolveNativeSymbolName(UINT_PTR instructionPointer, trace::WSTRING& outName) override
     {
         return capturer_ ? capturer_->ResolveNativeSymbolName(instructionPointer, outName) : E_FAIL;
     }

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/OpenTelemetry.AutoInstrumentation.Native.Tests.vcxproj
@@ -71,6 +71,8 @@
     <ClCompile Include="integration_test.cpp" />
     <ClCompile Include="clr_helper_test.cpp" />
     <ClCompile Include="metadata_builder_test.cpp" />
+    <ClCompile Include="continuous_profiler_batch_test.cpp" />
+    <ClCompile Include="continuous_profiler_lifecycle_test.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -79,6 +81,9 @@
     </ClCompile>
     <ClCompile Include="startup_hook_test.cpp" />
     <ClCompile Include="thread_span_context_test.cpp" />
+    <ClCompile Include="runtime_sampler_configuration_test.cpp" />
+    <ClCompile Include="runtime_sampler_controller_test.cpp" />
+    <ClCompile Include="stack_walk_guard_test.cpp" />
     <ClCompile Include="util_test.cpp" />
     <ClCompile Include="version_struct_test.cpp" />
   </ItemGroup>

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_batch_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_batch_test.cpp
@@ -1,0 +1,267 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pch.h"
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h"
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace
+{
+
+constexpr std::size_t kTestSamplesBufferMaximumSize = 200 * 1024;
+
+class ContinuousProfilerBatchTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        Drain();
+    }
+
+    void TearDown() override
+    {
+        Drain();
+    }
+
+    static void Drain()
+    {
+        unsigned char output[8];
+        unsigned int  interval = 0;
+        while (ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval) > 0)
+        {
+        }
+    }
+
+    static void Record(const unsigned char value, const unsigned int interval)
+    {
+        ThreadSamplingRecordProducedThreadSample(new std::vector<unsigned char>{value}, interval);
+    }
+
+    static void Record(const std::initializer_list<unsigned char> values, const unsigned int interval)
+    {
+        ThreadSamplingRecordProducedThreadSample(new std::vector<unsigned char>(values), interval);
+    }
+};
+
+class ContinuousProfilerAuxiliaryBufferTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        Drain();
+    }
+
+    void TearDown() override
+    {
+        Drain();
+    }
+
+    static void Drain()
+    {
+        std::vector<unsigned char> output(kTestSamplesBufferMaximumSize);
+        ContinuousProfilerReadAllocationSamples(static_cast<std::int32_t>(output.size()), output.data());
+        SelectiveSamplerReadThreadSamples(static_cast<std::int32_t>(output.size()), output.data());
+    }
+};
+
+} // namespace
+
+TEST_F(ContinuousProfilerBatchTest, ExtendedReaderReturnsTheIntervalStoredWithEachBatch)
+{
+    using ExtendedReader = std::int32_t(STDAPICALLTYPE*)(std::int32_t, unsigned char*, std::uint32_t*);
+    static_assert(std::is_same<decltype(&ContinuousProfilerReadThreadSamplesV2), ExtendedReader>::value,
+                  "The V2 reader ABI changed.");
+
+    Record(0x11, 1000u);
+    Record(0x22, 2000u);
+
+    unsigned char output[1];
+    unsigned int  interval = 0;
+
+    ASSERT_EQ(1, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0x11, output[0]);
+    ASSERT_EQ(1000u, interval);
+
+    ASSERT_EQ(1, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0x22, output[0]);
+    ASSERT_EQ(2000u, interval);
+
+    interval = 99u;
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0u, interval);
+}
+
+TEST_F(ContinuousProfilerBatchTest, LegacyReaderKeepsItsAbiAndConsumesTheSameQueue)
+{
+    using LegacyReader = std::int32_t (*)(std::int32_t, unsigned char*);
+    static_assert(std::is_same<decltype(&ContinuousProfilerReadThreadSamples), LegacyReader>::value,
+                  "The legacy reader ABI changed.");
+
+    Record(0x11, 1000u);
+    Record(0x22, 2000u);
+
+    unsigned char output[1];
+    ASSERT_EQ(1, ContinuousProfilerReadThreadSamples(sizeof(output), output));
+    ASSERT_EQ(0x11, output[0]);
+
+    unsigned int interval = 0;
+    ASSERT_EQ(1, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0x22, output[0]);
+    ASSERT_EQ(2000u, interval);
+}
+
+TEST_F(ContinuousProfilerBatchTest, InvalidExtendedReadDoesNotConsumeThePendingBatch)
+{
+    Record(0x11, 1000u);
+
+    unsigned char output[1];
+    unsigned int  interval = 99u;
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(0, output, &interval));
+    ASSERT_EQ(0u, interval);
+
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, nullptr));
+
+    ASSERT_EQ(1, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0x11, output[0]);
+    ASSERT_EQ(1000u, interval);
+}
+
+TEST_F(ContinuousProfilerBatchTest, UndersizedExtendedReadDropsTheWholeBatchWithoutReturningAPrefix)
+{
+    Record({0x11, 0x22}, 1000u);
+
+    unsigned char output   = 0xEE;
+    unsigned int  interval = 99u;
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(sizeof(output), &output, &interval));
+    ASSERT_EQ(0xEE, output);
+    ASSERT_EQ(0u, interval);
+
+    unsigned char remaining[2] = {0xEE, 0xEE};
+    interval                   = 99u;
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(sizeof(remaining), remaining, &interval));
+    ASSERT_EQ(0u, interval);
+    ASSERT_TRUE(ThreadSamplingShouldProduceThreadSample());
+}
+
+TEST_F(ContinuousProfilerBatchTest, UndersizedLegacyReadDropsTheWholeBatchWithoutReturningAPrefix)
+{
+    Record({0x11, 0x22}, 1000u);
+
+    unsigned char output = 0xEE;
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamples(sizeof(output), &output));
+    ASSERT_EQ(0xEE, output);
+
+    unsigned char remaining[2] = {0xEE, 0xEE};
+    unsigned int  interval     = 99u;
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(sizeof(remaining), remaining, &interval));
+    ASSERT_EQ(0u, interval);
+    ASSERT_TRUE(ThreadSamplingShouldProduceThreadSample());
+}
+
+TEST_F(ContinuousProfilerBatchTest, OverflowedWriterDoesNotPublishAMalformedBatch)
+{
+    continuous_profiler::ContinuousProfiler profiler;
+    profiler.AllocateBuffer();
+
+    ASSERT_NE(nullptr, profiler.cur_cpu_writer_);
+    profiler.cur_cpu_writer_->StartBatch();
+
+    continuous_profiler::ThreadState state;
+    profiler.cur_cpu_writer_->StartSample(&state, {});
+
+    const trace::WSTRING largeFrame(512, static_cast<WCHAR>('x'));
+    for (std::uint32_t index = 1; index <= 300; index++)
+    {
+        profiler.cur_cpu_writer_
+            ->RecordFrame(continuous_profiler::FunctionIdentifier::Managed(static_cast<mdToken>(index), 1, true),
+                          largeFrame);
+    }
+
+    profiler.cur_cpu_writer_->EndSample();
+    profiler.cur_cpu_writer_->EndBatch();
+    profiler.cur_cpu_writer_->WriteFinalStats({});
+    profiler.PublishBuffer(1000u);
+
+    std::vector<unsigned char> output(kTestSamplesBufferMaximumSize + 2048, 0xEE);
+    unsigned int               interval = 99u;
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(static_cast<int32_t>(output.size()), output.data(), &interval));
+    ASSERT_EQ(0u, interval);
+    ASSERT_TRUE(ThreadSamplingShouldProduceThreadSample());
+}
+
+TEST_F(ContinuousProfilerBatchTest, FinalMultiByteWriteMarksABatchThatCrossesTheCapacityBoundary)
+{
+    std::vector<unsigned char>               bytes(kTestSamplesBufferMaximumSize - 1);
+    continuous_profiler::ThreadSamplesBuffer writer(&bytes);
+
+    writer.WriteFinalStats({});
+
+    ASSERT_TRUE(writer.IsOverflowed());
+}
+
+TEST_F(ContinuousProfilerBatchTest, BackPressureDropsAWholeBatchWithoutMismatchingMetadata)
+{
+    Record(0x11, 1000u);
+    Record(0x22, 2000u);
+    ASSERT_FALSE(ThreadSamplingShouldProduceThreadSample());
+
+    Record(0x33, 3000u);
+
+    unsigned char output[1];
+    unsigned int  interval = 0;
+    ASSERT_EQ(1, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0x11, output[0]);
+    ASSERT_EQ(1000u, interval);
+
+    ASSERT_EQ(1, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0x22, output[0]);
+    ASSERT_EQ(2000u, interval);
+
+    ASSERT_EQ(0, ContinuousProfilerReadThreadSamplesV2(sizeof(output), output, &interval));
+    ASSERT_EQ(0u, interval);
+    ASSERT_TRUE(ThreadSamplingShouldProduceThreadSample());
+}
+
+TEST_F(ContinuousProfilerAuxiliaryBufferTest, UndersizedAllocationReadDropsTheWholeSampleWithoutReturningAPrefix)
+{
+    unsigned char sample[2] = {0x11, 0x22};
+    AllocationSamplingAppendToBuffer(static_cast<std::int32_t>(sizeof(sample)), sample);
+
+    unsigned char output = 0xEE;
+    ASSERT_EQ(0, ContinuousProfilerReadAllocationSamples(static_cast<std::int32_t>(sizeof(output)), &output));
+    ASSERT_EQ(0xEE, output);
+
+    unsigned char remaining[2] = {0xEE, 0xEE};
+    ASSERT_EQ(0, ContinuousProfilerReadAllocationSamples(static_cast<std::int32_t>(sizeof(remaining)), remaining));
+    ASSERT_TRUE(AllocationSamplingShouldProduceSample());
+}
+
+TEST_F(ContinuousProfilerAuxiliaryBufferTest, AllocationBackPressureSkipsCaptureUntilTheBufferIsRead)
+{
+    std::vector<unsigned char> oversizedSample(kTestSamplesBufferMaximumSize + 1, 0x33);
+    AllocationSamplingAppendToBuffer(static_cast<std::int32_t>(oversizedSample.size()), oversizedSample.data());
+
+    ASSERT_FALSE(AllocationSamplingShouldProduceSample());
+
+    std::vector<unsigned char> output(kTestSamplesBufferMaximumSize);
+    ASSERT_EQ(0, ContinuousProfilerReadAllocationSamples(static_cast<std::int32_t>(output.size()), output.data()));
+    ASSERT_TRUE(AllocationSamplingShouldProduceSample());
+}
+
+TEST_F(ContinuousProfilerAuxiliaryBufferTest, UndersizedSelectiveReadDropsTheWholeBatchWithoutReturningAPrefix)
+{
+    unsigned char sample[2] = {0x11, 0x22};
+    SelectiveSamplingRecordProducedThreadSample(static_cast<std::int32_t>(sizeof(sample)), sample);
+
+    unsigned char output = 0xEE;
+    ASSERT_EQ(0, SelectiveSamplerReadThreadSamples(static_cast<std::int32_t>(sizeof(output)), &output));
+    ASSERT_EQ(0xEE, output);
+
+    unsigned char remaining[2] = {0xEE, 0xEE};
+    ASSERT_EQ(0, SelectiveSamplerReadThreadSamples(static_cast<std::int32_t>(sizeof(remaining)), remaining));
+    ASSERT_TRUE(SelectiveSamplingShouldProduceThreadSample());
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_lifecycle_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_lifecycle_test.cpp
@@ -1,0 +1,410 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pch.h"
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+using continuous_profiler::ContinuousProfiler;
+using continuous_profiler::IAllocationSamplingSessionProvider;
+using continuous_profiler::IStackWalker;
+using continuous_profiler::RuntimeSamplerConfiguration;
+using continuous_profiler::StackCaptureRequest;
+
+constexpr std::uint32_t kPeriodicIntervalMilliseconds  = 3'600'000u;
+constexpr std::uint32_t kSelectiveIntervalMilliseconds = 1'800'000u;
+
+RuntimeSamplerConfiguration AllDisabled()
+{
+    return {};
+}
+
+RuntimeSamplerConfiguration PeriodicOnly()
+{
+    return {kPeriodicIntervalMilliseconds, std::nullopt, std::nullopt};
+}
+
+RuntimeSamplerConfiguration SelectiveOnly()
+{
+    return {std::nullopt, kSelectiveIntervalMilliseconds, std::nullopt};
+}
+
+RuntimeSamplerConfiguration BothThreadModes()
+{
+    return {kPeriodicIntervalMilliseconds, kSelectiveIntervalMilliseconds, std::nullopt};
+}
+
+RuntimeSamplerConfiguration AllocationOnly(const std::uint32_t samplesPerMinute)
+{
+    return {std::nullopt, std::nullopt, samplesPerMinute};
+}
+
+void AssertConfiguration(const ContinuousProfiler& profiler, const RuntimeSamplerConfiguration& expected)
+{
+    ASSERT_TRUE(profiler.GetConfiguration() == expected);
+}
+
+class FakeStackWalker final : public IStackWalker
+{
+public:
+    HRESULT prepareResult = S_OK;
+    int     prepareCalls  = 0;
+
+    HRESULT PrepareForStackWalking() noexcept override
+    {
+        prepareCalls++;
+        return prepareResult;
+    }
+
+    HRESULT CaptureStacks(const std::unordered_set<ThreadID>&, StackCaptureRequest*) override
+    {
+        return S_OK;
+    }
+
+    HRESULT ResolveNativeSymbolName(UINT_PTR, trace::WSTRING&) override
+    {
+        return E_NOTIMPL;
+    }
+};
+
+struct StartSessionResult
+{
+    HRESULT           result;
+    EVENTPIPE_SESSION session;
+};
+
+class FakeAllocationSamplingSessionProvider final : public IAllocationSamplingSessionProvider
+{
+public:
+    std::vector<StartSessionResult> startResults;
+    std::vector<HRESULT>            stopResults;
+    std::vector<EVENTPIPE_SESSION>  stoppedSessions;
+    std::size_t                     startCalls = 0;
+
+    HRESULT StartAllocationSamplingSession(EVENTPIPE_SESSION* session) noexcept override
+    {
+        if (session == nullptr || startCalls >= startResults.size())
+        {
+            return E_UNEXPECTED;
+        }
+
+        const auto result = startResults[startCalls++];
+        *session          = result.session;
+        return result.result;
+    }
+
+    HRESULT StopAllocationSamplingSession(const EVENTPIPE_SESSION session) noexcept override
+    {
+        const auto stopCall = stoppedSessions.size();
+        stoppedSessions.push_back(session);
+        return stopCall < stopResults.size() ? stopResults[stopCall] : E_UNEXPECTED;
+    }
+};
+
+class BlockingAllocationSamplingSessionProvider final : public IAllocationSamplingSessionProvider
+{
+public:
+    HRESULT StartAllocationSamplingSession(EVENTPIPE_SESSION* session) noexcept override
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        startEntered_ = true;
+        stateChanged_.notify_all();
+        stateChanged_.wait(lock, [this] { return releaseStart_; });
+        *session = 606;
+        return S_OK;
+    }
+
+    HRESULT StopAllocationSamplingSession(const EVENTPIPE_SESSION session) noexcept override
+    {
+        stoppedSession_.store(session);
+        stopCalls_.fetch_add(1);
+        return S_OK;
+    }
+
+    void WaitUntilStartIsEntered()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        stateChanged_.wait(lock, [this] { return startEntered_; });
+    }
+
+    void ReleaseStart()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            releaseStart_ = true;
+        }
+        stateChanged_.notify_all();
+    }
+
+    std::size_t StopCalls() const noexcept
+    {
+        return stopCalls_.load();
+    }
+
+    EVENTPIPE_SESSION StoppedSession() const noexcept
+    {
+        return stoppedSession_.load();
+    }
+
+private:
+    std::mutex                     mutex_;
+    std::condition_variable        stateChanged_;
+    bool                           startEntered_ = false;
+    bool                           releaseStart_ = false;
+    std::atomic<std::size_t>       stopCalls_{0};
+    std::atomic<EVENTPIPE_SESSION> stoppedSession_{0};
+};
+
+} // namespace
+
+TEST(ContinuousProfilerLifecycleTest, AllDisabledConfigurationDoesNotCreateAWorker)
+{
+    ContinuousProfiler profiler;
+    FakeStackWalker    stackWalker;
+    profiler.SetStackWalker(&stackWalker);
+
+    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_EQ(0, stackWalker.prepareCalls);
+}
+
+TEST(ContinuousProfilerLifecycleTest, ThreadModesShareOneWorkerAndStopOnlyAfterTheFinalDisable)
+{
+    ContinuousProfiler profiler;
+    FakeStackWalker    stackWalker;
+    profiler.SetStackWalker(&stackWalker);
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(PeriodicOnly()));
+    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, PeriodicOnly());
+    ASSERT_EQ(1, stackWalker.prepareCalls);
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(BothThreadModes()));
+    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, BothThreadModes());
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(SelectiveOnly()));
+    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, SelectiveOnly());
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, AllDisabled());
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(PeriodicOnly()));
+    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, PeriodicOnly());
+    ASSERT_EQ(2, stackWalker.prepareCalls);
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+}
+
+TEST(ContinuousProfilerLifecycleTest, UnsupportedAllocationRollsBackACombinedThreadTransition)
+{
+    ContinuousProfiler profiler;
+    FakeStackWalker    stackWalker;
+    profiler.SetStackWalker(&stackWalker);
+    const RuntimeSamplerConfiguration unsupportedCandidate{kPeriodicIntervalMilliseconds, std::nullopt, 200u};
+
+    ASSERT_FALSE(profiler.ApplyConfiguration(unsupportedCandidate));
+
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_FALSE(profiler.allocationSubSampler);
+}
+
+TEST(ContinuousProfilerLifecycleTest, StackWalkingPreparationFailureRejectsTheThreadTransition)
+{
+    ContinuousProfiler profiler;
+    FakeStackWalker    stackWalker;
+    stackWalker.prepareResult = E_FAIL;
+    profiler.SetStackWalker(&stackWalker);
+
+    ASSERT_FALSE(profiler.ApplyConfiguration(PeriodicOnly()));
+
+    ASSERT_EQ(1, stackWalker.prepareCalls);
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, AllDisabled());
+}
+
+TEST(ContinuousProfilerLifecycleTest, ShutdownIsTerminalAndIdempotent)
+{
+    ContinuousProfiler profiler;
+    FakeStackWalker    stackWalker;
+    profiler.SetStackWalker(&stackWalker);
+    ASSERT_TRUE(profiler.ApplyConfiguration(BothThreadModes()));
+    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
+
+    profiler.Shutdown();
+    profiler.Shutdown();
+
+    ASSERT_TRUE(profiler.IsShutdownRequested());
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_FALSE(profiler.ApplyConfiguration(PeriodicOnly()));
+    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    AssertConfiguration(profiler, AllDisabled());
+}
+
+TEST(ContinuousProfilerAllocationLifecycleTest, EnableAndRateUpdateReuseOneEventPipeSession)
+{
+    FakeAllocationSamplingSessionProvider sessions;
+    sessions.startResults = {{S_OK, 101}};
+    sessions.stopResults  = {S_OK};
+    ContinuousProfiler profiler(&sessions);
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_EQ(1u, sessions.startCalls);
+    ASSERT_TRUE(sessions.stoppedSessions.empty());
+    ASSERT_TRUE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllocationOnly(100));
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(200)));
+    ASSERT_EQ(1u, sessions.startCalls);
+    ASSERT_TRUE(sessions.stoppedSessions.empty());
+    ASSERT_TRUE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllocationOnly(200));
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{101}), sessions.stoppedSessions);
+    ASSERT_FALSE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllDisabled());
+}
+
+TEST(ContinuousProfilerAllocationLifecycleTest, FailedDisableRollsBackAndCanBeRetried)
+{
+    FakeAllocationSamplingSessionProvider sessions;
+    sessions.startResults = {{S_OK, 202}};
+    sessions.stopResults  = {E_FAIL, S_OK};
+    ContinuousProfiler profiler(&sessions);
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_FALSE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{202}), sessions.stoppedSessions);
+    ASSERT_TRUE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllocationOnly(100));
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{202, 202}), sessions.stoppedSessions);
+    ASSERT_FALSE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllDisabled());
+}
+
+TEST(ContinuousProfilerAllocationLifecycleTest, FailedStartIsCleanedUpBeforeReenable)
+{
+    FakeAllocationSamplingSessionProvider sessions;
+    sessions.startResults = {{E_FAIL, 303}, {S_OK, 404}};
+    sessions.stopResults  = {E_FAIL, S_OK, S_OK};
+    ContinuousProfiler profiler(&sessions);
+
+    ASSERT_FALSE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_EQ(1u, sessions.startCalls);
+    ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{303}), sessions.stoppedSessions);
+    ASSERT_FALSE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllDisabled());
+
+    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_EQ(2u, sessions.startCalls);
+    ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{303, 303}), sessions.stoppedSessions);
+    ASSERT_TRUE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllocationOnly(100));
+
+    profiler.Shutdown();
+    ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{303, 303, 404}), sessions.stoppedSessions);
+}
+
+TEST(ContinuousProfilerAllocationLifecycleTest, SuccessfulStartWithoutASessionIsRejected)
+{
+    FakeAllocationSamplingSessionProvider sessions;
+    sessions.startResults = {{S_OK, 0}};
+    ContinuousProfiler profiler(&sessions);
+
+    ASSERT_FALSE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_EQ(1u, sessions.startCalls);
+    ASSERT_TRUE(sessions.stoppedSessions.empty());
+    ASSERT_FALSE(profiler.allocationSubSampler);
+    AssertConfiguration(profiler, AllDisabled());
+}
+
+TEST(ContinuousProfilerAllocationLifecycleTest, TerminalShutdownStopsTheSessionOnce)
+{
+    FakeAllocationSamplingSessionProvider sessions;
+    sessions.startResults = {{S_OK, 505}};
+    sessions.stopResults  = {S_OK};
+
+    {
+        ContinuousProfiler profiler(&sessions);
+        ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
+
+        profiler.Shutdown();
+        profiler.Shutdown();
+
+        ASSERT_TRUE(profiler.IsShutdownRequested());
+        ASSERT_FALSE(profiler.ApplyConfiguration(AllocationOnly(200)));
+        AssertConfiguration(profiler, AllDisabled());
+    }
+
+    ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{505}), sessions.stoppedSessions);
+}
+
+TEST(ContinuousProfilerAllocationLifecycleTest, ConcurrentShutdownStopsTheSessionCreatedByAnInFlightApply)
+{
+    BlockingAllocationSamplingSessionProvider sessions;
+    ContinuousProfiler                        profiler(&sessions);
+    bool                                      applySucceeded = false;
+    std::thread applyThread([&] { applySucceeded = profiler.ApplyConfiguration(AllocationOnly(100)); });
+    sessions.WaitUntilStartIsEntered();
+
+    std::mutex              shutdownStateMutex;
+    std::condition_variable shutdownStateChanged;
+    bool                    shutdownCallIssued = false;
+    bool                    shutdownReturned   = false;
+    std::thread             shutdownThread(
+        [&]
+        {
+            {
+                std::lock_guard<std::mutex> lock(shutdownStateMutex);
+                shutdownCallIssued = true;
+            }
+            shutdownStateChanged.notify_all();
+
+            profiler.Shutdown();
+
+            {
+                std::lock_guard<std::mutex> lock(shutdownStateMutex);
+                shutdownReturned = true;
+            }
+            shutdownStateChanged.notify_all();
+        });
+
+    {
+        std::unique_lock<std::mutex> lock(shutdownStateMutex);
+        shutdownStateChanged.wait(lock, [&] { return shutdownCallIssued; });
+        EXPECT_FALSE(shutdownReturned);
+    }
+    EXPECT_FALSE(profiler.IsShutdownRequested());
+
+    sessions.ReleaseStart();
+    applyThread.join();
+    shutdownThread.join();
+
+    ASSERT_TRUE(applySucceeded);
+    ASSERT_TRUE(shutdownReturned);
+    ASSERT_TRUE(profiler.IsShutdownRequested());
+    ASSERT_EQ(1u, sessions.StopCalls());
+    ASSERT_EQ(606u, sessions.StoppedSession());
+    AssertConfiguration(profiler, AllDisabled());
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_lifecycle_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_lifecycle_test.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "../../src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.h"
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -10,6 +11,42 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+
+// dllmain.cpp is not linked into the native test executable.
+HINSTANCE DllHandle = nullptr;
+
+namespace trace
+{
+
+class CorProfilerContinuousProfilerTestAccess
+{
+public:
+    static continuous_profiler::ContinuousProfiler* InstallSampler(CorProfiler& profiler)
+    {
+        auto  sampler                 = std::make_unique<continuous_profiler::ContinuousProfiler>();
+        auto* result                  = sampler.get();
+        profiler.continuous_profiler_ = std::move(sampler);
+        profiler.continuous_profiler_callbacks_.store(result, std::memory_order_release);
+        return result;
+    }
+
+    static continuous_profiler::ContinuousProfiler* OwnedSampler(const CorProfiler& profiler)
+    {
+        return profiler.continuous_profiler_.get();
+    }
+
+    static continuous_profiler::ContinuousProfiler* PublishedSampler(const CorProfiler& profiler)
+    {
+        return profiler.continuous_profiler_callbacks_.load(std::memory_order_acquire);
+    }
+
+    static void ShutdownSampling(CorProfiler& profiler)
+    {
+        profiler.ShutdownSampling();
+    }
+};
+
+} // namespace trace
 
 namespace
 {
@@ -186,6 +223,30 @@ private:
 };
 
 } // namespace
+
+TEST(CorProfilerContinuousProfilerTest, TerminalShutdownRetainsFacadeAndMakesLateCallbacksNoOp)
+{
+    trace::CorProfiler profiler;
+    auto*              sampler    = trace::CorProfilerContinuousProfilerTestAccess::InstallSampler(profiler);
+    trace::WSTRING     threadName = WStr("before-shutdown");
+
+    ASSERT_EQ(sampler, trace::CorProfilerContinuousProfilerTestAccess::OwnedSampler(profiler));
+    ASSERT_EQ(sampler, trace::CorProfilerContinuousProfilerTestAccess::PublishedSampler(profiler));
+    ASSERT_EQ(S_OK, profiler.ThreadNameChanged(101, static_cast<ULONG>(threadName.size()), threadName.data()));
+    ASSERT_EQ(1u, sampler->managed_tid_to_state_.count(101));
+
+    trace::CorProfilerContinuousProfilerTestAccess::ShutdownSampling(profiler);
+    trace::CorProfilerContinuousProfilerTestAccess::ShutdownSampling(profiler);
+
+    ASSERT_TRUE(sampler->IsShutdownRequested());
+    ASSERT_EQ(sampler, trace::CorProfilerContinuousProfilerTestAccess::OwnedSampler(profiler));
+    ASSERT_EQ(sampler, trace::CorProfilerContinuousProfilerTestAccess::PublishedSampler(profiler));
+
+    threadName = WStr("after-shutdown");
+    ASSERT_EQ(S_OK, profiler.ThreadNameChanged(202, static_cast<ULONG>(threadName.size()), threadName.data()));
+    ASSERT_EQ(1u, sampler->managed_tid_to_state_.count(101));
+    ASSERT_EQ(0u, sampler->managed_tid_to_state_.count(202));
+}
 
 TEST(ContinuousProfilerLifecycleTest, AllDisabledConfigurationDoesNotCreateAWorker)
 {

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_lifecycle_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/continuous_profiler_lifecycle_test.cpp
@@ -48,10 +48,31 @@ RuntimeSamplerConfiguration AllocationOnly(const std::uint32_t samplesPerMinute)
     return {std::nullopt, std::nullopt, samplesPerMinute};
 }
 
-void AssertConfiguration(const ContinuousProfiler& profiler, const RuntimeSamplerConfiguration& expected)
+RuntimeSamplerConfiguration PeriodicAndAllocation(const std::uint32_t samplesPerMinute)
 {
-    ASSERT_TRUE(profiler.GetConfiguration() == expected);
+    return {kPeriodicIntervalMilliseconds, std::nullopt, samplesPerMinute};
 }
+
+class ConfigurationApplier
+{
+public:
+    explicit ConfigurationApplier(ContinuousProfiler& profiler) : profiler_(profiler) {}
+
+    bool Apply(const RuntimeSamplerConfiguration& candidate)
+    {
+        if (!profiler_.ApplyConfiguration(current_, candidate))
+        {
+            return false;
+        }
+
+        current_ = candidate;
+        return true;
+    }
+
+private:
+    ContinuousProfiler&         profiler_;
+    RuntimeSamplerConfiguration current_;
+};
 
 class FakeStackWalker final : public IStackWalker
 {
@@ -168,95 +189,113 @@ private:
 
 TEST(ContinuousProfilerLifecycleTest, AllDisabledConfigurationDoesNotCreateAWorker)
 {
-    ContinuousProfiler profiler;
-    FakeStackWalker    stackWalker;
+    ContinuousProfiler   profiler;
+    FakeStackWalker      stackWalker;
+    ConfigurationApplier applier(profiler);
     profiler.SetStackWalker(&stackWalker);
 
-    AssertConfiguration(profiler, AllDisabled());
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_FALSE(profiler.HasThreadSamplingWorker());
+    ASSERT_TRUE(applier.Apply(AllDisabled()));
+    ASSERT_FALSE(profiler.HasThreadSamplingWorker());
     ASSERT_EQ(0, stackWalker.prepareCalls);
 }
 
-TEST(ContinuousProfilerLifecycleTest, ThreadModesShareOneWorkerAndStopOnlyAfterTheFinalDisable)
+TEST(ContinuousProfilerLifecycleTest, ThreadModesShareOneWorkerThatQuiescesAfterTheFinalDisable)
 {
-    ContinuousProfiler profiler;
-    FakeStackWalker    stackWalker;
+    ContinuousProfiler   profiler;
+    FakeStackWalker      stackWalker;
+    ConfigurationApplier applier(profiler);
     profiler.SetStackWalker(&stackWalker);
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(PeriodicOnly()));
-    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, PeriodicOnly());
+    ASSERT_TRUE(applier.Apply(PeriodicOnly()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
+    ASSERT_FALSE(profiler.IsThreadSamplingWorkerQuiescent());
     ASSERT_EQ(1, stackWalker.prepareCalls);
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(BothThreadModes()));
-    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, BothThreadModes());
+    ASSERT_TRUE(applier.Apply(BothThreadModes()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(SelectiveOnly()));
-    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, SelectiveOnly());
+    ASSERT_TRUE(applier.Apply(SelectiveOnly()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_TRUE(applier.Apply(AllDisabled()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
+    ASSERT_TRUE(profiler.IsThreadSamplingWorkerQuiescent());
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(PeriodicOnly()));
-    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, PeriodicOnly());
-    ASSERT_EQ(2, stackWalker.prepareCalls);
+    ASSERT_TRUE(applier.Apply(PeriodicOnly()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
+    ASSERT_FALSE(profiler.IsThreadSamplingWorkerQuiescent());
+    ASSERT_EQ(1, stackWalker.prepareCalls);
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
+    ASSERT_TRUE(applier.Apply(AllDisabled()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
+    ASSERT_TRUE(profiler.IsThreadSamplingWorkerQuiescent());
 }
 
-TEST(ContinuousProfilerLifecycleTest, UnsupportedAllocationRollsBackACombinedThreadTransition)
+TEST(ContinuousProfilerLifecycleTest, UnsupportedAllocationRejectsCombinedConfigurationBeforeWorkerCreation)
 {
-    ContinuousProfiler profiler;
-    FakeStackWalker    stackWalker;
+    ContinuousProfiler   profiler;
+    FakeStackWalker      stackWalker;
+    ConfigurationApplier applier(profiler);
     profiler.SetStackWalker(&stackWalker);
     const RuntimeSamplerConfiguration unsupportedCandidate{kPeriodicIntervalMilliseconds, std::nullopt, 200u};
 
-    ASSERT_FALSE(profiler.ApplyConfiguration(unsupportedCandidate));
+    ASSERT_FALSE(applier.Apply(unsupportedCandidate));
 
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_FALSE(profiler.HasThreadSamplingWorker());
     ASSERT_FALSE(profiler.allocationSubSampler);
+}
+
+TEST(ContinuousProfilerLifecycleTest, FailedAllocationActivationLeavesTheWorkerQuiescentAndReusable)
+{
+    FakeAllocationSamplingSessionProvider sessions;
+    sessions.startResults = {{E_FAIL, 0}};
+    ContinuousProfiler   profiler(&sessions);
+    FakeStackWalker      stackWalker;
+    ConfigurationApplier applier(profiler);
+    profiler.SetStackWalker(&stackWalker);
+
+    ASSERT_FALSE(applier.Apply(PeriodicAndAllocation(100)));
+
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
+    ASSERT_TRUE(profiler.IsThreadSamplingWorkerQuiescent());
+    ASSERT_EQ(1, stackWalker.prepareCalls);
+
+    ASSERT_TRUE(applier.Apply(PeriodicOnly()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
+    ASSERT_EQ(1, stackWalker.prepareCalls);
 }
 
 TEST(ContinuousProfilerLifecycleTest, StackWalkingPreparationFailureRejectsTheThreadTransition)
 {
-    ContinuousProfiler profiler;
-    FakeStackWalker    stackWalker;
+    ContinuousProfiler   profiler;
+    FakeStackWalker      stackWalker;
+    ConfigurationApplier applier(profiler);
     stackWalker.prepareResult = E_FAIL;
     profiler.SetStackWalker(&stackWalker);
 
-    ASSERT_FALSE(profiler.ApplyConfiguration(PeriodicOnly()));
+    ASSERT_FALSE(applier.Apply(PeriodicOnly()));
 
     ASSERT_EQ(1, stackWalker.prepareCalls);
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_FALSE(profiler.HasThreadSamplingWorker());
 }
 
 TEST(ContinuousProfilerLifecycleTest, ShutdownIsTerminalAndIdempotent)
 {
-    ContinuousProfiler profiler;
-    FakeStackWalker    stackWalker;
+    ContinuousProfiler   profiler;
+    FakeStackWalker      stackWalker;
+    ConfigurationApplier applier(profiler);
     profiler.SetStackWalker(&stackWalker);
-    ASSERT_TRUE(profiler.ApplyConfiguration(BothThreadModes()));
-    ASSERT_TRUE(profiler.IsThreadSamplingThreadRunning());
+    ASSERT_TRUE(applier.Apply(BothThreadModes()));
+    ASSERT_TRUE(profiler.HasThreadSamplingWorker());
 
     profiler.Shutdown();
     profiler.Shutdown();
 
     ASSERT_TRUE(profiler.IsShutdownRequested());
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, AllDisabled());
-    ASSERT_FALSE(profiler.ApplyConfiguration(PeriodicOnly()));
-    ASSERT_FALSE(profiler.IsThreadSamplingThreadRunning());
-    AssertConfiguration(profiler, AllDisabled());
+    ASSERT_FALSE(profiler.HasThreadSamplingWorker());
+    ASSERT_FALSE(applier.Apply(PeriodicOnly()));
+    ASSERT_FALSE(profiler.HasThreadSamplingWorker());
 }
 
 TEST(ContinuousProfilerAllocationLifecycleTest, EnableAndRateUpdateReuseOneEventPipeSession)
@@ -264,24 +303,22 @@ TEST(ContinuousProfilerAllocationLifecycleTest, EnableAndRateUpdateReuseOneEvent
     FakeAllocationSamplingSessionProvider sessions;
     sessions.startResults = {{S_OK, 101}};
     sessions.stopResults  = {S_OK};
-    ContinuousProfiler profiler(&sessions);
+    ContinuousProfiler   profiler(&sessions);
+    ConfigurationApplier applier(profiler);
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_TRUE(applier.Apply(AllocationOnly(100)));
     ASSERT_EQ(1u, sessions.startCalls);
     ASSERT_TRUE(sessions.stoppedSessions.empty());
     ASSERT_TRUE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllocationOnly(100));
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(200)));
+    ASSERT_TRUE(applier.Apply(AllocationOnly(200)));
     ASSERT_EQ(1u, sessions.startCalls);
     ASSERT_TRUE(sessions.stoppedSessions.empty());
     ASSERT_TRUE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllocationOnly(200));
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_TRUE(applier.Apply(AllDisabled()));
     ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{101}), sessions.stoppedSessions);
     ASSERT_FALSE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllDisabled());
 }
 
 TEST(ContinuousProfilerAllocationLifecycleTest, FailedDisableRollsBackAndCanBeRetried)
@@ -289,18 +326,17 @@ TEST(ContinuousProfilerAllocationLifecycleTest, FailedDisableRollsBackAndCanBeRe
     FakeAllocationSamplingSessionProvider sessions;
     sessions.startResults = {{S_OK, 202}};
     sessions.stopResults  = {E_FAIL, S_OK};
-    ContinuousProfiler profiler(&sessions);
+    ContinuousProfiler   profiler(&sessions);
+    ConfigurationApplier applier(profiler);
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
-    ASSERT_FALSE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_TRUE(applier.Apply(AllocationOnly(100)));
+    ASSERT_FALSE(applier.Apply(AllDisabled()));
     ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{202}), sessions.stoppedSessions);
     ASSERT_TRUE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllocationOnly(100));
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllDisabled()));
+    ASSERT_TRUE(applier.Apply(AllDisabled()));
     ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{202, 202}), sessions.stoppedSessions);
     ASSERT_FALSE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllDisabled());
 }
 
 TEST(ContinuousProfilerAllocationLifecycleTest, FailedStartIsCleanedUpBeforeReenable)
@@ -308,19 +344,18 @@ TEST(ContinuousProfilerAllocationLifecycleTest, FailedStartIsCleanedUpBeforeReen
     FakeAllocationSamplingSessionProvider sessions;
     sessions.startResults = {{E_FAIL, 303}, {S_OK, 404}};
     sessions.stopResults  = {E_FAIL, S_OK, S_OK};
-    ContinuousProfiler profiler(&sessions);
+    ContinuousProfiler   profiler(&sessions);
+    ConfigurationApplier applier(profiler);
 
-    ASSERT_FALSE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_FALSE(applier.Apply(AllocationOnly(100)));
     ASSERT_EQ(1u, sessions.startCalls);
     ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{303}), sessions.stoppedSessions);
     ASSERT_FALSE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllDisabled());
 
-    ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_TRUE(applier.Apply(AllocationOnly(100)));
     ASSERT_EQ(2u, sessions.startCalls);
     ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{303, 303}), sessions.stoppedSessions);
     ASSERT_TRUE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllocationOnly(100));
 
     profiler.Shutdown();
     ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{303, 303, 404}), sessions.stoppedSessions);
@@ -330,13 +365,13 @@ TEST(ContinuousProfilerAllocationLifecycleTest, SuccessfulStartWithoutASessionIs
 {
     FakeAllocationSamplingSessionProvider sessions;
     sessions.startResults = {{S_OK, 0}};
-    ContinuousProfiler profiler(&sessions);
+    ContinuousProfiler   profiler(&sessions);
+    ConfigurationApplier applier(profiler);
 
-    ASSERT_FALSE(profiler.ApplyConfiguration(AllocationOnly(100)));
+    ASSERT_FALSE(applier.Apply(AllocationOnly(100)));
     ASSERT_EQ(1u, sessions.startCalls);
     ASSERT_TRUE(sessions.stoppedSessions.empty());
     ASSERT_FALSE(profiler.allocationSubSampler);
-    AssertConfiguration(profiler, AllDisabled());
 }
 
 TEST(ContinuousProfilerAllocationLifecycleTest, TerminalShutdownStopsTheSessionOnce)
@@ -346,15 +381,15 @@ TEST(ContinuousProfilerAllocationLifecycleTest, TerminalShutdownStopsTheSessionO
     sessions.stopResults  = {S_OK};
 
     {
-        ContinuousProfiler profiler(&sessions);
-        ASSERT_TRUE(profiler.ApplyConfiguration(AllocationOnly(100)));
+        ContinuousProfiler   profiler(&sessions);
+        ConfigurationApplier applier(profiler);
+        ASSERT_TRUE(applier.Apply(AllocationOnly(100)));
 
         profiler.Shutdown();
         profiler.Shutdown();
 
         ASSERT_TRUE(profiler.IsShutdownRequested());
-        ASSERT_FALSE(profiler.ApplyConfiguration(AllocationOnly(200)));
-        AssertConfiguration(profiler, AllDisabled());
+        ASSERT_FALSE(applier.Apply(AllocationOnly(200)));
     }
 
     ASSERT_EQ((std::vector<EVENTPIPE_SESSION>{505}), sessions.stoppedSessions);
@@ -364,8 +399,9 @@ TEST(ContinuousProfilerAllocationLifecycleTest, ConcurrentShutdownStopsTheSessio
 {
     BlockingAllocationSamplingSessionProvider sessions;
     ContinuousProfiler                        profiler(&sessions);
+    ConfigurationApplier                      applier(profiler);
     bool                                      applySucceeded = false;
-    std::thread applyThread([&] { applySucceeded = profiler.ApplyConfiguration(AllocationOnly(100)); });
+    std::thread                               applyThread([&] { applySucceeded = applier.Apply(AllocationOnly(100)); });
     sessions.WaitUntilStartIsEntered();
 
     std::mutex              shutdownStateMutex;
@@ -406,5 +442,4 @@ TEST(ContinuousProfilerAllocationLifecycleTest, ConcurrentShutdownStopsTheSessio
     ASSERT_TRUE(profiler.IsShutdownRequested());
     ASSERT_EQ(1u, sessions.StopCalls());
     ASSERT_EQ(606u, sessions.StoppedSession());
-    AssertConfiguration(profiler, AllDisabled());
 }

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/runtime_sampler_configuration_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/runtime_sampler_configuration_test.cpp
@@ -1,0 +1,277 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pch.h"
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_configuration.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace
+{
+
+using continuous_profiler::DecodeRuntimeSamplerConfigurationV1;
+using continuous_profiler::EncodeRuntimeSamplerStateV1;
+using continuous_profiler::kRuntimeSamplerSchemaVersionV1;
+using continuous_profiler::RuntimeSamplerAllocationSupport;
+using continuous_profiler::RuntimeSamplerApplyResult;
+using continuous_profiler::RuntimeSamplerConfiguration;
+using continuous_profiler::RuntimeSamplerConfigurationV1;
+using continuous_profiler::RuntimeSamplerStateQueryResult;
+using continuous_profiler::RuntimeSamplerStateV1;
+
+RuntimeSamplerConfigurationV1 CreateConfigurationV1(const std::uint32_t periodicInterval  = 0,
+                                                    const std::uint32_t selectiveInterval = 0,
+                                                    const std::uint32_t allocationRate    = 0)
+{
+    return {sizeof(RuntimeSamplerConfigurationV1),
+            kRuntimeSamplerSchemaVersionV1,
+            periodicInterval,
+            selectiveInterval,
+            allocationRate,
+            0,
+            0,
+            0};
+}
+
+RuntimeSamplerStateV1 CreateStateV1()
+{
+    RuntimeSamplerStateV1 state{};
+    state.structureSize = sizeof(RuntimeSamplerStateV1);
+    state.schemaVersion = kRuntimeSamplerSchemaVersionV1;
+    return state;
+}
+
+RuntimeSamplerConfiguration CreateSentinelConfiguration()
+{
+    return {11u, 1u, 7u};
+}
+
+void AssertSentinelConfiguration(const RuntimeSamplerConfiguration& configuration)
+{
+    ASSERT_EQ(11u, configuration.periodicThreadSamplingIntervalMilliseconds.value());
+    ASSERT_EQ(1u, configuration.selectiveThreadSamplingIntervalMilliseconds.value());
+    ASSERT_EQ(7u, configuration.maxAllocationSamplesPerMinute.value());
+}
+
+} // namespace
+
+TEST(RuntimeSamplerConfigurationAbiTest, V1LayoutsAreStableOnEveryNativeArchitecture)
+{
+    static_assert(std::is_standard_layout<RuntimeSamplerConfigurationV1>::value, "V1 request must be standard layout.");
+    static_assert(std::is_trivially_copyable<RuntimeSamplerConfigurationV1>::value,
+                  "V1 request must be trivially copyable.");
+    static_assert(std::is_standard_layout<RuntimeSamplerStateV1>::value, "V1 state must be standard layout.");
+    static_assert(std::is_trivially_copyable<RuntimeSamplerStateV1>::value, "V1 state must be trivially copyable.");
+
+    ASSERT_EQ(32u, sizeof(RuntimeSamplerConfigurationV1));
+    ASSERT_EQ(0u, offsetof(RuntimeSamplerConfigurationV1, structureSize));
+    ASSERT_EQ(4u, offsetof(RuntimeSamplerConfigurationV1, schemaVersion));
+    ASSERT_EQ(8u, offsetof(RuntimeSamplerConfigurationV1, periodicThreadSamplingIntervalMilliseconds));
+    ASSERT_EQ(12u, offsetof(RuntimeSamplerConfigurationV1, selectiveThreadSamplingIntervalMilliseconds));
+    ASSERT_EQ(16u, offsetof(RuntimeSamplerConfigurationV1, maxAllocationSamplesPerMinute));
+    ASSERT_EQ(20u, offsetof(RuntimeSamplerConfigurationV1, reserved0));
+    ASSERT_EQ(24u, offsetof(RuntimeSamplerConfigurationV1, reserved1));
+    ASSERT_EQ(28u, offsetof(RuntimeSamplerConfigurationV1, reserved2));
+
+    ASSERT_EQ(48u, sizeof(RuntimeSamplerStateV1));
+    ASSERT_EQ(0u, offsetof(RuntimeSamplerStateV1, structureSize));
+    ASSERT_EQ(4u, offsetof(RuntimeSamplerStateV1, schemaVersion));
+    ASSERT_EQ(8u, offsetof(RuntimeSamplerStateV1, generation));
+    ASSERT_EQ(16u, offsetof(RuntimeSamplerStateV1, activeConfiguration));
+
+    ASSERT_EQ(4u, sizeof(RuntimeSamplerApplyResult));
+    ASSERT_EQ(4u, sizeof(RuntimeSamplerStateQueryResult));
+}
+
+TEST(RuntimeSamplerConfigurationAbiTest, ResultValuesRemainStable)
+{
+    ASSERT_EQ(0, static_cast<std::int32_t>(RuntimeSamplerApplyResult::Applied));
+    ASSERT_EQ(1, static_cast<std::int32_t>(RuntimeSamplerApplyResult::NoChange));
+    ASSERT_EQ(2, static_cast<std::int32_t>(RuntimeSamplerApplyResult::IgnoredInitialConfiguration));
+    ASSERT_EQ(3, static_cast<std::int32_t>(RuntimeSamplerApplyResult::RejectedInvalidArgument));
+    ASSERT_EQ(4, static_cast<std::int32_t>(RuntimeSamplerApplyResult::RejectedUnsupportedSchema));
+    ASSERT_EQ(5, static_cast<std::int32_t>(RuntimeSamplerApplyResult::RejectedReservedField));
+    ASSERT_EQ(6, static_cast<std::int32_t>(RuntimeSamplerApplyResult::RejectedInvalidConfiguration));
+    ASSERT_EQ(7, static_cast<std::int32_t>(RuntimeSamplerApplyResult::RejectedUnsupportedRuntime));
+    ASSERT_EQ(8, static_cast<std::int32_t>(RuntimeSamplerApplyResult::BootstrapFailed));
+    ASSERT_EQ(9, static_cast<std::int32_t>(RuntimeSamplerApplyResult::ActivationFailed));
+    ASSERT_EQ(10, static_cast<std::int32_t>(RuntimeSamplerApplyResult::ShuttingDown));
+
+    ASSERT_EQ(0, static_cast<std::int32_t>(RuntimeSamplerStateQueryResult::Succeeded));
+    ASSERT_EQ(1, static_cast<std::int32_t>(RuntimeSamplerStateQueryResult::InvalidArgument));
+    ASSERT_EQ(2, static_cast<std::int32_t>(RuntimeSamplerStateQueryResult::UnsupportedSchema));
+    ASSERT_EQ(3, static_cast<std::int32_t>(RuntimeSamplerStateQueryResult::ReservedFieldNonZero));
+}
+
+TEST(RuntimeSamplerConfigurationDecodeTest, ZeroValuesProduceTheCanonicalAllDisabledConfiguration)
+{
+    const auto                  input   = CreateConfigurationV1();
+    RuntimeSamplerConfiguration decoded = CreateSentinelConfiguration();
+
+    const auto result =
+        DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Unsupported, decoded);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, result);
+    ASSERT_FALSE(decoded.periodicThreadSamplingIntervalMilliseconds.has_value());
+    ASSERT_FALSE(decoded.selectiveThreadSamplingIntervalMilliseconds.has_value());
+    ASSERT_FALSE(decoded.maxAllocationSamplesPerMinute.has_value());
+    ASSERT_FALSE(decoded.HasThreadSampling());
+    ASSERT_FALSE(decoded.HasAllocationSampling());
+}
+
+TEST(RuntimeSamplerConfigurationDecodeTest, CompleteValidConfigurationIsDecodedAsOneCandidate)
+{
+    const auto                  input = CreateConfigurationV1(1000u, 100u, 200u);
+    RuntimeSamplerConfiguration decoded{};
+
+    const auto result =
+        DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Supported, decoded);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, result);
+    ASSERT_EQ(1000u, decoded.periodicThreadSamplingIntervalMilliseconds.value());
+    ASSERT_EQ(100u, decoded.selectiveThreadSamplingIntervalMilliseconds.value());
+    ASSERT_EQ(200u, decoded.maxAllocationSamplesPerMinute.value());
+    ASSERT_TRUE(decoded.HasThreadSampling());
+    ASSERT_TRUE(decoded.HasAllocationSampling());
+}
+
+TEST(RuntimeSamplerConfigurationDecodeTest, InvalidIntervalPairRejectsTheWholeCandidate)
+{
+    const std::array<std::array<std::uint32_t, 2>, 3> invalidPairs = {{{100u, 100u}, {50u, 100u}, {1000u, 300u}}};
+
+    for (const auto& pair : invalidPairs)
+    {
+        SCOPED_TRACE(::testing::Message() << "periodic=" << pair[0] << ", selective=" << pair[1]);
+        const auto                  input   = CreateConfigurationV1(pair[0], pair[1], 200u);
+        RuntimeSamplerConfiguration decoded = CreateSentinelConfiguration();
+
+        const auto result =
+            DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Supported, decoded);
+
+        ASSERT_EQ(RuntimeSamplerApplyResult::RejectedInvalidConfiguration, result);
+        AssertSentinelConfiguration(decoded);
+    }
+}
+
+TEST(RuntimeSamplerConfigurationDecodeTest, EveryNonZeroReservedFieldIsRejectedWithoutChangingOutput)
+{
+    for (auto reservedIndex = 0u; reservedIndex < 3u; reservedIndex++)
+    {
+        SCOPED_TRACE(::testing::Message() << "reservedIndex=" << reservedIndex);
+        auto input = CreateConfigurationV1(1000u, 100u, 200u);
+        if (reservedIndex == 0)
+        {
+            input.reserved0 = 1;
+        }
+        else if (reservedIndex == 1)
+        {
+            input.reserved1 = 1;
+        }
+        else
+        {
+            input.reserved2 = 1;
+        }
+
+        RuntimeSamplerConfiguration decoded = CreateSentinelConfiguration();
+        const auto                  result =
+            DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Supported, decoded);
+
+        ASSERT_EQ(RuntimeSamplerApplyResult::RejectedReservedField, result);
+        AssertSentinelConfiguration(decoded);
+    }
+}
+
+TEST(RuntimeSamplerConfigurationDecodeTest, AllocationEnableOnUnsupportedRuntimePreservesOutput)
+{
+    const auto                  input   = CreateConfigurationV1(1000u, 100u, 200u);
+    RuntimeSamplerConfiguration decoded = CreateSentinelConfiguration();
+
+    const auto result =
+        DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Unsupported, decoded);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::RejectedUnsupportedRuntime, result);
+    AssertSentinelConfiguration(decoded);
+}
+
+TEST(RuntimeSamplerConfigurationDecodeTest, NullAndUnsupportedPayloadHeadersPreserveOutput)
+{
+    RuntimeSamplerConfiguration decoded = CreateSentinelConfiguration();
+    ASSERT_EQ(RuntimeSamplerApplyResult::RejectedInvalidArgument,
+              DecodeRuntimeSamplerConfigurationV1(nullptr, RuntimeSamplerAllocationSupport::Supported, decoded));
+    AssertSentinelConfiguration(decoded);
+
+    auto input          = CreateConfigurationV1(1000u, 100u, 200u);
+    input.structureSize = sizeof(RuntimeSamplerConfigurationV1) - 1;
+    ASSERT_EQ(RuntimeSamplerApplyResult::RejectedUnsupportedSchema,
+              DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Supported, decoded));
+    AssertSentinelConfiguration(decoded);
+
+    input.structureSize = sizeof(RuntimeSamplerConfigurationV1) + 1;
+    ASSERT_EQ(RuntimeSamplerApplyResult::RejectedUnsupportedSchema,
+              DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Supported, decoded));
+    AssertSentinelConfiguration(decoded);
+
+    input.structureSize = sizeof(RuntimeSamplerConfigurationV1);
+    input.schemaVersion = kRuntimeSamplerSchemaVersionV1 + 1;
+    ASSERT_EQ(RuntimeSamplerApplyResult::RejectedUnsupportedSchema,
+              DecodeRuntimeSamplerConfigurationV1(&input, RuntimeSamplerAllocationSupport::Supported, decoded));
+    AssertSentinelConfiguration(decoded);
+}
+
+TEST(RuntimeSamplerStateEncodeTest, NullAndUnsupportedOutputHeadersAreRejected)
+{
+    const RuntimeSamplerConfiguration configuration{1000u, 100u, 200u};
+
+    ASSERT_EQ(RuntimeSamplerStateQueryResult::InvalidArgument,
+              EncodeRuntimeSamplerStateV1(configuration, 17u, nullptr));
+
+    auto state          = CreateStateV1();
+    state.structureSize = sizeof(RuntimeSamplerStateV1) - 1;
+    ASSERT_EQ(RuntimeSamplerStateQueryResult::UnsupportedSchema,
+              EncodeRuntimeSamplerStateV1(configuration, 17u, &state));
+    ASSERT_EQ(0u, state.generation);
+
+    state               = CreateStateV1();
+    state.schemaVersion = kRuntimeSamplerSchemaVersionV1 + 1;
+    ASSERT_EQ(RuntimeSamplerStateQueryResult::UnsupportedSchema,
+              EncodeRuntimeSamplerStateV1(configuration, 17u, &state));
+    ASSERT_EQ(0u, state.generation);
+}
+
+TEST(RuntimeSamplerStateEncodeTest, NonZeroNestedReservedFieldIsRejectedWithoutWritingState)
+{
+    const RuntimeSamplerConfiguration configuration{1000u, 100u, 200u};
+    auto                              state = CreateStateV1();
+    state.generation                        = 23u;
+    state.activeConfiguration.reserved1     = 1u;
+
+    const auto result = EncodeRuntimeSamplerStateV1(configuration, 17u, &state);
+
+    ASSERT_EQ(RuntimeSamplerStateQueryResult::ReservedFieldNonZero, result);
+    ASSERT_EQ(23u, state.generation);
+    ASSERT_EQ(1u, state.activeConfiguration.reserved1);
+}
+
+TEST(RuntimeSamplerStateEncodeTest, SuccessWritesOneNormalizedCoherentSnapshot)
+{
+    const RuntimeSamplerConfiguration configuration{1000u, std::nullopt, 200u};
+    auto                              state = CreateStateV1();
+
+    const auto result = EncodeRuntimeSamplerStateV1(configuration, 17u, &state);
+
+    ASSERT_EQ(RuntimeSamplerStateQueryResult::Succeeded, result);
+    ASSERT_EQ(sizeof(RuntimeSamplerStateV1), state.structureSize);
+    ASSERT_EQ(kRuntimeSamplerSchemaVersionV1, state.schemaVersion);
+    ASSERT_EQ(17u, state.generation);
+    ASSERT_EQ(sizeof(RuntimeSamplerConfigurationV1), state.activeConfiguration.structureSize);
+    ASSERT_EQ(kRuntimeSamplerSchemaVersionV1, state.activeConfiguration.schemaVersion);
+    ASSERT_EQ(1000u, state.activeConfiguration.periodicThreadSamplingIntervalMilliseconds);
+    ASSERT_EQ(0u, state.activeConfiguration.selectiveThreadSamplingIntervalMilliseconds);
+    ASSERT_EQ(200u, state.activeConfiguration.maxAllocationSamplesPerMinute);
+    ASSERT_EQ(0u, state.activeConfiguration.reserved0);
+    ASSERT_EQ(0u, state.activeConfiguration.reserved1);
+    ASSERT_EQ(0u, state.activeConfiguration.reserved2);
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/runtime_sampler_controller_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/runtime_sampler_controller_test.cpp
@@ -41,6 +41,7 @@ public:
     int         applyCount                  = 0;
     int         shutdownCount               = 0;
 
+    std::vector<RuntimeSamplerConfiguration> previousConfigurations;
     std::vector<RuntimeSamplerConfiguration> appliedConfigurations;
 
     bool IsAllocationSamplingSupported() const noexcept override
@@ -55,9 +56,11 @@ public:
         return bootstrapSucceeds;
     }
 
-    bool ApplyConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept override
+    bool ApplyConfiguration(const RuntimeSamplerConfiguration& previousConfiguration,
+                            const RuntimeSamplerConfiguration& configuration) noexcept override
     {
         applyCount++;
+        previousConfigurations.push_back(previousConfiguration);
         appliedConfigurations.push_back(configuration);
         return activationSucceeds;
     }
@@ -92,41 +95,6 @@ TEST(RuntimeSamplerControllerTest, AllDisabledInitialConfigurationCommitsWithout
     ASSERT_EQ(0, lifecycle.applyCount);
 }
 
-TEST(RuntimeSamplerControllerTest, PrepareBootstrapsFoundationWithoutApplyingAConfiguration)
-{
-    FakeRuntimeSamplerLifecycle lifecycle;
-    RuntimeSamplerController    controller(lifecycle);
-
-    ASSERT_TRUE(controller.Prepare());
-    ASSERT_TRUE(controller.Prepare());
-
-    AssertState(controller, 0u, AllDisabled());
-    ASSERT_EQ(1, lifecycle.bootstrapCount);
-    ASSERT_EQ(0, lifecycle.applyCount);
-
-    controller.Shutdown();
-    ASSERT_EQ(1, lifecycle.shutdownCount);
-}
-
-TEST(RuntimeSamplerControllerTest, FailedPrepareIsStickyAndRemainsFailClosed)
-{
-    FakeRuntimeSamplerLifecycle lifecycle;
-    lifecycle.bootstrapSucceeds = false;
-    RuntimeSamplerController controller(lifecycle);
-
-    ASSERT_FALSE(controller.Prepare());
-    lifecycle.bootstrapSucceeds = true;
-    ASSERT_FALSE(controller.Prepare());
-    ASSERT_EQ(RuntimeSamplerApplyResult::BootstrapFailed, controller.ApplyConfiguration(PeriodicSampling(1000u)));
-
-    AssertState(controller, 0u, AllDisabled());
-    ASSERT_EQ(1, lifecycle.bootstrapCount);
-    ASSERT_EQ(0, lifecycle.applyCount);
-
-    controller.Shutdown();
-    ASSERT_EQ(1, lifecycle.shutdownCount);
-}
-
 TEST(RuntimeSamplerControllerTest, ExplicitAllDisabledConfigurationPreventsALaterLegacySeed)
 {
     FakeRuntimeSamplerLifecycle lifecycle;
@@ -152,7 +120,10 @@ TEST(RuntimeSamplerControllerTest, BootstrapIsLazyAndRunsOnlyOnce)
 
     ASSERT_EQ(1, lifecycle.bootstrapCount);
     ASSERT_EQ(2, lifecycle.applyCount);
+    ASSERT_EQ(2u, lifecycle.previousConfigurations.size());
     ASSERT_EQ(2u, lifecycle.appliedConfigurations.size());
+    ASSERT_TRUE(lifecycle.previousConfigurations[0] == AllDisabled());
+    ASSERT_TRUE(lifecycle.previousConfigurations[1] == PeriodicSampling(1000u));
     ASSERT_TRUE(lifecycle.appliedConfigurations[0] == PeriodicSampling(1000u));
     ASSERT_TRUE(lifecycle.appliedConfigurations[1] == PeriodicSampling(2000u));
     AssertState(controller, 3u, PeriodicSampling(2000u));
@@ -173,6 +144,9 @@ TEST(RuntimeSamplerControllerTest, FailedBootstrapIsStickyAndFailsClosed)
     ASSERT_EQ(1, lifecycle.bootstrapCount);
     ASSERT_EQ(0, lifecycle.applyCount);
     AssertState(controller, 1u, AllDisabled());
+
+    controller.Shutdown();
+    ASSERT_EQ(1, lifecycle.shutdownCount);
 }
 
 TEST(RuntimeSamplerControllerTest, ChangedAndUnchangedCandidatesHaveDeterministicGenerations)
@@ -215,6 +189,9 @@ TEST(RuntimeSamplerControllerTest, ActivationFailurePreservesLastKnownGoodConfig
 
     ASSERT_EQ(1, lifecycle.bootstrapCount);
     ASSERT_EQ(3, lifecycle.applyCount);
+    ASSERT_TRUE(lifecycle.previousConfigurations[0] == AllDisabled());
+    ASSERT_TRUE(lifecycle.previousConfigurations[1] == PeriodicSampling(1000u));
+    ASSERT_TRUE(lifecycle.previousConfigurations[2] == PeriodicSampling(1000u));
 }
 
 TEST(RuntimeSamplerControllerTest, FirstSuccessfulInitialConfigurationWins)
@@ -266,6 +243,7 @@ TEST(RuntimeSamplerControllerTest, AllDisabledInitialAfterBootstrapIsEstablished
     AssertState(controller, 1u, AllDisabled());
     ASSERT_EQ(1, lifecycle.bootstrapCount);
     ASSERT_EQ(3, lifecycle.applyCount);
+    ASSERT_TRUE(lifecycle.previousConfigurations.back() == AllDisabled());
     ASSERT_TRUE(lifecycle.appliedConfigurations.back() == AllDisabled());
 }
 

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/runtime_sampler_controller_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/runtime_sampler_controller_test.cpp
@@ -1,0 +1,330 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pch.h"
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/runtime_sampler_controller.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+
+using continuous_profiler::IRuntimeSamplerLifecycle;
+using continuous_profiler::RuntimeSamplerApplyResult;
+using continuous_profiler::RuntimeSamplerConfiguration;
+using continuous_profiler::RuntimeSamplerController;
+
+RuntimeSamplerConfiguration AllDisabled()
+{
+    return {};
+}
+
+RuntimeSamplerConfiguration PeriodicSampling(const std::uint32_t interval)
+{
+    return {interval, std::nullopt, std::nullopt};
+}
+
+RuntimeSamplerConfiguration AllSamplingModes()
+{
+    return {1000u, 100u, 200u};
+}
+
+class FakeRuntimeSamplerLifecycle final : public IRuntimeSamplerLifecycle
+{
+public:
+    bool        allocationSamplingSupported = true;
+    bool        bootstrapSucceeds           = true;
+    bool        activationSucceeds          = true;
+    mutable int allocationSupportQueryCount = 0;
+    int         bootstrapCount              = 0;
+    int         applyCount                  = 0;
+    int         shutdownCount               = 0;
+
+    std::vector<RuntimeSamplerConfiguration> appliedConfigurations;
+
+    bool IsAllocationSamplingSupported() const noexcept override
+    {
+        allocationSupportQueryCount++;
+        return allocationSamplingSupported;
+    }
+
+    bool Bootstrap() noexcept override
+    {
+        bootstrapCount++;
+        return bootstrapSucceeds;
+    }
+
+    bool ApplyConfiguration(const RuntimeSamplerConfiguration& configuration) noexcept override
+    {
+        applyCount++;
+        appliedConfigurations.push_back(configuration);
+        return activationSucceeds;
+    }
+
+    void ShutdownSampling() noexcept override
+    {
+        shutdownCount++;
+    }
+};
+
+void AssertState(const RuntimeSamplerController&    controller,
+                 const std::uint64_t                expectedGeneration,
+                 const RuntimeSamplerConfiguration& expectedConfiguration)
+{
+    const auto state = controller.GetState();
+    ASSERT_EQ(expectedGeneration, state.generation);
+    ASSERT_TRUE(state.configuration == expectedConfiguration);
+}
+
+} // namespace
+
+TEST(RuntimeSamplerControllerTest, AllDisabledInitialConfigurationCommitsWithoutBootstrap)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    AssertState(controller, 0u, AllDisabled());
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(AllDisabled()));
+    AssertState(controller, 1u, AllDisabled());
+    ASSERT_EQ(0, lifecycle.bootstrapCount);
+    ASSERT_EQ(0, lifecycle.applyCount);
+}
+
+TEST(RuntimeSamplerControllerTest, PrepareBootstrapsFoundationWithoutApplyingAConfiguration)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_TRUE(controller.Prepare());
+    ASSERT_TRUE(controller.Prepare());
+
+    AssertState(controller, 0u, AllDisabled());
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(0, lifecycle.applyCount);
+
+    controller.Shutdown();
+    ASSERT_EQ(1, lifecycle.shutdownCount);
+}
+
+TEST(RuntimeSamplerControllerTest, FailedPrepareIsStickyAndRemainsFailClosed)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    lifecycle.bootstrapSucceeds = false;
+    RuntimeSamplerController controller(lifecycle);
+
+    ASSERT_FALSE(controller.Prepare());
+    lifecycle.bootstrapSucceeds = true;
+    ASSERT_FALSE(controller.Prepare());
+    ASSERT_EQ(RuntimeSamplerApplyResult::BootstrapFailed, controller.ApplyConfiguration(PeriodicSampling(1000u)));
+
+    AssertState(controller, 0u, AllDisabled());
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(0, lifecycle.applyCount);
+
+    controller.Shutdown();
+    ASSERT_EQ(1, lifecycle.shutdownCount);
+}
+
+TEST(RuntimeSamplerControllerTest, ExplicitAllDisabledConfigurationPreventsALaterLegacySeed)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyConfiguration(AllDisabled()));
+    ASSERT_EQ(RuntimeSamplerApplyResult::IgnoredInitialConfiguration,
+              controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+
+    AssertState(controller, 1u, AllDisabled());
+    ASSERT_EQ(0, lifecycle.bootstrapCount);
+    ASSERT_EQ(0, lifecycle.applyCount);
+}
+
+TEST(RuntimeSamplerControllerTest, BootstrapIsLazyAndRunsOnlyOnce)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(AllDisabled()));
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyConfiguration(PeriodicSampling(1000u)));
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyConfiguration(PeriodicSampling(2000u)));
+
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(2, lifecycle.applyCount);
+    ASSERT_EQ(2u, lifecycle.appliedConfigurations.size());
+    ASSERT_TRUE(lifecycle.appliedConfigurations[0] == PeriodicSampling(1000u));
+    ASSERT_TRUE(lifecycle.appliedConfigurations[1] == PeriodicSampling(2000u));
+    AssertState(controller, 3u, PeriodicSampling(2000u));
+}
+
+TEST(RuntimeSamplerControllerTest, FailedBootstrapIsStickyAndFailsClosed)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    lifecycle.bootstrapSucceeds = false;
+    RuntimeSamplerController controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(AllDisabled()));
+    ASSERT_EQ(RuntimeSamplerApplyResult::BootstrapFailed, controller.ApplyConfiguration(PeriodicSampling(1000u)));
+
+    lifecycle.bootstrapSucceeds = true;
+    ASSERT_EQ(RuntimeSamplerApplyResult::BootstrapFailed, controller.ApplyConfiguration(PeriodicSampling(1000u)));
+
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(0, lifecycle.applyCount);
+    AssertState(controller, 1u, AllDisabled());
+}
+
+TEST(RuntimeSamplerControllerTest, ChangedAndUnchangedCandidatesHaveDeterministicGenerations)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(AllDisabled()));
+    ASSERT_EQ(RuntimeSamplerApplyResult::NoChange, controller.ApplyConfiguration(AllDisabled()));
+    AssertState(controller, 1u, AllDisabled());
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyConfiguration(PeriodicSampling(1000u)));
+    AssertState(controller, 2u, PeriodicSampling(1000u));
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::NoChange, controller.ApplyConfiguration(PeriodicSampling(1000u)));
+    AssertState(controller, 2u, PeriodicSampling(1000u));
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyConfiguration(PeriodicSampling(2000u)));
+    AssertState(controller, 3u, PeriodicSampling(2000u));
+
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(2, lifecycle.applyCount);
+}
+
+TEST(RuntimeSamplerControllerTest, ActivationFailurePreservesLastKnownGoodConfiguration)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+    AssertState(controller, 1u, PeriodicSampling(1000u));
+
+    lifecycle.activationSucceeds = false;
+    ASSERT_EQ(RuntimeSamplerApplyResult::ActivationFailed, controller.ApplyConfiguration(PeriodicSampling(2000u)));
+    AssertState(controller, 1u, PeriodicSampling(1000u));
+
+    lifecycle.activationSucceeds = true;
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyConfiguration(PeriodicSampling(2000u)));
+    AssertState(controller, 2u, PeriodicSampling(2000u));
+
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(3, lifecycle.applyCount);
+}
+
+TEST(RuntimeSamplerControllerTest, FirstSuccessfulInitialConfigurationWins)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+    ASSERT_EQ(RuntimeSamplerApplyResult::IgnoredInitialConfiguration,
+              controller.ApplyInitialConfiguration(PeriodicSampling(2000u)));
+
+    AssertState(controller, 1u, PeriodicSampling(1000u));
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(1, lifecycle.applyCount);
+}
+
+TEST(RuntimeSamplerControllerTest, FailedInitialActivationDoesNotConsumeTheInitialSlot)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    lifecycle.activationSucceeds = false;
+    RuntimeSamplerController controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::ActivationFailed,
+              controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+    AssertState(controller, 0u, AllDisabled());
+
+    lifecycle.activationSucceeds = true;
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(PeriodicSampling(2000u)));
+    AssertState(controller, 1u, PeriodicSampling(2000u));
+
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(2, lifecycle.applyCount);
+}
+
+TEST(RuntimeSamplerControllerTest, AllDisabledInitialAfterBootstrapIsEstablishedOnlyWhenLifecycleAcceptsIt)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    lifecycle.activationSucceeds = false;
+    RuntimeSamplerController controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::ActivationFailed,
+              controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+    ASSERT_EQ(RuntimeSamplerApplyResult::ActivationFailed, controller.ApplyInitialConfiguration(AllDisabled()));
+    AssertState(controller, 0u, AllDisabled());
+
+    lifecycle.activationSucceeds = true;
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(AllDisabled()));
+
+    AssertState(controller, 1u, AllDisabled());
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(3, lifecycle.applyCount);
+    ASSERT_TRUE(lifecycle.appliedConfigurations.back() == AllDisabled());
+}
+
+TEST(RuntimeSamplerControllerTest, UnsupportedAllocationIsRejectedBeforeBootstrap)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    lifecycle.allocationSamplingSupported = false;
+    RuntimeSamplerController controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::RejectedUnsupportedRuntime, controller.ApplyConfiguration(AllSamplingModes()));
+
+    AssertState(controller, 0u, AllDisabled());
+    ASSERT_EQ(0, lifecycle.bootstrapCount);
+    ASSERT_EQ(0, lifecycle.applyCount);
+}
+
+TEST(RuntimeSamplerControllerTest, DisablingAfterBootstrapIsForwardedToTheLifecycle)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyConfiguration(AllDisabled()));
+
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(2, lifecycle.applyCount);
+    ASSERT_TRUE(lifecycle.appliedConfigurations.back() == AllDisabled());
+    AssertState(controller, 2u, AllDisabled());
+}
+
+TEST(RuntimeSamplerControllerTest, ShutdownIsTerminalAndIdempotent)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    ASSERT_EQ(RuntimeSamplerApplyResult::Applied, controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+    controller.Shutdown();
+    controller.Shutdown();
+
+    ASSERT_EQ(1, lifecycle.shutdownCount);
+    ASSERT_EQ(RuntimeSamplerApplyResult::ShuttingDown, controller.ApplyConfiguration(AllDisabled()));
+    ASSERT_EQ(RuntimeSamplerApplyResult::ShuttingDown, controller.ApplyInitialConfiguration(PeriodicSampling(2000u)));
+    AssertState(controller, 1u, PeriodicSampling(1000u));
+    ASSERT_EQ(1, lifecycle.bootstrapCount);
+    ASSERT_EQ(1, lifecycle.applyCount);
+    ASSERT_EQ(1, lifecycle.shutdownCount);
+}
+
+TEST(RuntimeSamplerControllerTest, ShutdownBeforeBootstrapHasNoProducerLifecycleSideEffect)
+{
+    FakeRuntimeSamplerLifecycle lifecycle;
+    RuntimeSamplerController    controller(lifecycle);
+
+    controller.Shutdown();
+    controller.Shutdown();
+
+    ASSERT_EQ(0, lifecycle.bootstrapCount);
+    ASSERT_EQ(0, lifecycle.applyCount);
+    ASSERT_EQ(0, lifecycle.shutdownCount);
+    ASSERT_EQ(RuntimeSamplerApplyResult::ShuttingDown, controller.ApplyInitialConfiguration(PeriodicSampling(1000u)));
+    AssertState(controller, 0u, AllDisabled());
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/stack_walk_guard_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/stack_walk_guard_test.cpp
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pch.h"
+#include "../../src/OpenTelemetry.AutoInstrumentation.Native/stack_walk_guard.h"
+
+#include <chrono>
+
+namespace
+{
+
+using ProfilerStackCapture::IProfilerApi;
+using ProfilerStackCapture::StackWalkGuard;
+
+class FakeProfilerApi final : public IProfilerApi
+{
+public:
+    HRESULT DoStackSnapshot(ThreadID, StackSnapshotCallback, DWORD, void*, BYTE*, ULONG) override
+    {
+        return E_NOTIMPL;
+    }
+
+    HRESULT GetThreadInfo(ThreadID, DWORD*) override
+    {
+        return E_NOTIMPL;
+    }
+
+    HRESULT GetFunctionFromIP(LPCBYTE, FunctionID*) override
+    {
+        return E_NOTIMPL;
+    }
+};
+
+} // namespace
+
+TEST(StackWalkGuardTest, ConstructionIsDormant)
+{
+    FakeProfilerApi api;
+    StackWalkGuard  guard(&api, std::chrono::seconds(1), std::chrono::seconds(1));
+
+    ASSERT_FALSE(guard.IsStarted());
+    ASSERT_TRUE(guard.IsIdle());
+    ASSERT_FALSE(guard.ScheduleDssProbe());
+}
+
+TEST(StackWalkGuardTest, StartIsIdempotentAndEnablesProbes)
+{
+    FakeProfilerApi api;
+    StackWalkGuard  guard(&api, std::chrono::seconds(1), std::chrono::seconds(1));
+
+    ASSERT_TRUE(guard.Start());
+    ASSERT_TRUE(guard.IsStarted());
+    ASSERT_TRUE(guard.Start());
+
+    ASSERT_TRUE(guard.ScheduleDssProbe());
+    ASSERT_EQ(StackWalkGuard::ProbeResult::Success, guard.AwaitProbeResult());
+}

--- a/test/OpenTelemetry.AutoInstrumentation.Native.Tests/stack_walk_guard_test.cpp
+++ b/test/OpenTelemetry.AutoInstrumentation.Native.Tests/stack_walk_guard_test.cpp
@@ -55,3 +55,19 @@ TEST(StackWalkGuardTest, StartIsIdempotentAndEnablesProbes)
     ASSERT_TRUE(guard.ScheduleDssProbe());
     ASSERT_EQ(StackWalkGuard::ProbeResult::Success, guard.AwaitProbeResult());
 }
+
+TEST(StackWalkGuardTest, StopIsTerminalAndIdempotent)
+{
+    FakeProfilerApi api;
+    StackWalkGuard  guard(&api, std::chrono::seconds(1), std::chrono::seconds(1));
+
+    ASSERT_TRUE(guard.Start());
+
+    guard.Stop();
+    guard.Stop();
+
+    ASSERT_FALSE(guard.IsStarted());
+    ASSERT_FALSE(guard.IsIdle());
+    ASSERT_FALSE(guard.Start());
+    ASSERT_FALSE(guard.ScheduleDssProbe());
+}


### PR DESCRIPTION
## Why

Towards #5360

## What

Native includes:
- atomic V1 configuration/state ABI;
- dynamic enable/update/disable/re-enable capabilities;
- shared CPU/selective worker modes;
- a dedicated EventPipe lifecycle allocation profiler;
- actual interval metadata in V2 batches while preserving the legacy ABI;
- safe bootstrap and terminal shutdown;
- protection against partial stacks, buffer overflows, and callback races.

## Tests

Ci

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
