### PR TITLE
zizmor-fix: use self-repository workflow syntax

### DIFF
--- a/.github/actions/prepare-build-environment/action.yml
+++ b/.github/actions/prepare-build-environment/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: Setup .NET
       if: inputs.environment-type == 'host'
-      uses: ./.github/actions/setup-dotnet
+      uses: $/.github/actions/setup-dotnet
 
     - name: Set up Docker Buildx
       if: inputs.environment-type == 'container'

--- a/.github/actions/prepare-test-environment/action.yml
+++ b/.github/actions/prepare-test-environment/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Create test directory in container
       if: inputs.environment-type == 'container'
-      uses: ./.github/actions/run-command-in-environment
+      uses: $/.github/actions/run-command-in-environment
       with:
         container-name: ${{ inputs.container-name }}
         container-user: "0"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Prepare build environment
         id: prepare-build-environment
-        uses: ./.github/actions/prepare-build-environment
+        uses: $/.github/actions/prepare-build-environment
         with:
           artifact-name: ${{ inputs.artifact-name }}
           environment-type: ${{ inputs.environment-type }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Restore NuGet packages
         if: ${{ steps.nuget-cache.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/run-command-in-environment
+        uses: $/.github/actions/run-command-in-environment
         with:
           container-name: ${{ steps.prepare-build-environment.outputs.container-name }}
           run: ${{ env.BUILD_SCRIPT }} Restore
@@ -104,7 +104,7 @@ jobs:
       - name: Run build target
         env:
           OS_TYPE: ${{ inputs.os-type }}
-        uses: ./.github/actions/run-command-in-environment
+        uses: $/.github/actions/run-command-in-environment
         with:
           container-name: ${{ steps.prepare-build-environment.outputs.container-name }}
           container-publish-env: ${{ inputs.os-type != '' && 'OS_TYPE' || '' }}
@@ -118,19 +118,19 @@ jobs:
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Replace build artifacts
-        uses: ./.github/actions/replace-build-artifacts
+        uses: $/.github/actions/replace-build-artifacts
         with:
           replace-artifacts: ${{ inputs.replace-artifacts }}
 
       - name: Prepare test environment
-        uses: ./.github/actions/prepare-test-environment
+        uses: $/.github/actions/prepare-test-environment
         with:
           environment-type: ${{ inputs.environment-type }}
           container-name: ${{ steps.prepare-build-environment.outputs.container-name }}
           log-directory: ${{ inputs.log-directory }}
 
       - name: Test the Shell scripts from README.md
-        uses: ./.github/actions/run-command-in-environment
+        uses: $/.github/actions/run-command-in-environment
         env:
           LOG_DIRECTORY: ${{ inputs.log-directory }}
         with:
@@ -181,7 +181,7 @@ jobs:
           path: bin/installation-scripts
 
       - name: Regenerate LibraryVersions.g.cs
-        uses: ./.github/actions/run-command-in-environment
+        uses: $/.github/actions/run-command-in-environment
         with:
           container-name: ${{ steps.prepare-build-environment.outputs.container-name }}
           run: ${{ env.BUILD_SCRIPT }} GenerateLibraryVersionFiles
@@ -196,7 +196,7 @@ jobs:
 
       - name: Cleanup build environment
         if: ${{ always() }}
-        uses: ./.github/actions/cleanup-build-environment
+        uses: $/.github/actions/cleanup-build-environment
         with:
           environment-type: ${{ inputs.environment-type }}
           container-name: ${{ steps.prepare-build-environment.outputs.container-name }}

--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/build-ubuntu1604-native-container.yml
+++ b/.github/workflows/build-ubuntu1604-native-container.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Prepare build environment
         id: prepare-build-environment
-        uses: ./.github/actions/prepare-build-environment
+        uses: $/.github/actions/prepare-build-environment
         with:
           artifact-name: ubuntu1604-native
           environment-type: container
@@ -33,7 +33,7 @@ jobs:
       - name: Build native library in Docker container
         env:
           OS_TYPE: linux-glibc
-        uses: ./.github/actions/run-command-in-environment
+        uses: $/.github/actions/run-command-in-environment
         with:
           container-name: ${{ steps.prepare-build-environment.outputs.container-name }}
           container-publish-env: OS_TYPE
@@ -51,7 +51,7 @@ jobs:
 
       - name: Cleanup build environment
         if: ${{ always() }}
-        uses: ./.github/actions/cleanup-build-environment
+        uses: $/.github/actions/cleanup-build-environment
         with:
           environment-type: ${{ steps.prepare-build-environment.outputs.container-name != '' && 'container' || 'host' }}
           container-name: ${{ steps.prepare-build-environment.outputs.container-name }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-windows:
-    uses: ./.github/workflows/_build.yml
+    uses: $/.github/workflows/_build.yml
     with:
       artifact-name: windows-2022
       runner: windows-2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             os-type: linux-musl
             replace-artifacts: |
               bin-windows-2022!net
-    uses: ./.github/workflows/_build.yml
+    uses: $/.github/workflows/_build.yml
     with:
       artifact-name: ${{ matrix.artifact-name }}
       runner: ${{ matrix.runner }}

--- a/.github/workflows/check-sdk-versions.yml
+++ b/.github/workflows/check-sdk-versions.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Run VerifySdkVersions
         run: ./build.cmd VerifySdkVersions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,21 @@ permissions:
 jobs:
   build-ubuntu1604-native:
     name: Build native on Ubuntu 16.04 container
-    uses: ./.github/workflows/build-ubuntu1604-native-container.yml
+    uses: $/.github/workflows/build-ubuntu1604-native-container.yml
 
   build-windows:
     name: Build on Windows
-    uses: ./.github/workflows/build-windows.yml
+    uses: $/.github/workflows/build-windows.yml
 
   build:
     name: Build
     needs: [ build-windows, build-ubuntu1604-native ]
-    uses: ./.github/workflows/build.yml
+    uses: $/.github/workflows/build.yml
 
   build-nuget-packages:
     name: Build NuGet packages
     needs: [ build-windows, build ]
-    uses: ./.github/workflows/build-nuget-packages.yml
+    uses: $/.github/workflows/build-nuget-packages.yml
 
   test-build-managed:
     name: Test ${{ matrix.test-tfm }} on ${{ matrix.machine }} (managed)
@@ -83,7 +83,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -172,7 +172,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -213,7 +213,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -380,7 +380,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -78,7 +78,7 @@ jobs:
         queries: ${{ matrix.queries }}
 
     - name: Setup .NET
-      uses: ./.github/actions/setup-dotnet
+      uses: $/.github/actions/setup-dotnet
       if: matrix.language == 'csharp'
 
     # If the analyze step fails for one of the languages you are analyzing with

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -33,7 +33,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup .NET
-      uses: ./.github/actions/setup-dotnet
+      uses: $/.github/actions/setup-dotnet
 
     - name: Create local NuGet package source
       run: New-Item -ItemType Directory -Path .\bin\nuget-artifacts -Force

--- a/.github/workflows/release-nextgen-forwarder-packages.yml
+++ b/.github/workflows/release-nextgen-forwarder-packages.yml
@@ -36,7 +36,7 @@ jobs:
           ref: out-of-process-collection
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Check for NuGet packages cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Test the PowerShell module instructions from README.md
         shell: powershell
@@ -100,7 +100,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Install MacOS CoreUtils
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,18 @@ env:
 
 jobs:
   build-ubuntu1604-native:
-    uses: ./.github/workflows/build-ubuntu1604-native-container.yml
+    uses: $/.github/workflows/build-ubuntu1604-native-container.yml
 
   build-windows:
-    uses: ./.github/workflows/build-windows.yml
+    uses: $/.github/workflows/build-windows.yml
 
   build:
     needs: [ build-windows, build-ubuntu1604-native ]
-    uses: ./.github/workflows/build.yml
+    uses: $/.github/workflows/build.yml
 
   build-nuget-packages:
     needs: [ build-windows, build ]
-    uses: ./.github/workflows/build-nuget-packages.yml
+    uses: $/.github/workflows/build-nuget-packages.yml
 
   create-release:
     name: Create GitHub release

--- a/.github/workflows/verify-test.yml
+++ b/.github/workflows/verify-test.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
+        uses: $/.github/actions/setup-dotnet
 
       - name: Run BuildTracer and ManagedTests
         shell: bash


### PR DESCRIPTION
## Why

New issues detected by zizmor. 35 in total.

Related to https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/

## What

Replace workspace-relative in-repository action and reusable workflow references with GitHub's self-repository syntax to address zizmor findings.

Assisted-by: GPT-5


## Tests

Locally check with zizmor run, all issues gone

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- ~~[ ] `CHANGELOG.md` is updated.~~
- ~~[ ] Documentation is updated.~~
- ~~[ ] New features are covered by tests.~~
