### PR TITLE
Align native minimum runtime with .NET 8

### DIFF
--- a/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
+++ b/src/OpenTelemetry.AutoInstrumentation.Native/cor_profiler.cpp
@@ -134,9 +134,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         }
     }
 
-    if (runtime_information_.is_core() && runtime_information_.major_version < 6)
+    if (runtime_information_.is_core() && runtime_information_.major_version < 8)
     {
-        FailProfiler(Warn, "Failed to attach profiler: Not supported .NET version (lower than 6.0).")
+        FailProfiler(Warn, "Failed to attach profiler: Not supported .NET version (lower than 8.0).")
     }
 
     if (runtime_information_.is_core())


### PR DESCRIPTION
## Why

Some ancient leftover in the code, found while working on native code update.

## What

Align native minimum runtime with .NET 8

## Tests

CI

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- [x] ~~New~~ features are covered by tests.
