### PR TITLE
[OpAmp] treat present empty opamp section as enabled with defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ This component adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fixed
 
+- Allow an empty `opamp/development` section in file-based configuration to
+  enable the OpAMP client with default settings.
 - Prevent the shell installer from using a predictable path for temporary
   downloads.
 - Use the standard `service.namespace` resource attribute instead of `service.namespace.name`

--- a/docs/file-based-configuration.md
+++ b/docs/file-based-configuration.md
@@ -642,6 +642,7 @@ instrumentation/development:
 ### OpAMP
 
 ``` yaml
+# The presence of this section enables the OpAMP client. All fields are optional.
 opamp/development:
   # Configure the server endpoint. If not explicitly set, a default
   # URL is used: https://localhost:4320/v1/opamp.

--- a/examples/file-based-configuration-files/default-config.yaml
+++ b/examples/file-based-configuration-files/default-config.yaml
@@ -58,9 +58,6 @@ resource:
 
 # OpAMP is disabled by default. Uncomment this section to enable it.
 # opamp/development:
-#   server_url: https://localhost:4320/v1/opamp
-#   max_pending_custom_messages: 2048
-#   max_pending_custom_message_bytes: 67108864
 
 # Instrumentation Configuration
 instrumentation/development:

--- a/src/OpenTelemetry.AutoInstrumentation/Configurations/FileBasedConfiguration/OpAmpConfiguration.cs
+++ b/src/OpenTelemetry.AutoInstrumentation/Configurations/FileBasedConfiguration/OpAmpConfiguration.cs
@@ -1,10 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser;
 using Vendors.YamlDotNet.Serialization;
 
 namespace OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 
+[EmptyObjectOnEmptyYaml]
 internal class OpAmpConfiguration
 {
     /// <summary>

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FileBasedOpAmpSettingsTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/FileBasedOpAmpSettingsTests.cs
@@ -35,7 +35,7 @@ public class FileBasedOpAmpSettingsTests
     }
 
     [Fact]
-    public void LoadFile_CustomMessageLimitsAreUnsetByDefault()
+    public void LoadFile_EmptyOpAmpConfiguration_ShouldEnableOpAmpWithDefaultSettings()
     {
         var conf = new YamlConfiguration
         {
@@ -45,6 +45,8 @@ public class FileBasedOpAmpSettingsTests
 
         settings.LoadFile(conf);
 
+        Assert.True(settings.OpAmpClientEnabled);
+        Assert.Null(settings.ServerUrl);
         Assert.Null(settings.MaxPendingCustomMessages);
         Assert.Null(settings.MaxPendingCustomMessageBytes);
     }

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserOpAmpTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserOpAmpTests.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
@@ -41,7 +40,7 @@ public class ParserOpAmpTests
     [Theory]
     [InlineData("file_format: \"1.0\"\nopamp/development:\n")]
     [InlineData("file_format: \"1.0\"\nopamp/development: {}\n")]
-    public void Parse_EmptyOpAmpConfigYaml_ShouldEnableOpAmpWithDefaultSettings(string yaml)
+    public void Parse_EmptyOpAmpConfigYaml_ShouldCreateOpAmpConfigurationWithDefaultSettings(string yaml)
     {
         var config = YamlParser.ParseYamlContent<YamlConfiguration>(yaml);
 
@@ -50,14 +49,6 @@ public class ParserOpAmpTests
         Assert.Null(config.OpAmp.ServerUrl);
         Assert.Null(config.OpAmp.MaxPendingCustomMessages);
         Assert.Null(config.OpAmp.MaxPendingCustomMessageBytes);
-
-        var settings = new OpAmpSettings();
-        settings.LoadFile(config);
-
-        Assert.True(settings.OpAmpClientEnabled);
-        Assert.Null(settings.ServerUrl);
-        Assert.Null(settings.MaxPendingCustomMessages);
-        Assert.Null(settings.MaxPendingCustomMessageBytes);
     }
 
     [Fact]

--- a/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserOpAmpTests.cs
+++ b/test/OpenTelemetry.AutoInstrumentation.Tests/Configurations/FileBased/Parser/ParserOpAmpTests.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using OpenTelemetry.AutoInstrumentation.Configurations;
 using OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration;
 using OpenTelemetry.AutoInstrumentation.Tests.Util;
 using YamlParser = OpenTelemetry.AutoInstrumentation.Configurations.FileBasedConfiguration.Parser.Parser;
@@ -35,6 +36,28 @@ public class ParserOpAmpTests
 
         // By default opamp is disabled
         Assert.Null(config.OpAmp);
+    }
+
+    [Theory]
+    [InlineData("file_format: \"1.0\"\nopamp/development:\n")]
+    [InlineData("file_format: \"1.0\"\nopamp/development: {}\n")]
+    public void Parse_EmptyOpAmpConfigYaml_ShouldEnableOpAmpWithDefaultSettings(string yaml)
+    {
+        var config = YamlParser.ParseYamlContent<YamlConfiguration>(yaml);
+
+        Assert.NotNull(config);
+        Assert.NotNull(config.OpAmp);
+        Assert.Null(config.OpAmp.ServerUrl);
+        Assert.Null(config.OpAmp.MaxPendingCustomMessages);
+        Assert.Null(config.OpAmp.MaxPendingCustomMessageBytes);
+
+        var settings = new OpAmpSettings();
+        settings.LoadFile(config);
+
+        Assert.True(settings.OpAmpClientEnabled);
+        Assert.Null(settings.ServerUrl);
+        Assert.Null(settings.MaxPendingCustomMessages);
+        Assert.Null(settings.MaxPendingCustomMessageBytes);
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Fixes #5425

## What

Treat present empty opamp section as enabled with defaults.

## Tests
Included in PR.

Note:
Adding `EmptyObjectOnEmptyYamlAttribute` changes also how `null`, `~` and `''` are handled.
It seems there is a gap at the moment with how these are handled (https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/5434).

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.
- [x] New features are covered by tests.
Assisted by: GPT-5.6 Sol