### PR TITLE
[CI] fix build by reverting `Azure.Storage.Blobs` dep update

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Packages.props" />
   <ItemGroup>
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.2" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageVersion Include="Confluent.Kafka" Version="2.15.0" />
     <PackageVersion Include="CoreWCF.Http" Version="1.9.1" />
     <PackageVersion Include="CoreWCF.NetTcp" Version="1.9.1" />


### PR DESCRIPTION
This reverts commit a11b42bd57f06cdda5e54b951f630bd5a7bec191.
https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/5191#issuecomment-4902853494 still an issue