### PR TITLE
[native-code] use standard compliant way to obtain one-past-the-end pointer

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/continuous_profiler.cpp
@@ -220,7 +220,7 @@ void AllocationSamplingAppendToBuffer(int32_t appendLen, unsigned char* appendBu
         trace::Logger::Warn("Discarding captured allocation sample. Allocation buffer is full.");
         return;
     }
-    allocation_buffer->insert(allocation_buffer->end(), appendBuf, &appendBuf[appendLen]);
+    allocation_buffer->insert(allocation_buffer->end(), appendBuf, appendBuf + appendLen);
 }
 
 // Can return 0


### PR DESCRIPTION
## Why && What
Use standard compliant way to obtain one-past-the-end pointer.